### PR TITLE
feat: Enhance regsitry definition rendering to support RegDef V2 (#722)

### DIFF
--- a/scripts/build_env/main.py
+++ b/scripts/build_env/main.py
@@ -1,4 +1,6 @@
 import argparse
+import os
+import pathlib
 
 import ansible_runner
 from envgenehelper import *
@@ -377,7 +379,42 @@ def validate_appregdefs(render_dir, env_name):
             print(f"[INFO] No RegDef YAMLs found in {regdef_dir}")
         for file in regdef_files:
             print(f"[VALIDATING] RegDef file: {file}")
-            validate_yaml_by_scheme_or_fail(file, "schemas/regdef.schema.json")
+            
+            # Detect version and use appropriate schema
+            regdef_content = openYaml(file)
+            version = str(regdef_content.get('version', '1.0'))
+            
+            if version != '1.0':
+                schema_path = "schemas/regdef-v2.schema.json"
+                print(f"  Using RegDef V2 schema for {os.path.basename(file)} (version: {version})")
+                # Validate authConfig references for V2
+                validate_regdef_v2_authconfig(regdef_content, file)
+            else:
+                schema_path = "schemas/regdef.schema.json"
+                print(f"  Using RegDef V1 schema for {os.path.basename(file)}")
+            
+            validate_yaml_by_scheme_or_fail(file, schema_path)
+
+def validate_regdef_v2_authconfig(regdef_content, file_path):
+    """Validate authConfig references in V2 RegDefs"""
+    auth_configs = regdef_content.get('authConfig', {})
+    
+    # Config sections that may reference authConfig
+    config_sections = ['mavenConfig', 'dockerConfig', 'goConfig', 'rawConfig', 
+                      'npmConfig', 'helmConfig', 'helmAppConfig']
+    
+    for config_type in config_sections:
+        if config_type in regdef_content:
+            config = regdef_content[config_type]
+            if isinstance(config, dict) and 'authConfig' in config:
+                auth_ref = config['authConfig']
+                if auth_ref not in auth_configs:
+                    raise ValueError(
+                        f"RegDef {os.path.basename(file_path)}: "
+                        f"authConfig reference '{auth_ref}' in {config_type} "
+                        f"not found in authConfig section. "
+                        f"Available authConfigs: {list(auth_configs.keys())}"
+                    )
 
 
 def render_environment(env_name, cluster_name, templates_dir, all_instances_dir, output_dir, g_template_version,


### PR DESCRIPTION
* feat: Support for Registry V2

* fix: import issue fixed

# Pull Request

## Summary

Added RegDef V2 schema support with automatic version detection and authConfig validation for public cloud registries (AWS, Azure, GCP), maintaining full backward compatibility with V1 RegDefs.

## Issue

Enables validation of RegDef V2 files for public cloud registry support with enhanced authentication mechanisms.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`qubership-envgene` - RegDef validation

## Implementation Notes

**Enhanced validation in [validate_appregdefs()](cci:1://file:///c:/devjara1022/devenvgen/opensource/qubership-envgene/scripts/build_env/main.py:363:0-395:62)**:
- Auto-detects RegDef version from YAML content (defaults to V1 if not specified)
- Routes to appropriate schema: [regdef.schema.json](cci:7://file:///c:/devjara1022/devenvgen/opensource/qubership-envgene/schemas/regdef.schema.json:0:0-0:0) (V1) or [regdef-v2.schema.json](cci:7://file:///C:/devjara1022/devenvgen/opensource/qubership-envgene/schemas/regdef-v2.schema.json:0:0-0:0) (V2)

**Added [validate_regdef_v2_authconfig()](cci:1://file:///c:/devjara1022/devenvgen/opensource/qubership-envgene/scripts/build_env/main.py:397:0-416:21)**:
- Validates authConfig references in artifact configs
- Ensures referenced authConfigs exist with clear error messages

**New RegDef V2 Schema**:
- Supports cloud provider authentication (AWS, Azure, GCP)
- Per-artifact-type authConfig references and repository domains

## Tests / Evidence

- V1 and V2 files validate against correct schemas
- AuthConfig reference validation working
- Console output shows schema selection per file

## Additional Notes

**Files Modified**: [scripts/build_env/main.py](cci:7://file:///c:/devjara1022/devenvgen/opensource/qubership-envgene/scripts/build_env/main.py:0:0-0:0), [schemas/regdef-v2.schema.json](cci:7://file:///C:/devjara1022/devenvgen/opensource/qubership-envgene/schemas/regdef-v2.schema.json:0:0-0:0) (new)

**Migration**: V1 RegDefs work unchanged. V2 detected by `version: "2.0"` field.