### PR TITLE
fix: create env folder before copy

### DIFF
--- a/build_envgene/scripts/git_commit.sh
+++ b/build_envgene/scripts/git_commit.sh
@@ -156,12 +156,14 @@ git pull origin "${REF_NAME}"
 echo "Restoring environments/${CLUSTER_NAME}/${ENVIRONMENT_NAME}"
 if [ "${COMMIT_ENV}" = "true" ]; then
     rm -rf "environments/${CLUSTER_NAME}/${ENVIRONMENT_NAME}"
-    cp -r /tmp/artifact_environments/${CLUSTER_NAME}/${ENVIRONMENT_NAME} "environments/${CLUSTER_NAME}/"
+    mkdir -p "environments/${CLUSTER_NAME}/${ENVIRONMENT_NAME}"
+    cp -r /tmp/artifact_environments/${CLUSTER_NAME}/${ENVIRONMENT_NAME}/. "environments/${CLUSTER_NAME}/${ENVIRONMENT_NAME}/"
 fi
 
 if [ -e /tmp/artifact_environments/${CLUSTER_NAME}/cloud-passport ]; then
     rm -rf environments/${CLUSTER_NAME}/cloud-passport
-    cp -r /tmp/artifact_environments/${CLUSTER_NAME}/cloud-passport "environments/${CLUSTER_NAME}/"
+    mkdir -p environments/${CLUSTER_NAME}/cloud-passport
+    cp -r /tmp/artifact_environments/${CLUSTER_NAME}/cloud-passport/. "environments/${CLUSTER_NAME}/cloud-passport/"
 fi
 
 if [ -e /tmp/configuration ]; then

--- a/github_workflows/instance-repo-pipeline/.github/workflows/Envgene.yml
+++ b/github_workflows/instance-repo-pipeline/.github/workflows/Envgene.yml
@@ -69,9 +69,9 @@ env:
   DOCKER_IMAGE_NAME_EFFECTIVE_SET_GENERATOR: "${{ vars.DOCKER_REGISTRY || 'ghcr.io/netcracker' }}/qubership-effective-set-generator"
 
   #DOCKER_IMAGE_TAGS
-  DOCKER_IMAGE_TAG_PIPEGENE: "1.6.3"
-  DOCKER_IMAGE_TAG_ENVGENE: "1.6.3"
-  DOCKER_IMAGE_TAG_EFFECTIVE_SET_GENERATOR: "1.6.3"
+  DOCKER_IMAGE_TAG_PIPEGENE: "bugfix_git-commit-script_20251024-093605"
+  DOCKER_IMAGE_TAG_ENVGENE: "bugfix_git-commit-script_20251024-093606"
+  DOCKER_IMAGE_TAG_EFFECTIVE_SET_GENERATOR: "bugfix_git-commit-script_20251024-093718"
 
 jobs:
   process_environment_variables:


### PR DESCRIPTION
# Pull Request

## Summary

During restoring of environment step in git_commit job, we are cleaning the environment folder by deleting the folder itself. After this, we are running the copy command which is not copying properly as the folder doesn't exist. 

To fix this, we need to have step to create the directory before running the copy command.

## Issue

Link to the issue(s) this PR addresses (e.g., `Fixes #123` or `Closes #456`). If no issue exists, explain why this change is necessary.

## Breaking Change?

- [ ] Yes
- [x] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

Provide details on how the change was implemented, including any technical considerations, trade-offs, or notable design decisions. Leave blank if not applicable.

## Tests / Evidence

Describe how the changes were verified, including:

- Tests added or updated (e.g., unit, integration, end-to-end)
- Manual testing steps or results
- Screenshots, logs, or other evidence (if applicable)

## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
