### PR TITLE
fix: preserving the data type while using macros in the generation of effective set

### DIFF
--- a/build_effective_set_generator_java/commons/src/main/java/org/qubership/cloud/devops/commons/utils/ParameterUtils.java
+++ b/build_effective_set_generator_java/commons/src/main/java/org/qubership/cloud/devops/commons/utils/ParameterUtils.java
@@ -18,6 +18,8 @@ package org.qubership.cloud.devops.commons.utils;
 
 import lombok.experimental.UtilityClass;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 
@@ -116,6 +118,27 @@ public class ParameterUtils {
         Object password = controller.remove(PASSWORD);
         bgDomainParamsMap.put(CONTROLLER_NAMESPACE, controller);
         bgDomainSecureMap.put(CONTROLLER_NAMESPACE, Map.of(USERNAME, userName, PASSWORD, password));
+    }
+
+    public static Object toTypedValue(Object input) {
+        if (ObjectUtils.isEmpty(input)) {
+            return StringUtils.EMPTY;
+        }
+        String trimmed = "";
+        if(input instanceof String){
+            trimmed = input.toString().trim();
+        }
+        if (trimmed.matches("(?i)^(true|false)$")) {
+            return Boolean.parseBoolean(trimmed);
+        }
+        if (trimmed.matches("^[+-]?\\d+$")) {
+            try {
+                return Integer.parseInt(trimmed);
+            } catch (NumberFormatException ignored) {
+                return Long.parseLong(trimmed);
+            }
+        }
+        return trimmed;
     }
 }
 

--- a/build_effective_set_generator_java/parameters-processor/src/test/java/org/qubership/cloud/expression/ExpressionLanguageTest.java
+++ b/build_effective_set_generator_java/parameters-processor/src/test/java/org/qubership/cloud/expression/ExpressionLanguageTest.java
@@ -259,7 +259,7 @@ public class ExpressionLanguageTest extends BindingBaseTest {
                              }},
                         new HashMap<String, Object>(),
                         new HashMap<String, Object>() {{
-                            put("key1", "1");
+                            put("key1", 1);
                         }}),
                 Arguments.of(new HashMap<String, Object>() {{
                                  put("key1", "'[{\"test\": \"value\"}]");
@@ -524,7 +524,7 @@ public class ExpressionLanguageTest extends BindingBaseTest {
         map.remove("OPENSHIFT_SERVER");
         map.remove("CLOUD_API_PORT");
 
-        result.put("ESCAPE_SEQUENCE", "true");
+        result.put("ESCAPE_SEQUENCE", true);
         assertEquals(result, map);
     }
 


### PR DESCRIPTION

# Pull Request

## Summary

Holding the data type while using macros in the generation of effective set

## Issue

Link to the issue(s) this PR addresses (e.g., `Fixes #123` or `Closes #456`). If no issue exists, explain why this change is necessary.

## Breaking Change?

- [ ] Yes
- [X] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

Provide details on how the change was implemented, including any technical considerations, trade-offs, or notable design decisions. Leave blank if not applicable.

## Tests / Evidence

Describe how the changes were verified, including:

- Tests added or updated (e.g., unit, integration, end-to-end)
- Manual testing steps or results
- Screenshots, logs, or other evidence (if applicable)

## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
