### PR TITLE
fix: Added changes to retain type

### DIFF
--- a/build_effective_set_generator_java/parameters-processor/src/main/java/org/qubership/cloud/parameters/processor/expression/binding/Binding.java
+++ b/build_effective_set_generator_java/parameters-processor/src/main/java/org/qubership/cloud/parameters/processor/expression/binding/Binding.java
@@ -47,6 +47,8 @@ public class Binding extends HashMap<String, Parameter> implements Cloneable {
     private String tenant;
     private ParametersParser escapeParser;
     private ParametersParser oldParser;
+    @Getter
+    private Map<Object, Class<?>> typeCollector = new HashMap<>();
 
     public Binding(String defaultEscapeSequence) {
         this.escapeSequence = defaultEscapeSequence;
@@ -209,6 +211,9 @@ public class Binding extends HashMap<String, Parameter> implements Cloneable {
         }
         if (result == null || result.getValue() == null) {
             return null;
+        }
+        if (result != null && result.getValue() != null) {
+            typeCollector.put(result.getValue().toString(), result.getValue().getClass());
         }
         return result;
     }


### PR DESCRIPTION
# Pull Request

## Summary

Retain the data type after jinjava/groovy rendering of macros during generation of effective set
Example 
TEST: 123
TEST1:$TEST

TEST1 had "123" in the output which is wrong. Expected result is 123

## Issue

Link to the issue(s) this PR addresses (e.g., `Fixes #123` or `Closes #456`). If no issue exists, explain why this change is necessary.

## Breaking Change?

- [ ] Yes
- [ X] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

build_effective_set_generator_java

## Implementation Notes


## Tests / Evidence

Describe how the changes were verified, including:

- Tests added or updated (e.g., unit, integration, end-to-end)
- Manual testing steps or results
- Screenshots, logs, or other evidence (if applicable)

Tested it against the instance repo by running cli program locally.
 Input:

CLOUD_API_HOST: "localhost"
TEST1: $CLOUD_API_HOST
TEST2: 123456
SSL_SECRET: $TEST2
BOOL: 890
MYBOOL: $BOOL
DUPBOOL: "890"
MYDUPBOOL: $DUPBOOL
PARAMA: 7878
PARAMB: $PARAMA
PARAMC: $PARAMB

output:

CLOUD_API_HOST: '1234'
TEST1: '1234'
TEST2: 123456
SSL_SECRET: 123456
BOOL: 890
MYBOOL: 890
DUPBOOL: '890'
MYDUPBOOL: '890'
PARAMA: 7878
PARAMB: 7878
PARAMC: 7878

## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
