### PR TITLE
fix: extend delimiters for multi value params

### DIFF
--- a/build_pipegene/scripts/gitlab_ci.py
+++ b/build_pipegene/scripts/gitlab_ci.py
@@ -1,7 +1,7 @@
 import os
 from os import listdir
 
-from envgenehelper import logger, get_cluster_name_from_full_name, get_environment_name_from_full_name, parse_env_names
+from envgenehelper import logger, get_cluster_name_from_full_name, get_environment_name_from_full_name
 from envgenehelper.plugin_engine import PluginEngine
 from gcip import JobFilter, Pipeline
 
@@ -14,6 +14,8 @@ from inventory_generation_job import prepare_inventory_generation_job, is_invent
 from passport_jobs import prepare_trigger_passport_job, prepare_passport_job
 from process_sd_job import prepare_process_sd
 from pipeline_helper import get_gav_coordinates_from_build, find_predecessor_job
+from envgenehelper.collections_helper import split_multi_value_param
+
 
 PROJECT_DIR = os.getenv('CI_PROJECT_DIR') or os.getenv('GITHUB_WORKSPACE')
 IS_GITLAB = bool(os.getenv('CI_PROJECT_DIR')) and not bool(os.getenv('GITHUB_ACTIONS'))
@@ -55,7 +57,7 @@ def build_pipeline(params: dict) -> None:
 
     per_env_plugin_engine = PluginEngine(plugins_dir='/module/scripts/pipegene_plugins/per_env')
 
-    env_names = parse_env_names(params['ENV_NAMES'])
+    env_names = split_multi_value_param(params['ENV_NAMES'])
     if len(env_names) > 1 and is_inventory_generation_needed(params['IS_TEMPLATE_TEST'], params):
         raise ValueError(
             f"Generating Inventories for multiple Environments in single pipeline is not supported. "

--- a/build_pipegene/scripts/validations.py
+++ b/build_pipegene/scripts/validations.py
@@ -2,6 +2,7 @@ import os
 from os import getenv
 
 from envgenehelper import check_for_cyrillic, logger, findAllYamlsInDir, openYaml, check_dir_exists, get_cluster_name_from_full_name, get_environment_name_from_full_name, check_environment_is_valid_or_fail, check_file_exists, validate_yaml_by_scheme_or_fail
+from envgenehelper.collections_helper import split_multi_value_param
 
 project_dir = os.getenv('CI_PROJECT_DIR') or os.getenv('GITHUB_WORKSPACE')
 logger.info(f"Info about project_dir: {project_dir}")
@@ -42,7 +43,8 @@ def template_test_checks():
         raise ReferenceError("Execution is aborted as validation is not successful. See logs above.")
 
 def real_execution_checks(env_names, get_passport, env_build, env_inventory_init, env_inventory_content):
-    for env in env_names.split("\n"):
+    environment_names = split_multi_value_param(env_names)
+    for env in environment_names:
         # now we are using only complex environment names that contain both cluster_name and environment_name
         if env.count('/') != 1:
             logger.fatal(f"Wrong env_name given: {env}. Env_name should contain both cloud name and environment name by pattern '<cluster_name>/<environment_name>'")

--- a/python/envgene/envgenehelper/business_helper.py
+++ b/python/envgene/envgenehelper/business_helper.py
@@ -408,7 +408,3 @@ def get_bgd_object(env_dir: Path | None = None) -> CommentedMap:
     bgd_object = openYaml(bgd_path, allow_default=True)
     logger.debug(bgd_object)
     return bgd_object
-
-
-def parse_env_names(full_env_names: str):
-    return full_env_names.split("\n")

--- a/python/envgene/envgenehelper/collections_helper.py
+++ b/python/envgene/envgenehelper/collections_helper.py
@@ -2,6 +2,7 @@ from io import StringIO
 from pprint import pformat
 from .yaml_helper import yaml
 import copy
+from .logger import logger
 
 def merge_lists(list1, list2) :
     if len(list2) > 0 :
@@ -94,4 +95,42 @@ def _compare_dicts_recurse(source: object, target: object, path: DictPath, diff_
             _compare_dicts_recurse(source[k], target[k], new_path, diff_paths, removed_paths)
     elif source != target:
         diff_paths.append(path.copy())
+
+def split_multi_value_param(param: str)-> list[str]:
+    
+    if not param:
+        return []
+        
+    param = param.strip()
+    if not param:
+        return []
+
+    has_comma = ',' in param
+    has_semicolon = ';' in param
+    has_space = ' ' in param
+    has_newline = '\n' in param
+
+    delimiter_count = sum([has_comma, has_semicolon, has_space, has_newline])
+
+    if delimiter_count > 1:
+        raise ValueError(
+            "Invalid input: use only ONE delimiter type (comma, semicolon, space, or newline)"
+        )
+
+    if has_comma:
+        logger.info(f"env names {param} has comma as delimiter. splitting it")
+        parts = param.split(',')
+    elif has_semicolon:
+        logger.info(f"env names {param} has semicolon as delimiter. splitting it")
+        parts = param.split(';')
+    elif has_space:
+        logger.info(f"env names {param} has space as delimiter. splitting it")
+        parts = param.split()
+    elif has_newline:
+        logger.info(f"env names {param} has newline as delimiter. splitting it")
+        parts = param.splitlines()
+    else:
+        return [param]
+
+    return [p.strip() for p in parts if p.strip()]
 

--- a/python/envgene/envgenehelper/crypt.py
+++ b/python/envgene/envgenehelper/crypt.py
@@ -7,6 +7,7 @@ from .config_helper import get_envgene_config_yaml
 from .yaml_helper import openYaml, get_empty_yaml
 from .file_helper import check_file_exists, get_files_with_filter
 from .logger import logger
+from .collections_helper import split_multi_value_param
 
 from .crypt_backends.fernet_handler import crypt_Fernet, extract_value_Fernet, is_encrypted_Fernet
 from .crypt_backends.sops_handler import crypt_SOPS, extract_value_SOPS, is_encrypted_SOPS
@@ -117,7 +118,7 @@ def get_all_necessary_cred_files() -> set[str]:
     if env_names == "env_template_test":
         logger.info("Running in env_template_test mode")
         return get_files_with_filter(BASE_DIR, is_cred_file)
-    env_names_list = env_names.split("\n")
+    env_names_list = split_multi_value_param(env_names)
 
     sources = set()
     sources.add("configuration")

--- a/python/envgene/envgenehelper/test_collections.py
+++ b/python/envgene/envgenehelper/test_collections.py
@@ -1,4 +1,5 @@
 from .collections_helper import *
+import pytest
 
 def convert_list_elements_to_strings_in_place(lst):
     for i in range(len(lst)):
@@ -59,3 +60,38 @@ def test_compare_dicts():
 
     assert len(s_diff) == len(diff) # no duplicates
     assert s_diff == set(expected_arr) and removed == [], f"Failed Test 8: {diff}, {removed}"
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("env01", ["env01"]),
+        ("env01,env02", ["env01", "env02"]),
+        ("env01;env02", ["env01", "env02"]),
+        ("env01 env02", ["env01", "env02"]),
+        ("env01\nenv02", ["env01", "env02"]),
+        (" env01 env02 ", ["env01", "env02"]),
+        ("app1:1.0", ["app1:1.0"]),
+        ("app1:1.0;app2:2.0", ["app1:1.0", "app2:2.0"]),
+        ("app1:1.0;app2:2.0", ["app1:1.0", "app2:2.0"]),
+        ("app1:1.0;app2:2.0", ["app1:1.0", "app2:2.0"]),
+        ("app1:1.0;app2:2.0", ["app1:1.0", "app2:2.0"]),
+        ("", []),
+        ("   ", []),
+    ],
+)
+def test_split_multi_value_param_valid(value, expected):
+    assert split_multi_value_param(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "env01, env02", 
+        "env01; env02",
+        "env01\nenv02 env03",
+        "env01,env02;env03",
+    ],
+)
+def test_split_multi_value_param_invalid(value):
+    with pytest.raises(ValueError, match=r"use only ONE delimiter type"):
+        split_multi_value_param(value)

--- a/scripts/build_env/process_sd.py
+++ b/scripts/build_env/process_sd.py
@@ -5,6 +5,7 @@ from enum import Enum
 from os import path, getenv
 from pathlib import Path
 
+
 import envgenehelper as helper
 import yaml
 from artifact_searcher import artifact
@@ -15,6 +16,7 @@ from envgenehelper.file_helper import identify_yaml_extension
 from envgenehelper.logger import logger
 from envgenehelper.plugin_engine import PluginEngine
 from envgenehelper.sd_merge_helper import basic_merge_multiple
+from envgenehelper.collections_helper import split_multi_value_param
 
 
 class MergeType(Enum):
@@ -270,7 +272,7 @@ def download_sds_with_version(env, base_sd_path, sd_version, effective_merge_mod
         logger.error("SD_SOURCE_TYPE is set to 'artifact', but SD_VERSION was not given in pipeline variables")
         exit(1)
     sd_version = sd_version.replace("\\n", "\n")
-    sd_entries = [line.strip() for line in sd_version.strip().splitlines() if line.strip()]
+    sd_entries = split_multi_value_param(sd_version)
     if not sd_entries:
         logger.error("No valid SD versions found in SD_VERSION")
         exit(1)


### PR DESCRIPTION
# Pull Request

## Summary

Currently we support 2 multi value parameters like ENV_NAMES and SD_VERSION and the delimiters allowed in gitlab is \n. Change is to extend the delimiters to comma, space and semicolon.

## Issue

Link to the issue(s) this PR addresses (e.g., `Fixes #123` or `Closes #456`). If no issue exists, explain why this change is necessary.

https://github.com/Netcracker/qubership-envgene/issues/776

## Breaking Change?

No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).
build_pipegene and sd handling part.

## Implementation Notes

Provide details on how the change was implemented, including any technical considerations, trade-offs, or notable design decisions. Leave blank if not applicable.

1. Added a split method in utility file to extend \n to other delimiters.
2. If multiple delimiters are used together, it will throw error. Only one delimiter is allowed at a time.

## Tests / Evidence

Describe how the changes were verified, including:

- Tests added or updated (e.g., unit, integration, end-to-end)
- Manual testing steps or results
- Screenshots, logs, or other evidence (if applicable)

Tested instance pipeline with Multi Value params ENV_NAMES and SD_VERSION.
Also added positive and negative test case for utility methods.

## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
