### PR TITLE
fix: Added options to override JVM heap size (Xms/Xmx) and ForkJoinPo…

### DIFF
--- a/build_effective_set_generator/build/Dockerfile
+++ b/build_effective_set_generator/build/Dockerfile
@@ -93,6 +93,7 @@ RUN addgroup ci && \
     adduser -D -h /module/ -s /bin/bash -G ci ci && \
     chown ci:ci -R /module /deployments && \
     chmod +x /module/scripts/*.sh && \
+    chmod +x /module/scripts/utils/entrypoint.sh && \
     chmod 644 /module/scripts/*.py 2>/dev/null || true && \
     chmod +x /usr/local/bin/sops && \
     chmod 540 /deployments/run-java.sh && \

--- a/build_pipegene/scripts/effective_set_job.py
+++ b/build_pipegene/scripts/effective_set_job.py
@@ -44,7 +44,7 @@ def prepare_generate_effective_set_job(pipeline, full_env_name, env_name, cluste
     ]
 
     cmdb_cli_cmd_call = [
-        f"/deployments/run-java.sh --env-id={full_env_name}",
+        f"/module/scripts/utils/entrypoint.sh --env-id={full_env_name}",
         "--envs-path=$CI_PROJECT_DIR/environments",
         f"--output=$CI_PROJECT_DIR/environments/{full_env_name}/effective-set"
     ]

--- a/scripts/utils/entrypoint.sh
+++ b/scripts/utils/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+merge_java_opts() {
+  base="$1"
+  override="$2"
+
+  result="$base"
+  allowed_override=""
+
+  for opt in $override; do
+    case "$opt" in
+      -Xms*)
+        result=$(echo "$result" | sed -E 's/-Xms[^ ]+//g')
+		allowed_override="$opt${allowed_override:+ $allowed_override}"
+        ;;
+      -Xmx*)
+        result=$(echo "$result" | sed -E 's/-Xmx[^ ]+//g')
+		allowed_override="$opt${allowed_override:+ $allowed_override}"
+        ;;
+      -Djava.util.concurrent.ForkJoinPool.common.parallelism=*)
+        result=$(echo "$result" | sed -E 's|-Djava.util.concurrent.ForkJoinPool.common.parallelism=[^ ]+||g')
+		allowed_override="$opt${allowed_override:+ $allowed_override}"
+        ;;
+    esac
+  done
+  echo "$result${allowed_override:+ $allowed_override}"
+}
+
+if [ -n "${CALCULATOR_CLI_JAVA_OPTIONS:-}" ]; then
+	JAVA_OPTIONS=$(merge_java_opts "$JAVA_OPTIONS" "$CALCULATOR_CLI_JAVA_OPTIONS" | tr -s '[:space:]')
+fi
+export JAVA_OPTIONS
+exec /deployments/run-java.sh "$@"

--- a/scripts/utils/pipeline_parameters.py
+++ b/scripts/utils/pipeline_parameters.py
@@ -33,6 +33,7 @@ def get_pipeline_parameters() -> dict:
         'RUNNER_SCRIPT_TIMEOUT': getenv("RUNNER_SCRIPT_TIMEOUT") or "10m",
         'DEPLOYMENT_SESSION_ID': getenv("DEPLOYMENT_SESSION_ID", "") or str(uuid.uuid4()),
         'ENVGENE_LOG_LEVEL': getenv("ENVGENE_LOG_LEVEL"),
+        'CALCULATOR_CLI_JAVA_OPTIONS' : getenv("CALCULATOR_CLI_JAVA_OPTIONS", ""),
         "BG_STATE": getenv("BG_STATE"),
         "BG_MANAGE": getenv("BG_MANAGE") == "true",
         "APP_DEFS_PATH": getenv("APP_DEFS_PATH"),


### PR DESCRIPTION
…ol thread count

# Pull Request

## Summary

Currently, when the CLI runs, no heap size is set explicitly, so run-java.sh picks it randomly. In practice, it sometimes chooses 1 GB and sometimes as high as 30 GB. When the heap is 30 GB, we’ve observed OutOfMemoryError even with a small number of applications. This is likely due to less frequent garbage collection causing memory to grow unchecked.

To address this, we’ve made two changes:

Set a default heap size of 1 GB in the Dockerfile in the internal EnvGene environment.

Introduced a new environment variable, CALCULATOR_CLI_JAVA_OPTIONS, which allows users to override heap size and ForkJoinPool thread count. CALCULATOR_CLI_JAVA_OPTIONS can be set as CI/CD or pipeline variable.

Currently, ForkJoinPool is used to process applications concurrently, and by default, it creates as many threads as there are applications. Users can now limit the number of threads and adjust heap size.

## Issue

Link to the issue(s) this PR addresses (e.g., `Fixes #123` or `Closes #456`). If no issue exists, explain why this change is necessary.

## Breaking Change?

- [ ] Yes
- [ ] No
No
If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

1. Added an entry point shell script which will process CALCULATOR_CLI_JAVA_OPTIONS and modify JAVA_OPTIONS and then calls run-java.sh 

Provide details on how the change was implemented, including any technical considerations, trade-offs, or notable design decisions. Leave blank if not applicable.

## Tests / Evidence

Describe how the changes were verified, including:

- Tests added or updated (e.g., unit, integration, end-to-end)
- Manual testing steps or results
- Screenshots, logs, or other evidence (if applicable)

## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
