### PR TITLE
fix: added disabled condition for cloud services if not found in clou…

### DIFF
--- a/scripts/build_env/cloud_passport.py
+++ b/scripts/build_env/cloud_passport.py
@@ -45,6 +45,8 @@ def process_cloud_definition(cloudPassportYaml, env_dir, comment) :
         process_and_update_key("maasUrl", cloudYaml["maasConfig"], "MAAS_SERVICE_ADDRESS", maasPassportYaml, comment)
         process_and_update_key("maasInternalAddress", cloudYaml["maasConfig"], "MAAS_INTERNAL_ADDRESS", maasPassportYaml, comment)
         del cloudPassportYaml["maas"]
+    else:
+        store_value_to_yaml(cloudYaml["maasConfig"], "enable", False)
     if "vault" in cloudPassportYaml :
         vaultPassportYaml = cloudPassportYaml["vault"]
         vaultUrl = vaultPassportYaml["VAULT_ADDR"]
@@ -57,6 +59,8 @@ def process_cloud_definition(cloudPassportYaml, env_dir, comment) :
             store_value_to_yaml(cloudYaml["vaultConfig"], "enable", False, comment)
             store_value_to_yaml(cloudYaml["vaultConfig"], "url", "", comment)
         del cloudPassportYaml["vault"]
+    else:
+        store_value_to_yaml(cloudYaml["vaultConfig"], "enable", False)
     if "dbaas" in cloudPassportYaml :
         dbaasPassportYaml = cloudPassportYaml["dbaas"]
         if "dbaasConfigs" not in cloudYaml or len(cloudYaml["dbaasConfigs"]) != 1 :
@@ -68,6 +72,9 @@ def process_cloud_definition(cloudPassportYaml, env_dir, comment) :
         process_and_update_key("apiUrl", dbaasConfigYaml, "API_DBAAS_ADDRESS", dbaasPassportYaml, comment)
         process_and_update_key("aggregatorUrl", dbaasConfigYaml, "DBAAS_AGGREGATOR_ADDRESS", dbaasPassportYaml, comment)
         del cloudPassportYaml["dbaas"]
+    else:
+        for cfg in cloudYaml["dbaasConfigs"]:
+            store_value_to_yaml(cfg, "enable", False)
     if "consul" in cloudPassportYaml :
           consulPassportYaml = cloudPassportYaml["consul"]
           consulConfigYaml = cloudYaml["consulConfig"]
@@ -78,6 +85,8 @@ def process_cloud_definition(cloudPassportYaml, env_dir, comment) :
           # CONSUL_ENABLED variable should be both in consul section and in deploy parameters
           store_value_to_yaml(cloudYaml["deployParameters"], "CONSUL_ENABLED", f"{consulConfigYaml['enabled']}".lower(), comment)
           del cloudPassportYaml["consul"]
+    else:
+        store_value_to_yaml(cloudYaml["consulConfig"], "enabled", False)
     # adding rest of cloud passport parameters to cloud deploy parameters
     logger.debug(f"Rest of params from cloud passport are: \n{dump_as_yaml_format(cloudPassportYaml)}")
     mergeDeployParametersFromPassport(cloudPassportYaml, cloudYaml, comment)

--- a/test_data/test_environments/bgd-cluster/bgd-env/cloud.yml
+++ b/test_data/test_environments/bgd-cluster/bgd-env/cloud.yml
@@ -14,7 +14,7 @@ dbMode: "db"
 databases: []
 maasConfig:
   credentialsId: "maas"
-  enable: true
+  enable: false
   maasUrl: "http://maas.None"
   maasInternalAddress: "http://maas.maas:8888"
 vaultConfig:
@@ -23,12 +23,12 @@ vaultConfig:
   url: ""
 dbaasConfigs:
   - credentialsId: "dbaas"
-    enable: true
+    enable: false
     apiUrl: "http://dbaas.dbaas:8888"
     aggregatorUrl: "https://dbaas.None"
 consulConfig:
   tokenSecret: "consul-token"
-  enabled: true
+  enabled: false
   publicUrl: "https://consul.None"
   internalUrl: "http://consul.consul:8888"
 deployParameters:

--- a/test_data/test_environments/cluster01/env01/cloud.yml
+++ b/test_data/test_environments/cluster01/env01/cloud.yml
@@ -15,7 +15,7 @@ databases: []
 mergeDeployParametersAndE2EParameters: false
 maasConfig:
   credentialsId: "maas"
-  enable: true
+  enable: false
   maasUrl: "http://maas.qubership.org"
   maasInternalAddress: "http://maas.maas:8888"
 vaultConfig:
@@ -24,12 +24,12 @@ vaultConfig:
   url: ""
 dbaasConfigs:
   - credentialsId: "dbaas"
-    enable: true
+    enable: false
     apiUrl: "http://dbaas.dbaas:8888"
     aggregatorUrl: "https://dbaas.qubership.org"
 consulConfig:
   tokenSecret: "consul-token"
-  enabled: true
+  enabled: false
   publicUrl: "https://consul.qubership.org"
   internalUrl: "http://consul.consul:8888"
 deployParameters:

--- a/test_data/test_environments/cluster01/env03/cloud.yml
+++ b/test_data/test_environments/cluster01/env03/cloud.yml
@@ -14,7 +14,7 @@ dbMode: "db"
 databases: []
 maasConfig:
   credentialsId: "maas"
-  enable: true
+  enable: false
   maasUrl: "http://maas."
   maasInternalAddress: "http://maas.maas:8888"
 vaultConfig:
@@ -23,12 +23,12 @@ vaultConfig:
   url: ""
 dbaasConfigs:
   - credentialsId: "dbaas"
-    enable: true
+    enable: false
     apiUrl: "http://dbaas.dbaas:8888"
     aggregatorUrl: "https://dbaas."
 consulConfig:
   tokenSecret: "consul-token"
-  enabled: true
+  enabled: false
   publicUrl: "https://consul."
   internalUrl: "http://consul.consul:8888"
 deployParameters:


### PR DESCRIPTION
…d passport.

# Pull Request

## Summary

Provide a concise description of what this pull request does and why it is needed.

## Issue
In an instance pipeline job, the cloud.yml template is merged with the cloud passport.

The user attempted to remove the “maas config” from the cloud passport, but it still appears as enabled in cloud.yml. The same issue occurs with other services such as Vault, Consul, and DBaaS.

The reason is that we only override values in cloud.yml if the corresponding configuration exists in the cloud passport. If it is not present in the cloud passport, no changes are made, and the original settings from the incoming cloud.yml remain unchanged.

Link to the issue(s) this PR addresses (e.g., `Fixes #123` or `Closes #456`). If no issue exists, explain why this change is necessary.
No gitlab issue
## Breaking Change?

- [ ] Yes
- [ ] No
No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).
cloud_passport.py invoked during env build underwent changes.

## Implementation Notes
Added a condition in cloud_passport.py fine to disable cloud services in cloud.yml if they are not present in cloud passport file.

Provide details on how the change was implemented, including any technical considerations, trade-offs, or notable design decisions. Leave blank if not applicable.

## Tests / Evidence

Describe how the changes were verified, including:

- Tests added or updated (e.g., unit, integration, end-to-end)
- Manual testing steps or results
- Screenshots, logs, or other evidence (if applicable)

Tested it in instance pipeline.
1. Created cloud passport without maas, vault, consul and dbaas.
2. Verified final cloud.yml has them as enabled: false.
3. Also accommodated the changes in test data folder.

## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
