### PR TITLE
fix: cmdb.creds macro support in cli

### DIFF
--- a/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/Namespaces/monitoring-origin/namespace.yml
+++ b/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/Namespaces/monitoring-origin/namespace.yml
@@ -36,6 +36,7 @@ deployParameters:
   TEST_ENVGENE_CREDS_GET_VAULT_SECRET_ID: "${creds.get( \"envgen-creds-get-vault-cred-secret-id\").secretId}" # paramset: test-deploy-creds version: 1 source: template
   TEST_SHARED_CREDS: "${creds.get('integration-cred').username}" # paramset: test-deploy-creds version: 1 source: template
   TEST_SHARED_CREDS_ACTIVATOR: "${creds.get('service-integration-cred').password}" # paramset: test-deploy-creds version: 1 source: template
+  TEST_CMDB_CREDS_USERNAME: "${cmdb.creds.get('creds-get-username-cred').username}" #added manually for cmdb.creds macro validation
   bss-app-exist: false
   core: # paramset: paramset-B version: 23.4 source: instance
     apps:

--- a/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/cleanup/monitoring-origin/credentials.yaml
+++ b/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/cleanup/monitoring-origin/credentials.yaml
@@ -21,6 +21,7 @@ TEST_ENVGENE_CREDS_GET_VAULT_ROLE: envgeneNullValue
 TEST_ENVGENE_CREDS_GET_VAULT_SECRET_ID: envgeneNullValue
 TEST_SHARED_CREDS: user-placeholder-123
 TEST_SHARED_CREDS_ACTIVATOR: pass-placeholder-123
+TEST_CMDB_CREDS_USERNAME: user-placeholder-123
 graphite-remote-adapter: user-placeholder-123
 kafka:
   password: pass-placeholder-123

--- a/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/deployment/monitoring-origin/MONITORING/values/credentials.yaml
+++ b/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/deployment/monitoring-origin/MONITORING/values/credentials.yaml
@@ -28,6 +28,7 @@ TEST_ENVGENE_CREDS_GET_VAULT_ROLE: envgeneNullValue
 TEST_ENVGENE_CREDS_GET_VAULT_SECRET_ID: envgeneNullValue
 TEST_SHARED_CREDS: user-placeholder-123
 TEST_SHARED_CREDS_ACTIVATOR: pass-placeholder-123
+TEST_CMDB_CREDS_USERNAME: user-placeholder-123
 kafka: &id001
   password: pass-placeholder-123
   username: user-placeholder-123
@@ -62,6 +63,7 @@ global: &id002
   TEST_ENVGENE_CREDS_GET_VAULT_SECRET_ID: envgeneNullValue
   TEST_SHARED_CREDS: user-placeholder-123
   TEST_SHARED_CREDS_ACTIVATOR: pass-placeholder-123
+  TEST_CMDB_CREDS_USERNAME: user-placeholder-123
   graphite-remote-adapter: user-placeholder-123
   kafka: *id001
 alertmanager: *id002

--- a/build_effective_set_generator/parameters-processor/src/main/java/org/qubership/cloud/parameters/processor/expression/ExpressionLanguage.java
+++ b/build_effective_set_generator/parameters-processor/src/main/java/org/qubership/cloud/parameters/processor/expression/ExpressionLanguage.java
@@ -344,9 +344,6 @@ public class ExpressionLanguage extends AbstractLanguage {
                         if (insecure) {
                             return failedParameter(entry);
                         } else {
-                            if(entry.getValue() != null && entry.getValue().toString().contains("cmdb.creds[")){
-                                throw new ExpressionLanguageException(String.format("Expressions started with \"cmdb\" is not supported (parameter %s, value: %s)", entry.getKey(), entry.getValue()), e);
-                            }
                             throw new ExpressionLanguageException(String.format("Could not process expression for parameter %s with value: %s", entry.getKey(), entry.getValue()), e);
                         }
                     }

--- a/build_effective_set_generator/parameters-processor/src/main/java/org/qubership/cloud/parameters/processor/expression/binding/Binding.java
+++ b/build_effective_set_generator/parameters-processor/src/main/java/org/qubership/cloud/parameters/processor/expression/binding/Binding.java
@@ -82,6 +82,9 @@ public class Binding extends HashMap<String, Parameter> implements Cloneable {
         super.put("tenant", new Parameter(new TenantMap(tenant, cloud, namespace, application, this, originalNamespace).init()));
         super.put("application", new Parameter(new ApplicationMap(application, this, namespace).init()));
         super.put("creds", new Parameter(new CredentialsMap(this).init()));
+        EscapeMap credentials = new EscapeMap(null, this, "");
+        credentials.put("creds", new CredentialsMap(this).init());
+        super.put("cmdb",new Parameter(credentials));
 
         Map<String, Parameter> processed = calculateCredentialsAndPrepareStructuredParams(this);
 


### PR DESCRIPTION
# Pull Request

## Summary
Currently in effective set caluculator cmdb.creds macros is not supported. If users use this macro in the files, it gives unsupported error. However, it's supported in CMDB. For No CMDB approach to work seamlessly, this macro has to be supported in envgene also. Hence this change is to support cmdb.creds macro in envgen.

## Issue
There is no issue raised in github,
We need this change to support cmdb.creds macro in envgen.

## Breaking Change?

- [ ] Yes
- [X] No


## Scope / Project
Module impacted by this change: build_effective_set_generator. 

## Implementation Notes


## Tests / Evidence

Existing test data is updated.

## Additional Notes

