### PR TITLE
fix: for unit duplicated code in paramset sorting

### DIFF
--- a/scripts/build_env/tests/env-build/test_paramset_sorting.py
+++ b/scripts/build_env/tests/env-build/test_paramset_sorting.py
@@ -1,19 +1,7 @@
 from envgenehelper.business_helper import is_from_template_dir
-
+from build_env import sort_paramsets_with_same_name
 
 class TestSortParamsetsWithSameName:
-
-    @staticmethod
-    def sort_paramsets_with_same_name(entries: list[dict]) -> list[dict]:
-        def sort_key(e):
-            path = e["filePath"]
-            if "from_instance" in path:
-                return 2, path
-            elif is_from_template_dir(path):
-                return 0, path
-            return 1, path
-
-        return sorted(entries, key=sort_key)
 
     def test_all_three_levels(self):
         entries = [
@@ -21,7 +9,7 @@ class TestSortParamsetsWithSameName:
             {"filePath": "/tmp/render/parameters/test.yml", "envSpecific": False},
             {"filePath": "/tmp/render/parameters/from_template/test.yml", "envSpecific": False},
         ]
-        sorted_entries = self.sort_paramsets_with_same_name(entries)
+        sorted_entries = sort_paramsets_with_same_name(entries)
         assert "from_template" in sorted_entries[0]["filePath"]
         assert "from_instance" not in sorted_entries[1]["filePath"]
         assert "from_instance" in sorted_entries[2]["filePath"]
@@ -31,7 +19,7 @@ class TestSortParamsetsWithSameName:
             {"filePath": "/tmp/render/parameters/from_instance/test.yml", "envSpecific": True},
             {"filePath": "/tmp/render/parameters/from_template/test.yml", "envSpecific": False},
         ]
-        sorted_entries = self.sort_paramsets_with_same_name(entries)
+        sorted_entries = sort_paramsets_with_same_name(entries)
         assert "from_template" in sorted_entries[0]["filePath"]
         assert "from_instance" in sorted_entries[1]["filePath"]
 
@@ -42,7 +30,7 @@ class TestSortParamsetsWithSameName:
             {"filePath": "/tmp/render/parameters/from_peer_template/test.yml", "envSpecific": False},
             {"filePath": "/tmp/render/parameters/from_origin_template/test.yml", "envSpecific": False},
         ]
-        sorted_entries = self.sort_paramsets_with_same_name(entries)
+        sorted_entries = sort_paramsets_with_same_name(entries)
         assert "from_origin_template" in sorted_entries[0]["filePath"]
         assert "from_peer_template" in sorted_entries[1]["filePath"]
         assert "from_template" in sorted_entries[2]["filePath"]
@@ -54,7 +42,7 @@ class TestSortParamsetsWithSameName:
             {"filePath": "/tmp/render/parameters/from_template/a_params.yml", "envSpecific": False},
             {"filePath": "/tmp/render/parameters/from_template/m_params.yml", "envSpecific": False},
         ]
-        sorted_entries = self.sort_paramsets_with_same_name(entries)
+        sorted_entries = sort_paramsets_with_same_name(entries)
         paths = [e["filePath"] for e in sorted_entries]
         assert paths == sorted(paths)
 
@@ -63,9 +51,9 @@ class TestSortParamsetsWithSameName:
             {"filePath": "/tmp/render/parameters/from_instance/DCL_E2E_parameters.yaml", "envSpecific": True},
             {"filePath": "/tmp/render/parameters/from_template/e2e/dcl.yaml", "envSpecific": False},
         ]
-        sorted_entries = self.sort_paramsets_with_same_name(entries)
+        sorted_entries = sort_paramsets_with_same_name(entries)
         assert "from_template" in sorted_entries[0]["filePath"]
         assert "from_instance" in sorted_entries[1]["filePath"]
 
     def test_empty_list(self):
-        assert len(self.sort_paramsets_with_same_name([])) == 0
+        assert len(sort_paramsets_with_same_name([])) == 0


### PR DESCRIPTION
# Pull Request

## Summary

Refactor test_paramset_sorting.py to remove duplicated sort_paramsets_with_same_name method and use the function from source code (build_env.py) instead, eliminating code duplication while maintaining test functionality.

## Issue

Fixes code duplication issue where the test class contained a copy of sort_paramsets_with_same_name method instead of importing and using the actual implementation from

## Breaking Change?

- [ ] Yes
- [x] No


## Tests / Evidence

Changes were verified via test passing in Pipeline: https://github.com/Netcracker/qubership-envgene/actions/runs/22948958318/job/66608485162


