### PR TITLE
fix: temporary fix for tmp folder overwrite

### DIFF
--- a/build_pipegene/scripts/appregdef_render_job.py
+++ b/build_pipegene/scripts/appregdef_render_job.py
@@ -52,8 +52,7 @@ def prepare_appregdef_render_job(pipeline, params, full_env, environment_name, c
     appregdef_render_job = job_instance(params=appregdef_render_params, vars=appregdef_render_vars)
 
     appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/environments/" + full_env)
-    appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/configuration")
-    #appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/tmp")
+    appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/configuration")   
     appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/${CI_PIPELINE_ID}/tmp")
     appregdef_render_job.artifacts.when = WhenStatement.ALWAYS
 

--- a/build_pipegene/scripts/appregdef_render_job.py
+++ b/build_pipegene/scripts/appregdef_render_job.py
@@ -52,8 +52,7 @@ def prepare_appregdef_render_job(pipeline, params, full_env, environment_name, c
     appregdef_render_job = job_instance(params=appregdef_render_params, vars=appregdef_render_vars)
 
     appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/environments/" + full_env)
-    appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/configuration")   
-    appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/${CI_PIPELINE_ID}/tmp")
+    appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/configuration")    
     appregdef_render_job.artifacts.when = WhenStatement.ALWAYS
 
     pipeline.add_children(appregdef_render_job)

--- a/build_pipegene/scripts/appregdef_render_job.py
+++ b/build_pipegene/scripts/appregdef_render_job.py
@@ -17,6 +17,16 @@ def prepare_appregdef_render_job(pipeline, params, full_env, environment_name, c
 
     script.append('python3 /build_env/scripts/build_env/appregdef_render.py')
 
+    script.append(
+    'if [ -d "$CI_PROJECT_DIR/tmp" ]; then '
+    'DEST="$CI_PROJECT_DIR/$CI_PIPELINE_ID/tmp"; '
+    'echo "Copying tmp in $CI_PROJECT_DIR to $DEST"; '
+    'mkdir -p "$DEST"; '
+    'cp -r "$CI_PROJECT_DIR/tmp/." "$DEST/"; '
+    'else echo "tmp directory does not exist in $CI_PROJECT_DIR, skipping copy"; '
+    'fi'
+    )
+
     appregdef_render_params = {
         "name": f'app_reg_def_render.{full_env}',
         "image": '${envgen_image}',
@@ -43,7 +53,8 @@ def prepare_appregdef_render_job(pipeline, params, full_env, environment_name, c
 
     appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/environments/" + full_env)
     appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/configuration")
-    appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/tmp")
+    #appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/tmp")
+    appregdef_render_job.artifacts.add_paths("${CI_PROJECT_DIR}/${CI_PIPELINE_ID}/tmp")
     appregdef_render_job.artifacts.when = WhenStatement.ALWAYS
 
     pipeline.add_children(appregdef_render_job)

--- a/build_pipegene/scripts/env_build_jobs.py
+++ b/build_pipegene/scripts/env_build_jobs.py
@@ -8,6 +8,13 @@ def prepare_env_build_job(pipeline, is_template_test, full_env, enviroment_name,
     logger.info(f'prepare env_build job for {full_env}')
 
     script = [
+        'echo "PIPELINE=$CI_PIPELINE_ID JOB=$CI_JOB_NAME"',
+        'if [ -d "$CI_PROJECT_DIR/$CI_PIPELINE_ID/tmp" ] && [ -d "$CI_PROJECT_DIR/tmp" ]; then',
+        'echo "Copying $CI_PROJECT_DIR/$CI_PIPELINE_ID/tmp -> $CI_PROJECT_DIR/tmp";',
+        'rm -rf "$CI_PROJECT_DIR/tmp/"* 2>/dev/null || echo "Warning: Failed to remove some files in tmp"',
+        'cp -r "$CI_PROJECT_DIR/$CI_PIPELINE_ID/tmp/." "$CI_PROJECT_DIR/tmp/" || echo "Warning: Failed to copy tmp contents"',
+        'rm -rf "$CI_PROJECT_DIR/$CI_PIPELINE_ID" || echo "Warning: Failed to delete pipeline directory"',
+        'fi',
         'cd /build_env; python3 /build_env/scripts/build_env/main.py'
     ]
 
@@ -46,7 +53,7 @@ def prepare_env_build_job(pipeline, is_template_test, full_env, enviroment_name,
     else:
         env_build_job.artifacts.add_paths("${CI_PROJECT_DIR}/environments/" + f"{full_env}")
         env_build_job.artifacts.add_paths("${CI_PROJECT_DIR}/configuration")
-        env_build_job.artifacts.add_paths("${CI_PROJECT_DIR}/tmp")
+        #env_build_job.artifacts.add_paths("${CI_PROJECT_DIR}/tmp")
     env_build_job.artifacts.when = WhenStatement.ALWAYS
     pipeline.add_children(env_build_job)
     return env_build_job

--- a/build_pipegene/scripts/env_build_jobs.py
+++ b/build_pipegene/scripts/env_build_jobs.py
@@ -9,6 +9,12 @@ def prepare_env_build_job(pipeline, is_template_test, full_env, enviroment_name,
 
     script = [
         'echo "PIPELINE=$CI_PIPELINE_ID JOB=$CI_JOB_NAME"',
+        'echo "==== Workspace contents ===="',
+        'ls -al $CI_PROJECT_DIR',
+        'echo "==== TMP contents ===="',
+        'ls -al $CI_PROJECT_DIR/tmp || echo "tmp missing"',
+        'if [ -d "$CI_PROJECT_DIR/tmp/templates/parameters" ]; then echo "==== TMP/templates/parameters contents ===="; ls -al $CI_PROJECT_DIR/tmp/templates/parameters; else echo "tmp/templates/parameters missing"; fi',
+        'echo "PIPELINE=$CI_PIPELINE_ID JOB=$CI_JOB_NAME"',
         'if [ -d "$CI_PROJECT_DIR/$CI_PIPELINE_ID/tmp" ] && [ -d "$CI_PROJECT_DIR/tmp" ]; then',
         'echo "Copying $CI_PROJECT_DIR/$CI_PIPELINE_ID/tmp -> $CI_PROJECT_DIR/tmp";',
         'rm -rf "$CI_PROJECT_DIR/tmp/"* 2>/dev/null || echo "Warning: Failed to remove some files in tmp"',

--- a/build_pipegene/scripts/env_build_jobs.py
+++ b/build_pipegene/scripts/env_build_jobs.py
@@ -8,13 +8,7 @@ def prepare_env_build_job(pipeline, is_template_test, full_env, enviroment_name,
     logger.info(f'prepare env_build job for {full_env}')
 
     script = [
-        'echo "PIPELINE=$CI_PIPELINE_ID JOB=$CI_JOB_NAME"',
-        'echo "==== Workspace contents ===="',
-        'ls -al $CI_PROJECT_DIR',
-        'echo "==== TMP contents ===="',
-        'ls -al $CI_PROJECT_DIR/tmp || echo "tmp missing"',
-        'if [ -d "$CI_PROJECT_DIR/tmp/templates/parameters" ]; then echo "==== TMP/templates/parameters contents ===="; ls -al $CI_PROJECT_DIR/tmp/templates/parameters; else echo "tmp/templates/parameters missing"; fi',
-        'echo "PIPELINE=$CI_PIPELINE_ID JOB=$CI_JOB_NAME"',
+        'echo "PIPELINE=$CI_PIPELINE_ID JOB=$CI_JOB_NAME"',        
         'if [ -d "$CI_PROJECT_DIR/$CI_PIPELINE_ID/tmp" ] && [ -d "$CI_PROJECT_DIR/tmp" ]; then',
         'echo "Copying $CI_PROJECT_DIR/$CI_PIPELINE_ID/tmp -> $CI_PROJECT_DIR/tmp";',
         'rm -rf "$CI_PROJECT_DIR/tmp/"* 2>/dev/null || echo "Warning: Failed to remove some files in tmp"',
@@ -58,8 +52,7 @@ def prepare_env_build_job(pipeline, is_template_test, full_env, enviroment_name,
         env_build_job.artifacts.add_paths("${CI_PROJECT_DIR}/set_variable.txt")
     else:
         env_build_job.artifacts.add_paths("${CI_PROJECT_DIR}/environments/" + f"{full_env}")
-        env_build_job.artifacts.add_paths("${CI_PROJECT_DIR}/configuration")
-        #env_build_job.artifacts.add_paths("${CI_PROJECT_DIR}/tmp")
+        env_build_job.artifacts.add_paths("${CI_PROJECT_DIR}/configuration")      
     env_build_job.artifacts.when = WhenStatement.ALWAYS
     pipeline.add_children(env_build_job)
     return env_build_job

--- a/build_pipegene/scripts/gitlab_ci.py
+++ b/build_pipegene/scripts/gitlab_ci.py
@@ -202,7 +202,8 @@ def build_pipeline(params: dict) -> None:
             'configuration/',
             'sboms/',
             'templates/',
-            'tmp/'
+            'tmp/',
+            '$CI_PIPELINE_ID/tmp'
         )
 
         is_first_job = job.needs is None or len(job.needs) == 0

--- a/build_pipegene/scripts/gitlab_ci.py
+++ b/build_pipegene/scripts/gitlab_ci.py
@@ -201,7 +201,8 @@ def build_pipeline(params: dict) -> None:
             'environments/',
             'configuration/',
             'sboms/',
-            'templates/'
+            'templates/',
+            'tmp/'
         )
 
         is_first_job = job.needs is None or len(job.needs) == 0

--- a/build_pipegene/scripts/process_sd_job.py
+++ b/build_pipegene/scripts/process_sd_job.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from gcip import WhenStatement
 
@@ -9,7 +9,7 @@ from pipeline_helper import job_instance
 def prepare_process_sd(pipeline, full_env, environment_name, cluster_name, artifact_app_defs_path, artifact_reg_defs_path, tags):
     logger.info(f'Prepare process_sd job for {full_env}')
     
-    base_dir = os.getenv('CI_PROJECT_DIR')
+    base_dir = getenv('CI_PROJECT_DIR')
     base_env_path = f"{base_dir}/environments/{full_env}"
     app_defs_path = f"{base_env_path}/AppDefs"
     reg_defs_path = f"{base_env_path}/RegDefs"
@@ -40,13 +40,9 @@ def prepare_process_sd(pipeline, full_env, environment_name, cluster_name, artif
     }
 
     process_sd_job = job_instance(params=process_sd_set_params, vars=process_sd_set_vars)
-
-    tmp_path = os.path.join(os.environ["CI_PROJECT_DIR"], os.environ["CI_PIPELINE_ID"], "tmp")
-    if os.path.isdir(tmp_path):
-        process_sd_job.artifacts.add_paths(tmp_path)  
-
     
     process_sd_job.artifacts.add_paths("${CI_PROJECT_DIR}/environments/" + full_env)
+    process_sd_job.artifacts.add_paths("${CI_PROJECT_DIR}/${CI_PIPELINE_ID}/tmp")
     process_sd_job.artifacts.when = WhenStatement.ALWAYS
     
     pipeline.add_children(process_sd_job)

--- a/build_pipegene/scripts/process_sd_job.py
+++ b/build_pipegene/scripts/process_sd_job.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from gcip import WhenStatement
 
@@ -40,13 +40,9 @@ def prepare_process_sd(pipeline, full_env, environment_name, cluster_name, artif
     }
 
     process_sd_job = job_instance(params=process_sd_set_params, vars=process_sd_set_vars)
-
-    tmp_path = os.path.join(os.environ["CI_PROJECT_DIR"], os.environ["CI_PIPELINE_ID"], "tmp")
-    if os.path.isdir(tmp_path):
-        process_sd_job.artifacts.add_paths(tmp_path)  
-
     
     process_sd_job.artifacts.add_paths("${CI_PROJECT_DIR}/environments/" + full_env)
+    process_sd_job.artifacts.add_paths("${CI_PROJECT_DIR}/${CI_PIPELINE_ID}/tmp")
     process_sd_job.artifacts.when = WhenStatement.ALWAYS
     
     pipeline.add_children(process_sd_job)

--- a/build_pipegene/scripts/process_sd_job.py
+++ b/build_pipegene/scripts/process_sd_job.py
@@ -42,7 +42,6 @@ def prepare_process_sd(pipeline, full_env, environment_name, cluster_name, artif
     process_sd_job = job_instance(params=process_sd_set_params, vars=process_sd_set_vars)
     
     process_sd_job.artifacts.add_paths("${CI_PROJECT_DIR}/environments/" + full_env)
-    process_sd_job.artifacts.add_paths("${CI_PROJECT_DIR}/${CI_PIPELINE_ID}/tmp")
     process_sd_job.artifacts.when = WhenStatement.ALWAYS
     
     pipeline.add_children(process_sd_job)

--- a/build_pipegene/scripts/process_sd_job.py
+++ b/build_pipegene/scripts/process_sd_job.py
@@ -9,7 +9,7 @@ from pipeline_helper import job_instance
 def prepare_process_sd(pipeline, full_env, environment_name, cluster_name, artifact_app_defs_path, artifact_reg_defs_path, tags):
     logger.info(f'Prepare process_sd job for {full_env}')
     
-    base_dir = getenv('CI_PROJECT_DIR')
+    base_dir = os.getenv('CI_PROJECT_DIR')
     base_env_path = f"{base_dir}/environments/{full_env}"
     app_defs_path = f"{base_env_path}/AppDefs"
     reg_defs_path = f"{base_env_path}/RegDefs"

--- a/build_pipegene/scripts/process_sd_job.py
+++ b/build_pipegene/scripts/process_sd_job.py
@@ -1,4 +1,4 @@
-from os import getenv
+from os
 
 from gcip import WhenStatement
 
@@ -40,6 +40,11 @@ def prepare_process_sd(pipeline, full_env, environment_name, cluster_name, artif
     }
 
     process_sd_job = job_instance(params=process_sd_set_params, vars=process_sd_set_vars)
+
+    tmp_path = os.path.join(os.environ["CI_PROJECT_DIR"], os.environ["CI_PIPELINE_ID"], "tmp")
+    if os.path.isdir(tmp_path):
+        process_sd_job.artifacts.add_paths(tmp_path)  
+
     
     process_sd_job.artifacts.add_paths("${CI_PROJECT_DIR}/environments/" + full_env)
     process_sd_job.artifacts.when = WhenStatement.ALWAYS

--- a/build_pipegene/scripts/process_sd_job.py
+++ b/build_pipegene/scripts/process_sd_job.py
@@ -1,4 +1,4 @@
-from os
+import os
 
 from gcip import WhenStatement
 

--- a/build_pipegene/scripts/process_sd_job.py
+++ b/build_pipegene/scripts/process_sd_job.py
@@ -9,7 +9,7 @@ from pipeline_helper import job_instance
 def prepare_process_sd(pipeline, full_env, environment_name, cluster_name, artifact_app_defs_path, artifact_reg_defs_path, tags):
     logger.info(f'Prepare process_sd job for {full_env}')
     
-    base_dir = os.getenv('CI_PROJECT_DIR')
+    base_dir = getenv('CI_PROJECT_DIR')
     base_env_path = f"{base_dir}/environments/{full_env}"
     app_defs_path = f"{base_env_path}/AppDefs"
     reg_defs_path = f"{base_env_path}/RegDefs"


### PR DESCRIPTION
# Pull Request

## Summary

GitLab runners do not always clean up the workspace before starting a new job. When the same runner is reused, artifacts or temporary files from previous jobs or pipelines may remain in the workspace. This can cause conflicts with data generated by the current pipeline.
The issue was observed with the CI_PROJECT_DIR/tmp directory, where template repository details are copied. As a temporary workaround, the /tmp directory will be copied to CI_PROJECT_DIR/CI_PIPELINE_ID/tmp in the app_reg_def_render job where this /tmp folder is created. Later, in the env_build job, the existing contents of the /tmp directory will be cleaned up and replaced with the contents from CI_PROJECT_DIR/CI_PIPELINE_ID/tmp.

This approach isolates pipeline-specific data and prevents conflicts caused by leftover files from previous jobs.

## Issue
Github issue is not created

## Breaking Change?

- [ ] Yes
- [X] No


## Scope / Project
area affected: pipeline workflow

## Implementation Notes
1. Copy the tmp artifacts to pipleineid/tmp in app_reg_def_render job and pass it as a new artifact
2. pipleineid/tmp is added as a new artifact in process_sd job as well as this job can come in between app_reg_def_render and env_builder job
3. in env_build job empty the contents of tmp and copy it from pipleineid/tmp passed as artifact to this job

## Tests / Evidence

Tested by running the instance pipeline and printing the contents of the /tmp folder to verify that the expected files are correctly copied and isolated for the current pipeline.

## Additional Notes

It's a temporary fix as it currently it handles only /tmp directory. Fix will be extended to add artifacts with pipeline id as part of a different change

