### PR TITLE
fix: change logic to create the repo url from registry

### DIFF
--- a/python/artifact-searcher/artifact_searcher/artifact.py
+++ b/python/artifact-searcher/artifact_searcher/artifact.py
@@ -16,6 +16,7 @@ from artifact_searcher.utils.constants import DEFAULT_REQUEST_TIMEOUT, TCP_CONNE
 from artifact_searcher.utils.models import Registry, Application, FileExtension, Credentials, ArtifactInfo
 from envgenehelper import logger
 from requests.auth import HTTPBasicAuth
+from artifact_searcher.utils.models import MavenConfig
 
 WORKSPACE = os.getenv("WORKSPACE", Path(tempfile.gettempdir()) / "zips")
 
@@ -306,7 +307,7 @@ async def check_artifact_async(
     if result is not None:
         return result
 
-    if not app.registry.maven_config.is_nexus:
+    if not MavenConfig.is_nexus(app.registry.maven_config.repository_domain_name):
         return result
 
     # trying to edit url for nexus and repeat
@@ -403,6 +404,9 @@ def check_artifact(repo_url: str, group_id: str, artifact_id: str, version: str,
                    artifact_extension: FileExtension,
                    cred: Credentials | None = None,
                    classifier: str = "") -> str | None:
+    if MavenConfig.is_nexus(repo_url):
+        repo_url = convert_nexus_repo_url_to_index_view(repo_url)
+
     base = repo_url.rstrip("/") + "/"
     group_id = group_id.replace(".", "/")
 

--- a/python/artifact-searcher/artifact_searcher/test_artifact.py
+++ b/python/artifact-searcher/artifact_searcher/test_artifact.py
@@ -2,11 +2,18 @@ import os
 
 import pytest
 from aiohttp import web
+from unittest.mock import patch, Mock
 
 os.environ["DEFAULT_REQUEST_TIMEOUT"] = "0.2"  # for test cases to run quicker
 from artifact_searcher.utils import models
 from artifact_searcher.artifact import check_artifact_async
+from artifact_searcher.artifact import check_artifact
+from artifact_searcher.utils.models import FileExtension
 
+TEST_REPO = "https://repo.example.com/repository/"
+GROUP_ID = "com.example"
+ARTIFACT_ID = "demo"
+VERSION = "1.0.0"
 
 class MockResponse:
     def __init__(self, status_code):
@@ -93,3 +100,72 @@ async def test_resolve_snapshot_version(aiohttp_server, index_path, monkeypatch)
 
     sample_url = f"{base_url.rstrip('/repository/')}{index_path}repo/com/example/app/1.0.0-SNAPSHOT/app-1.0.0-20240702.123456-1.json"
     assert full_url == sample_url, f"expected: {sample_url}, received: {full_url}"
+
+@patch("artifact_searcher.artifact.requests.head")
+@patch("artifact_searcher.artifact.create_artifact_name")
+@patch("artifact_searcher.artifact.version_to_folder_name")
+@patch("artifact_searcher.artifact.MavenConfig.is_nexus")
+def test_artifact_found(mock_nexus, mock_folder, mock_name, mock_head):
+
+    mock_nexus.return_value = False
+    mock_folder.return_value = VERSION
+    mock_name.return_value = "demo-1.0.0.zip"
+
+    response = Mock()
+    response.status_code = 200
+    mock_head.return_value = response
+
+    result = check_artifact(
+        TEST_REPO,
+        GROUP_ID,
+        ARTIFACT_ID,
+        VERSION,
+        FileExtension.ZIP
+    )
+
+    assert result == (
+        "https://repo.example.com/repository/com/example/demo/1.0.0/demo-1.0.0.zip"
+    )
+
+
+@patch("artifact_searcher.artifact.requests.head")
+@patch("artifact_searcher.artifact.create_artifact_name")
+@patch("artifact_searcher.artifact.version_to_folder_name")
+@patch("artifact_searcher.artifact.MavenConfig.is_nexus")
+def test_artifact_not_found(mock_nexus, mock_folder, mock_name, mock_head):
+
+    mock_nexus.return_value = False
+    mock_folder.return_value = VERSION
+    mock_name.return_value = "demo-1.0.0.zip"
+
+    response = Mock()
+    response.status_code = 404
+    mock_head.return_value = response
+
+    result = check_artifact(
+        TEST_REPO,
+        GROUP_ID,
+        ARTIFACT_ID,
+        VERSION,
+        FileExtension.ZIP
+    )
+
+    assert result is None
+
+
+@patch("artifact_searcher.artifact.MavenConfig.is_nexus")
+@patch("artifact_searcher.artifact.convert_nexus_repo_url_to_index_view")
+def test_nexus_repo_conversion(mock_convert, mock_detect):
+
+    mock_detect.return_value = True
+    mock_convert.return_value = "https://nexus.example.com/service/rest/repository/browse/"
+
+    check_artifact(
+        TEST_REPO,
+        GROUP_ID,
+        ARTIFACT_ID,
+        VERSION,
+        FileExtension.ZIP
+    )
+
+    mock_convert.assert_called_once()

--- a/python/artifact-searcher/artifact_searcher/utils/models.py
+++ b/python/artifact-searcher/artifact_searcher/utils/models.py
@@ -26,8 +26,6 @@ class MavenConfig(BaseSchema):
     snapshot_group: Optional[str] = ""
     release_group: Optional[str] = ""
 
-    is_nexus: bool = False
-
     @field_validator('full_repository_url')
     def check_full_repository_url(cls, full_repository_url):
         if full_repository_url:
@@ -38,20 +36,19 @@ class MavenConfig(BaseSchema):
     def ensure_trailing_slash(cls, value):
         return value.rstrip("/") + "/"
 
-    @model_validator(mode="after")
-    def detect_nexus(self):
-        if not self.repository_domain_name.endswith("/repository/"):
-            return self
-        base = self.repository_domain_name[: -len("repository/")]
+    @staticmethod
+    def is_nexus(repository_domain_name: str) -> bool:
+        if not repository_domain_name.endswith("/repository/"):
+            return False
+
+        base = repository_domain_name[: -len("repository/")]
         status_url = f"{base}service/rest/v1/status"
+
         try:
             resp = requests.get(status_url, timeout=DEFAULT_REQUEST_TIMEOUT)
-            self.is_nexus = resp.status_code == 200
+            return resp.status_code == 200
         except Exception:
-            self.is_nexus = False
-
-        return self
-
+            return False
 
 class DockerConfig(BaseSchema):
     snapshot_uri: Optional[str] = ""

--- a/scripts/build_env/env_template/process_env_template.py
+++ b/scripts/build_env/env_template/process_env_template.py
@@ -2,7 +2,6 @@ import asyncio
 import os
 import tempfile
 from pathlib import Path
-from urllib.parse import urlparse
 
 from artifact_searcher import artifact
 from artifact_searcher.utils.models import FileExtension, Credentials, Registry, Application
@@ -86,8 +85,7 @@ async def resolve_artifact_new_logic(app_def: Application, app_version: str, tem
         repo_url = dd_config.get("configurations", [{}])[0].get("maven_repository")
         
         if not repo_url:
-            parsed = urlparse(dd_url)
-            repo_url = f"{parsed.scheme}://{parsed.netloc}/{repo_name}"
+            repo_url = f"{app_def.registry.maven_config.repository_domain_name}/{repo_name}"
             logger.info(f"building repo url from the repo name : {repo_url}")
         template_url = artifact.check_artifact(repo_url, group_id, artifact_id, version, FileExtension.ZIP, cred)
         validate_url(template_url, group_id, artifact_id, version)


### PR DESCRIPTION
# Pull Request

## Summary

changed logic to build the repo url from registry when there is no maven_repository in deployment descriptor config


## Breaking Change?

- [ ] Yes
- [X] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).


## Tests / Evidence

Describe how the changes were verified, including:

Tested using the JUnit test cases

Leave blank if not applicable.
