### PR TITLE
fix: adding GIT_STRATEGY

### DIFF
--- a/build_pipegene/scripts/appregdef_render_job.py
+++ b/build_pipegene/scripts/appregdef_render_job.py
@@ -17,16 +17,6 @@ def prepare_appregdef_render_job(pipeline, params, full_env, environment_name, c
 
     script.append('python3 /build_env/scripts/build_env/appregdef_render.py')
 
-    script.append(
-    'if [ -d "$CI_PROJECT_DIR/tmp" ]; then '
-    'DEST="$CI_PROJECT_DIR/$CI_PIPELINE_ID/tmp"; '
-    'echo "Copying tmp in $CI_PROJECT_DIR to $DEST"; '
-    'mkdir -p "$DEST"; '
-    'cp -r "$CI_PROJECT_DIR/tmp/." "$DEST/"; '
-    'else echo "tmp directory does not exist in $CI_PROJECT_DIR, skipping copy"; '
-    'fi'
-    )
-
     appregdef_render_params = {
         "name": f'app_reg_def_render.{full_env}',
         "image": '${envgen_image}',

--- a/build_pipegene/scripts/env_build_jobs.py
+++ b/build_pipegene/scripts/env_build_jobs.py
@@ -8,13 +8,6 @@ def prepare_env_build_job(pipeline, is_template_test, full_env, enviroment_name,
     logger.info(f'prepare env_build job for {full_env}')
 
     script = [
-        'echo "PIPELINE=$CI_PIPELINE_ID JOB=$CI_JOB_NAME"',        
-        'if [ -d "$CI_PROJECT_DIR/$CI_PIPELINE_ID/tmp" ] && [ -d "$CI_PROJECT_DIR/tmp" ]; then',
-        'echo "Copying $CI_PROJECT_DIR/$CI_PIPELINE_ID/tmp -> $CI_PROJECT_DIR/tmp";',
-        'rm -rf "$CI_PROJECT_DIR/tmp/"* 2>/dev/null || echo "Warning: Failed to remove some files in tmp"',
-        'cp -r "$CI_PROJECT_DIR/$CI_PIPELINE_ID/tmp/." "$CI_PROJECT_DIR/tmp/" || echo "Warning: Failed to copy tmp contents"',
-        'rm -rf "$CI_PROJECT_DIR/$CI_PIPELINE_ID" || echo "Warning: Failed to delete pipeline directory"',
-        'fi',
         'cd /build_env; python3 /build_env/scripts/build_env/main.py'
     ]
 
@@ -83,7 +76,6 @@ def prepare_git_commit_job(pipeline, full_env, enviroment_name, cluster_name, de
         "envgen_args": " -vv",
         "envgen_debug": "true",
         "module_config_default": "/module/templates/defaults.yaml",
-        "GIT_STRATEGY": "none",
         "COMMIT_ENV": "true",
         "GITLAB_RUNNER_TAG_NAME": tags,
         "DEPLOY_SESSION_ID": deployment_session_id

--- a/build_pipegene/scripts/gitlab_ci.py
+++ b/build_pipegene/scripts/gitlab_ci.py
@@ -202,12 +202,11 @@ def build_pipeline(params: dict) -> None:
             'configuration/',
             'sboms/',
             'templates/',
-            'tmp/',
-            '$CI_PIPELINE_ID/tmp'
+            'tmp/'
         )
 
         is_first_job = job.needs is None or len(job.needs) == 0
         if not is_first_job:
-            job.add_variables(GIT_CHECKOUT="false")
+            job.add_variables(GIT_STRATEGY="empty")
 
     sorted_pipeline.write_yaml()

--- a/build_pipegene/scripts/process_sd_job.py
+++ b/build_pipegene/scripts/process_sd_job.py
@@ -35,8 +35,7 @@ def prepare_process_sd(pipeline, full_env, environment_name, cluster_name, artif
         "envgen_image": "$envgen_image",
         "envgen_args": " -vv",
         "envgen_debug": "true",
-        "GITLAB_RUNNER_TAG_NAME": tags,
-        "GIT_STRATEGY": "clone"
+        "GITLAB_RUNNER_TAG_NAME": tags
     }
 
     process_sd_job = job_instance(params=process_sd_set_params, vars=process_sd_set_vars)


### PR DESCRIPTION
# Pull Request

## Summary

GitLab runners do not always clean up the workspace before starting a new job. When the same runner is reused, artifacts or temporary files from previous jobs or pipelines may remain in the workspace. This can cause conflicts with data generated by the current pipeline.
The issue was observed with the CI_PROJECT_DIR/tmp directory, where template repository details are copied. Now we are setting GIT_STRATEGY to empty which will always create a fresh workspace for each jobs. 

## Issue

Github issue is not created

## Breaking Change?

- [ ] Yes
- [X] No

## Scope / Project

area affected: pipeline workflow

## Implementation Notes

1. remove GIT_CHECKOUT false and put GIT_STATEGY empty

## Tests / Evidence

Describe how the changes were verified, including:

Tested by running the instance pipeline and printing the contents of the /tmp folder to verify that the expected files are correctly copied and isolated for the current pipeline.

## Additional Notes

Leave blank if not applicable.
