### PR TITLE
fix: generate-effective-set job can't find solution descriptor

### DIFF
--- a/build_pipegene/scripts/effective_set_job.py
+++ b/build_pipegene/scripts/effective_set_job.py
@@ -26,22 +26,24 @@ def prepare_generate_effective_set_job(pipeline, full_env_name, env_name, cluste
 
     is_local_app_def = artifact_app_defs_path and artifact_reg_defs_path and app_reg_defs_job
 
-    base_dir = getenv('CI_PROJECT_DIR')
-    base_env_path = f"{base_dir}/environments/{full_env_name}"
-    app_defs_path = f"{base_env_path}/AppDefs"
-    reg_defs_path = f"{base_env_path}/RegDefs"
-    sboms_path = get_sboms_dir(base_dir)
+    base_dir = getenv('CI_PROJECT_DIR')   
 
     sd_path = Path(f'{base_dir}/environments/{full_env_name}/Inventory/solution-descriptor/sd.yaml')
     # TODO it is necessary to remove unnecessary calls, leave only script calls in such jobs! bad for gsf delivery
     script = [
+        #Overriding sd_path to pick the correct value for CI_PROJECT_DIR
+        f'base_env_path="$CI_PROJECT_DIR/environments/{full_env_name}";',
+        'app_defs_path="$base_env_path/AppDefs";',
+        'reg_defs_path="$base_env_path/RegDefs";',
+        'sboms_path="$CI_PROJECT_DIR/sboms";',
+        'sd_path="$base_env_path/Inventory/solution-descriptor/sd.yaml";',
         # cert handling for java
         'mkdir -p ${CI_PROJECT_DIR}/configuration/certs/',
         'if [ -f /default_cert.pem ]; then cp /default_cert.pem "${CI_PROJECT_DIR}/configuration/certs/"; fi',
         'for cert in "${CI_PROJECT_DIR}/configuration/certs/*" ; do [ -f "$cert" ] && keytool -import -trustcacerts -alias "$(basename "$cert")" -file "$cert" -keystore /etc/ssl/certs/keystore.jks -storepass changeit -noprompt; done',
         'python3 /module/scripts/main.py decrypt_cred_files',
-        f'[ -n "$APP_REG_DEFS_JOB" ] && [ -n "$APP_DEFS_PATH" ] && mkdir -p {app_defs_path} && cp -rf {artifact_app_defs_path}/* {app_defs_path}',
-        f'[ -n "$APP_REG_DEFS_JOB" ] && [ -n "$REG_DEFS_PATH" ] && mkdir -p {reg_defs_path} && cp -fr {artifact_reg_defs_path}/* {reg_defs_path}',
+        f'[ -n "$APP_REG_DEFS_JOB" ] && [ -n "$APP_DEFS_PATH" ] && mkdir -p $app_defs_path && cp -rf {artifact_app_defs_path}/* $app_defs_path',
+        f'[ -n "$APP_REG_DEFS_JOB" ] && [ -n "$REG_DEFS_PATH" ] && mkdir -p $reg_defs_path && cp -fr {artifact_reg_defs_path}/* $reg_defs_path',
         'python3 /module/scripts/main.py validate_creds',
         'python3 /module/scripts/sboms_retention_policy.py'
     ]
@@ -66,8 +68,8 @@ def prepare_generate_effective_set_job(pipeline, full_env_name, env_name, cluste
     if full_sd_exists or sd_data:
         cmdb_cli_cmd_call.extend([
             "--registries=${CI_PROJECT_DIR}/configuration/registry.yml",
-            f"--sboms-path={str(sboms_path)}",
-            f"--sd-path={sd_path}",
+            "--sboms-path=$sboms_path",
+            "--sd-path=$sd_path",
         ])
 
     logger.info(f'Prepare generate_effective_set job for {full_env_name}.')

--- a/build_pipegene/scripts/process_sd_job.py
+++ b/build_pipegene/scripts/process_sd_job.py
@@ -9,14 +9,12 @@ from pipeline_helper import job_instance
 def prepare_process_sd(pipeline, full_env, environment_name, cluster_name, artifact_app_defs_path, artifact_reg_defs_path, tags):
     logger.info(f'Prepare process_sd job for {full_env}')
     
-    base_dir = getenv('CI_PROJECT_DIR')
-    base_env_path = f"{base_dir}/environments/{full_env}"
-    app_defs_path = f"{base_env_path}/AppDefs"
-    reg_defs_path = f"{base_env_path}/RegDefs"
-    
     script = [
-        f'[ -n "$APP_REG_DEFS_JOB" ] && [ -n "$APP_DEFS_PATH" ] && mkdir -p {app_defs_path} && cp -rf {artifact_app_defs_path}/* {app_defs_path}',
-        f'[ -n "$APP_REG_DEFS_JOB" ] && [ -n "$REG_DEFS_PATH" ] && mkdir -p {reg_defs_path} && cp -fr {artifact_reg_defs_path}/* {reg_defs_path}',
+        f'base_env_path="$CI_PROJECT_DIR/environments/{full_env}";',
+        'app_defs_path="$base_env_path/AppDefs";',
+        'reg_defs_path="$base_env_path/RegDefs";',
+        f'[ -n "$APP_REG_DEFS_JOB" ] && [ -n "$APP_DEFS_PATH" ] && mkdir -p $app_defs_path && cp -rf {artifact_app_defs_path}/* $app_defs_path',
+        f'[ -n "$APP_REG_DEFS_JOB" ] && [ -n "$REG_DEFS_PATH" ] && mkdir -p $reg_defs_path && cp -fr {artifact_reg_defs_path}/* $reg_defs_path',
         'python3 /build_env/scripts/build_env/process_sd.py',
     ]
 


### PR DESCRIPTION
# Pull Request

## Summary

Issue: when effective set job is run, sd.yaml file is not found
Root cause:
The issue arises because CI_PROJECT_DIR changes depending on the Git strategy:
In jobs generated normally, CI_PROJECT_DIR does not contain -empty string. eg:
<path>/instance-project
In jobs where GIT_STRATEGY: empty, CI_PROJECT_DIR also gets appended with -empty. eg:
<path>/instance-project-empty
The variable sd_path was constructed before the script executes, using the value of CI_PROJECT_DIR at job creation time.
As a result, sd_path points to the wrong directory in effective_set_job were GIT_STRATEGY: empty.

## Issue

no github issue

## Breaking Change?

- [ ] Yes
- [x] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

Move the path construction logic into the script section so it uses the runtime value of CI_PROJECT_DIR, ensuring paths are correct regardless of Git strategy.

## Tests / Evidence

Describe how the changes were verified, including:

- Tests added or updated (e.g., unit, integration, end-to-end)
- Manual testing steps or results
- Screenshots, logs, or other evidence (if applicable)

## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
