### PR TITLE
fix: modified k8_token logic to keep only namespaces instead of deploy postfixes

### DIFF
--- a/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/parser/CliParameterParser.java
+++ b/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/parser/CliParameterParser.java
@@ -106,12 +106,13 @@ public class CliParameterParser {
         Map<String, String> errorList = new ConcurrentHashMap<>();
         Map<String, String> k8TokenMap = new ConcurrentHashMap<>();
         namespaceDTOMap.keySet().parallelStream().forEach(namespaceName -> {
+            String originalNamespace = inputData.getNamespaceDTOMap().get(namespaceName).getName();
             String credentialsId = findDefaultCredentialsId(namespaceName);
             if (StringUtils.isNotEmpty(credentialsId)) {
                 CredentialDTO credentialDTO = inputData.getCredentialDTOMap().get(credentialsId);
                 if (credentialDTO != null) {
                     SecretCredentialsDTO secCred = (SecretCredentialsDTO) credentialDTO.getData();
-                    k8TokenMap.put(namespaceName, secCred.getSecret());
+                    k8TokenMap.put(originalNamespace, secCred.getSecret());
                 }
             }
         });
@@ -273,15 +274,7 @@ public class CliParameterParser {
                                String appVersion, String appFileRef, Map<String, String> k8TokenMap) throws IOException {
         DeployerInputs deployerInputs = DeployerInputs.builder().appVersion(appVersion).appFileRef(appFileRef).build();
         String originalNamespace = inputData.getNamespaceDTOMap().get(namespaceName).getName();
-        String credentialsId = findDefaultCredentialsId(namespaceName);
-        if (StringUtils.isNotEmpty(credentialsId)) {
-            CredentialDTO credentialDTO = inputData.getCredentialDTOMap().get(credentialsId);
-            if (credentialDTO != null) {
-                SecretCredentialsDTO secCred = (SecretCredentialsDTO) credentialDTO.getData();
-                k8TokenMap.put(originalNamespace, secCred.getSecret());
-            }
-        }
-        ParameterBundle parameterBundle = null;
+        ParameterBundle parameterBundle;
         if (EffectiveSetVersion.V2_0 == sharedData.getEffectiveSetVersion()) {
             CustomParameterDTO customParams = getCustomParameters();
             parameterBundle = parametersServiceV2.getCliParameter(tenantName,
@@ -300,8 +293,7 @@ public class CliParameterParser {
                     namespaceName,
                     appName,
                     deployerInputs,
-                    originalNamespace,
-                    k8TokenMap);
+                    originalNamespace);
 
         }
         createFiles(namespaceName, appName, parameterBundle, originalNamespace);

--- a/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/topology/credentials.yaml
+++ b/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/topology/credentials.yaml
@@ -3,7 +3,5 @@ bg_domain:
     password: pass-placeholder-123
     username: user-placeholder-123
 k8s_tokens:
-  monitoring-origin: token-placeholder-123
-  pg: token-placeholder-123
   pl-01-pg: token-placeholder-123
   pl-01-monitoring: token-placeholder-123

--- a/build_effective_set_generator/parameters-processor/src/main/java/org/qubership/cloud/parameters/processor/service/ParametersCalculationServiceV1.java
+++ b/build_effective_set_generator/parameters-processor/src/main/java/org/qubership/cloud/parameters/processor/service/ParametersCalculationServiceV1.java
@@ -43,16 +43,12 @@ public class ParametersCalculationServiceV1 {
     }
 
     public ParameterBundle getCliParameter(String tenantName, String cloudName, String namespaceName, String applicationName,
-                                           DeployerInputs deployerInputs, String originalNamespace, Map<String, String> k8TokenMap) {
-        return getParameterBundle(tenantName, cloudName, namespaceName, applicationName, deployerInputs, originalNamespace, k8TokenMap);
-    }
-
-    public ParameterBundle getCliE2EParameter(String tenantName, String cloudName) {
-        return getE2EParameterBundle(tenantName, cloudName);
+                                           DeployerInputs deployerInputs, String originalNamespace) {
+        return getParameterBundle(tenantName, cloudName, namespaceName, applicationName, deployerInputs, originalNamespace);
     }
 
     private ParameterBundle getParameterBundle(String tenantName, String cloudName, String namespaceName, String applicationName, DeployerInputs deployerInputs
-            , String originalNamespace, Map<String, String> k8TokenMap) {
+            , String originalNamespace) {
         Params parameters = parametersProcessor.processAllParameters(tenantName,
                 cloudName,
                 namespaceName,
@@ -65,13 +61,6 @@ public class ParametersCalculationServiceV1 {
         ParameterBundle parameterBundle = ParameterBundle.builder().build();
         prepareSecureInsecureParams(parameters.getDeployParams(), parameterBundle, ParameterType.DEPLOY);
         prepareSecureInsecureParams(parameters.getTechParams(), parameterBundle, ParameterType.TECHNICAL);
-        return parameterBundle;
-    }
-
-    private ParameterBundle getE2EParameterBundle(String tenantName, String cloudName) {
-        Params parameters = parametersProcessor.processE2EParameters(tenantName, cloudName, null, null, null, null);
-        ParameterBundle parameterBundle = ParameterBundle.builder().build();
-        prepareSecureInsecureParams(parameters.getE2eParams(), parameterBundle, ParameterType.E2E);
         return parameterBundle;
     }
 


### PR DESCRIPTION

# Pull Request

## Summary

Modified k8_token logic to keep only namespaces instead of deploy postfixes also removed unused k8TokenMap in V1 service

## Issue

We now store only namespaces in k8_tokens, and the unused k8_tokens variable has been removed from the parameter calculation service (v1). 

## Breaking Change?

- [ ] Yes
- [x] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

Provide details on how the change was implemented, including any technical considerations, trade-offs, or notable design decisions. Leave blank if not applicable.

## Tests / Evidence

Tested using integration test case

## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
