### PR TITLE
fix: correct type for consul_enabled

### DIFF
--- a/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/cloud.yml
+++ b/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/cloud.yml
@@ -40,7 +40,7 @@ deployParameters:
   CDN_STORAGE_USERNAME: "${STORAGE_USERNAME}" # cloud passport: cluster-01 version: 1.5
   CLOUD_DASHBOARD_URL: "https://dashboard.cluster-01.qubership.org" # cloud passport: cluster-01 version: 1.5
   CMDB_URL: "https://cluster-01.qubership.org" # cloud passport: cluster-01 version: 1.5
-  CONSUL_ENABLED: "true" # cloud passport: cluster-01 version: 1.5
+  CONSUL_ENABLED: true # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_ADMIN_LOGIN: "admin" # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_ADMIN_PASSWORD: "password" # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_NAME: "tenant" # cloud passport: cluster-01 version: 1.5

--- a/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/cleanup/monitoring-origin/parameters.yaml
+++ b/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/cleanup/monitoring-origin/parameters.yaml
@@ -12,7 +12,7 @@ CLOUD_PROTOCOL: https
 CLOUD_PUBLIC_HOST: cluster-01.qubership.org
 CMDB_URL: https://cluster-01.qubership.org
 CONSUL_ADMIN_TOKEN: token-placeholder-123
-CONSUL_ENABLED: 'true'
+CONSUL_ENABLED: true
 CONSUL_PUBLIC_URL: http://consul.consul:8080
 CONSUL_URL: http://consul.consul:8080
 CONTROLLER_NAMESPACE: env-1-bg-controller

--- a/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/cleanup/pg/parameters.yaml
+++ b/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/cleanup/pg/parameters.yaml
@@ -12,7 +12,7 @@ CLOUD_PROTOCOL: https
 CLOUD_PUBLIC_HOST: cluster-01.qubership.org
 CMDB_URL: https://cluster-01.qubership.org
 CONSUL_ADMIN_TOKEN: token-placeholder-123
-CONSUL_ENABLED: 'true'
+CONSUL_ENABLED: true
 CONSUL_PUBLIC_URL: http://consul.consul:8080
 CONSUL_URL: http://consul.consul:8080
 CUSTOM_HOST: cluster-01.qubership.org

--- a/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/deployment/monitoring-origin/MONITORING/values/deployment-parameters.yaml
+++ b/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/deployment/monitoring-origin/MONITORING/values/deployment-parameters.yaml
@@ -17,7 +17,7 @@ CLOUD_PRIVATE_HOST: cluster-01.qubership.org
 CLOUD_PROTOCOL: https
 CLOUD_PUBLIC_HOST: cluster-01.qubership.org
 CMDB_URL: https://cluster-01.qubership.org
-CONSUL_ENABLED: 'true'
+CONSUL_ENABLED: true
 CONSUL_PUBLIC_URL: http://consul.consul:8080
 CONSUL_URL: http://consul.consul:8080
 CONTROLLER_NAMESPACE: env-1-bg-controller
@@ -100,7 +100,7 @@ global: &id002
   CLOUD_PROTOCOL: https
   CLOUD_PUBLIC_HOST: cluster-01.qubership.org
   CMDB_URL: https://cluster-01.qubership.org
-  CONSUL_ENABLED: 'true'
+  CONSUL_ENABLED: true
   CONSUL_PUBLIC_URL: http://consul.consul:8080
   CONSUL_URL: http://consul.consul:8080
   CONTROLLER_NAMESPACE: env-1-bg-controller

--- a/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/deployment/pg/postgres/values/deployment-parameters.yaml
+++ b/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/deployment/pg/postgres/values/deployment-parameters.yaml
@@ -17,7 +17,7 @@ CLOUD_PRIVATE_HOST: cluster-01.qubership.org
 CLOUD_PROTOCOL: https
 CLOUD_PUBLIC_HOST: cluster-01.qubership.org
 CMDB_URL: https://cluster-01.qubership.org
-CONSUL_ENABLED: 'true'
+CONSUL_ENABLED: true
 CONSUL_PUBLIC_URL: http://consul.consul:8080
 CONSUL_URL: http://consul.consul:8080
 CUSTOM_HOST: cluster-01.qubership.org
@@ -89,7 +89,7 @@ global: &id001
   CLOUD_PROTOCOL: https
   CLOUD_PUBLIC_HOST: cluster-01.qubership.org
   CMDB_URL: https://cluster-01.qubership.org
-  CONSUL_ENABLED: 'true'
+  CONSUL_ENABLED: true
   CONSUL_PUBLIC_URL: http://consul.consul:8080
   CONSUL_URL: http://consul.consul:8080
   CUSTOM_HOST: cluster-01.qubership.org

--- a/scripts/build_env/cloud_passport.py
+++ b/scripts/build_env/cloud_passport.py
@@ -83,7 +83,7 @@ def process_cloud_definition(cloudPassportYaml, env_dir, comment) :
           process_and_update_key("publicUrl", consulConfigYaml, "CONSUL_PUBLIC_URL", consulPassportYaml, comment)
           process_and_update_key("internalUrl", consulConfigYaml, "CONSUL_URL", consulPassportYaml, comment)
           # CONSUL_ENABLED variable should be both in consul section and in deploy parameters
-          store_value_to_yaml(cloudYaml["deployParameters"], "CONSUL_ENABLED", f"{consulConfigYaml['enabled']}".lower(), comment)
+          store_value_to_yaml(cloudYaml["deployParameters"], "CONSUL_ENABLED", consulConfigYaml['enabled'], comment)
           del cloudPassportYaml["consul"]
     else:
         store_value_to_yaml(cloudYaml["consulConfig"], "enabled", False)

--- a/test_data/test_environments/cluster-01/env-01/cloud.yml
+++ b/test_data/test_environments/cluster-01/env-01/cloud.yml
@@ -40,7 +40,7 @@ deployParameters:
   CDN_STORAGE_USERNAME: "${STORAGE_USERNAME}" # cloud passport: cluster-01 version: 1.5
   CLOUD_DASHBOARD_URL: "https://dashboard.cluster-01.qubership.org" # cloud passport: cluster-01 version: 1.5
   CMDB_URL: "https://cluster-01.qubership.org" # cloud passport: cluster-01 version: 1.5
-  CONSUL_ENABLED: "true" # cloud passport: cluster-01 version: 1.5
+  CONSUL_ENABLED: true # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_ADMIN_LOGIN: "admin" # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_ADMIN_PASSWORD: "password" # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_NAME: "tenant" # cloud passport: cluster-01 version: 1.5

--- a/test_data/test_environments/cluster-01/env-02/cloud.yml
+++ b/test_data/test_environments/cluster-01/env-02/cloud.yml
@@ -40,7 +40,7 @@ deployParameters:
   CDN_STORAGE_USERNAME: "${STORAGE_USERNAME}" # cloud passport: cluster-01 version: 1.5
   CLOUD_DASHBOARD_URL: "https://dashboard.cluster-01.qubership.org" # cloud passport: cluster-01 version: 1.5
   CMDB_URL: "https://cluster-01.qubership.org" # cloud passport: cluster-01 version: 1.5
-  CONSUL_ENABLED: "true" # cloud passport: cluster-01 version: 1.5
+  CONSUL_ENABLED: true # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_ADMIN_LOGIN: "admin" # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_ADMIN_PASSWORD: "password" # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_NAME: "tenant" # cloud passport: cluster-01 version: 1.5

--- a/test_data/test_environments/cluster-01/env-03/cloud.yml
+++ b/test_data/test_environments/cluster-01/env-03/cloud.yml
@@ -40,7 +40,7 @@ deployParameters:
   CDN_STORAGE_USERNAME: "${STORAGE_USERNAME}" # cloud passport: cluster-01 version: 1.5
   CLOUD_DASHBOARD_URL: "https://dashboard.cluster-01.qubership.org" # cloud passport: cluster-01 version: 1.5
   CMDB_URL: "https://cluster-01.qubership.org" # cloud passport: cluster-01 version: 1.5
-  CONSUL_ENABLED: "true" # cloud passport: cluster-01 version: 1.5
+  CONSUL_ENABLED: true # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_ADMIN_LOGIN: "admin" # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_ADMIN_PASSWORD: "password" # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_NAME: "tenant" # cloud passport: cluster-01 version: 1.5

--- a/test_data/test_environments/cluster-01/env-04/cloud.yml
+++ b/test_data/test_environments/cluster-01/env-04/cloud.yml
@@ -40,7 +40,7 @@ deployParameters:
   CDN_STORAGE_USERNAME: "${STORAGE_USERNAME}" # cloud passport: cluster-01 version: 1.5
   CLOUD_DASHBOARD_URL: "https://dashboard.cluster-01.qubership.org" # cloud passport: cluster-01 version: 1.5
   CMDB_URL: "https://cluster-01.qubership.org" # cloud passport: cluster-01 version: 1.5
-  CONSUL_ENABLED: "true" # cloud passport: cluster-01 version: 1.5
+  CONSUL_ENABLED: true # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_ADMIN_LOGIN: "admin" # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_ADMIN_PASSWORD: "password" # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_NAME: "tenant" # cloud passport: cluster-01 version: 1.5

--- a/test_data/test_environments/cluster-02/env-01/cloud.yml
+++ b/test_data/test_environments/cluster-02/env-01/cloud.yml
@@ -40,7 +40,7 @@ deployParameters:
   CDN_STORAGE_USERNAME: "${STORAGE_USERNAME}" # cloud passport: cluster-01 version: 1.5
   CLOUD_DASHBOARD_URL: "https://dashboard.cluster-01.qubership.org" # cloud passport: cluster-01 version: 1.5
   CMDB_URL: "https://cluster-01.qubership.org" # cloud passport: cluster-01 version: 1.5
-  CONSUL_ENABLED: "true" # cloud passport: cluster-01 version: 1.5
+  CONSUL_ENABLED: true # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_ADMIN_LOGIN: "admin" # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_ADMIN_PASSWORD: "password" # cloud passport: cluster-01 version: 1.5
   DEFAULT_TENANT_NAME: "tenant" # cloud passport: cluster-01 version: 1.5


### PR DESCRIPTION
# Pull Request

## Summary

Issue: Though CONSUL_ENABLED is given as true (boolean) in cloud passport, the final effective set had the value as string.
Root cause: While processing passport and wrting values into cloud.yml file, along with setting consul.enabled to true, CONSUL_ENABLED flag parameter gets added to deployParameter section also and this parameter was getting written as string.
This change ensures it is added as a boolean, as defined in the passport.

## Issue

no git hub issue

## Breaking Change?

- [ ] Yes
- [X] No

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

Modify data type for consul_enabled in cloud's deployparameter section.

## Tests / Evidence

Existing test cases are updated

## Additional Notes

Include any extra information, such as:
