### PR TITLE
fix: ssl verification failing

### DIFF
--- a/build_pipegene/scripts/pipeline_helper.py
+++ b/build_pipegene/scripts/pipeline_helper.py
@@ -47,6 +47,7 @@ def job_instance(params, vars, needs=None, rules=None):
     global_before = [
         'python /module/scripts/utils/log_pipe_params.py',
         '/module/scripts/utils/handle_certs.sh',
+        'source ~/.bashrc',
     ]
     job.prepend_scripts(*global_before)
 

--- a/scripts/utils/update_ca_cert.sh
+++ b/scripts/utils/update_ca_cert.sh
@@ -40,7 +40,8 @@ function debugPrintCertsFromFile {
     fi
     local cert_num=0
     local block=""
-    while IFS= read -r line; do
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      line="${line%$'\r'}"
       if [[ "$line" == "-----BEGIN CERTIFICATE-----" ]]; then
         block="$line"
         continue
@@ -50,7 +51,7 @@ function debugPrintCertsFromFile {
         if [[ "$line" == "-----END CERTIFICATE-----" ]]; then
           cert_num=$((cert_num + 1))
           echo "[DEBUG] --- Certificate #${cert_num} in ${file} ---"
-          echo "$block" | openssl x509 -noout -subject -issuer -dates 2>/dev/null || echo "[DEBUG] (openssl could not decode this block)"
+          printf "%s\n" "$block" | openssl x509 -noout -subject -issuer -dates 2>/dev/null || echo "[DEBUG] (openssl could not decode this block)"
           block=""
         fi
       fi


### PR DESCRIPTION
# Pull Request

Envgene instance pipeline failed with SSL Cert Error after upgrade from v2.31.6 to v2.91.7
The issue was that REQUEST_CA_BUNDLE was ending up empty because the certificate handling script (handle_certs.sh, which calls update_ca_certs.sh) was being executed in a subshell. As a result, although the script correctly bundled and set the REQUEST_CA_BUNDLE variable, the value was not preserved once the subshell exited, leaving the parent environment without the variable. 

Fixed misleading OpenSSL debug errors (e.g., “NO PEM block found”) caused by improper certificate parsing. The issue was due to skipping the last line without a newline, handling of Windows-style \r\n line endings, and use of echo which could alter formatting. This is resolved by ensuring the last line is read (read ... || [[ -n "$line" ]]), stripping trailing \r, and using printf to preserve exact PEM formatting.

## Issue
To fix this, source ~/.bashrc was added to the execution sequence so that the environment variables are reloaded into the current shell context. This ensures that REQUEST_CA_BUNDLE is available after the script execution, effectively resolving the issue.

Link to the issue(s) this PR addresses (e.g., `Fixes #123` or `Closes #456`). If no issue exists, explain why this change is necessary.

## Breaking Change?

- [ ] Yes
- [X] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

Provide details on how the change was implemented, including any technical considerations, trade-offs, or notable design decisions. Leave blank if not applicable.

## Tests / Evidence

Tested using instance pipeline

## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
