### PR TITLE
fix: Disable YAML anchors on excessive aliasing

### DIFF
--- a/build_effective_set_generator/effective-set-generator/pom.xml
+++ b/build_effective_set_generator/effective-set-generator/pom.xml
@@ -46,6 +46,11 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.3</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-picocli</artifactId>
         </dependency>

--- a/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/repository/implementation/FileDataConverterImpl.java
+++ b/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/repository/implementation/FileDataConverterImpl.java
@@ -34,13 +34,14 @@ import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.representer.Representer;
+import org.qubership.cloud.devops.cli.utils.yaml.AdaptiveYaml;
 
 import java.io.*;
 import java.util.Base64;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static org.qubership.cloud.devops.commons.utils.ConsoleLogger.logError;
+import static org.qubership.cloud.devops.commons.utils.ConsoleLogger.*;
 
 
 @ApplicationScoped
@@ -96,9 +97,16 @@ public class FileDataConverterImpl implements FileDataConverter {
     @Override
     public void writeToFile(Map<String, Object> params, String... args) throws IOException {
         File file = fileSystemUtils.getFileFromGivenPath(args);
+
+        boolean expand = params != null && !params.isEmpty()
+                && AdaptiveYaml.shouldExpand(params);
+        if (expand) {
+            logInfo("removing anchors and aliases for file: " + file.getAbsolutePath());
+        }
+
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
             if (params != null && !params.isEmpty()) {
-                getYamlObject().dump(params, writer);
+                getYamlObject(expand).dump(params, writer);
             }
         }
     }
@@ -112,11 +120,14 @@ public class FileDataConverterImpl implements FileDataConverter {
     }
 
 
-    private static Yaml getYamlObject() {
+    private static Yaml getYamlObject(boolean expand) {
         DumperOptions options = new DumperOptions();
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         options.setDefaultScalarStyle(DumperOptions.ScalarStyle.PLAIN);
         options.setPrettyFlow(false);
+        if (expand) {            
+            options.setDereferenceAliases(true);
+        }
         Representer representer = new Representer(options) {
             @Override
             protected Node representScalar(Tag tag, String value, DumperOptions.ScalarStyle style) {

--- a/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/utils/yaml/AdaptiveYaml.java
+++ b/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/utils/yaml/AdaptiveYaml.java
@@ -1,0 +1,98 @@
+package org.qubership.cloud.devops.cli.utils.yaml;
+
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AdaptiveYaml {
+    private static final int ALIAS_RATIO_RANGE_LOW = 400000;
+    private static final int ALIAS_RATIO_RANGE_HIGH = 4000000;
+    private static final double ALIAS_RATIO_RANGE =
+            (double) (ALIAS_RATIO_RANGE_HIGH - ALIAS_RATIO_RANGE_LOW);
+
+    private static class Statistic {
+        int repeats = 0;
+        int complexity = 0;
+    }
+
+    private static class Decoder {
+        // For more code details, check https://github.com/go-yaml/yaml/blob/v3/decode.go
+        
+        private final IdentityHashMap<Object, Statistic> unique = new IdentityHashMap<>();
+        private int decodeCount = 0;
+        private int aliasCount = 0;
+
+        public int unmarshal(Object node) {
+            if (!(node instanceof Map || node instanceof List)) {
+                decodeCount++;
+                return 1;
+            }
+
+
+            if (unique.containsKey(node)) {                
+                return alias(node);
+            }
+
+            decodeCount++;
+            Statistic stat = new Statistic();
+            stat.complexity = 1;
+            unique.put(node, stat);
+
+            int childComplexity = 0;
+
+            if (node instanceof Map<?, ?> map) {
+                for (Map.Entry<?, ?> e : map.entrySet()) {                    
+                    childComplexity += unmarshal(e.getKey());
+                    childComplexity += unmarshal(e.getValue());
+                }
+            } else if (node instanceof List<?> list) {
+                for (Object item : list) {
+                    childComplexity += unmarshal(item);
+                }
+            }
+
+            stat.complexity += childComplexity;
+
+            if (isLimitExceeded(aliasCount, decodeCount, node)) {
+                throw new RuntimeException("Excessive aliasing");
+            }
+
+            return stat.complexity;
+        }
+
+        private int alias(Object node) {
+            Statistic stat = unique.get(node);
+            stat.repeats++;
+            decodeCount += stat.complexity;
+            aliasCount += stat.complexity;
+            return stat.complexity;
+        }
+
+        private boolean isLimitExceeded(int alias, int decode, Object node ) {
+            double rt = allowedAliasRatio(decode);
+            double ad = ((double) alias / decode);            
+
+            return alias > 100 &&
+                    decode > 1000 &&
+                    ((double) alias / decode) > allowedAliasRatio(decode);
+        }
+
+        private double allowedAliasRatio(int count) {
+            if (count <= ALIAS_RATIO_RANGE_LOW) return 0.99;
+            if (count >= ALIAS_RATIO_RANGE_HIGH) return 0.1;
+
+            return 0.99 - 0.89 * ((double)(count - ALIAS_RATIO_RANGE_LOW) / ALIAS_RATIO_RANGE);
+        }
+    }
+
+    public static boolean shouldExpand(Object data) {
+        Decoder decoder = new Decoder();
+        try {
+            decoder.unmarshal(data);
+        } catch (RuntimeException e) {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/utils/yaml/AdaptiveYaml.java
+++ b/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/utils/yaml/AdaptiveYaml.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.qubership.cloud.devops.cli.utils.yaml;
 
 import java.util.IdentityHashMap;

--- a/build_effective_set_generator/effective-set-generator/src/test/java/org/qubership/cloud/devops/cli/utils/yaml/AdaptiveYamlTest.java
+++ b/build_effective_set_generator/effective-set-generator/src/test/java/org/qubership/cloud/devops/cli/utils/yaml/AdaptiveYamlTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.qubership.cloud.devops.cli.utils.yaml;
 
 import org.junit.jupiter.api.Test;
@@ -17,9 +33,7 @@ public class AdaptiveYamlTest {
         root.put("a", Map.of("x", 1));
         root.put("b", Map.of("y", 2));
 
-        boolean result = AdaptiveYaml.shouldExpand(root);
-
-        assertFalse(result);
+        assertFalse(AdaptiveYaml.shouldExpand(root));
     }
 
     @Test
@@ -31,9 +45,7 @@ public class AdaptiveYamlTest {
         root.put("a", shared);
         root.put("b", shared);
 
-        boolean result = AdaptiveYaml.shouldExpand(root);
-
-        assertFalse(result);
+        assertFalse(AdaptiveYaml.shouldExpand(root));
     }
 
     @Test
@@ -47,8 +59,6 @@ public class AdaptiveYamlTest {
             list.add(shared);
         }
 
-        boolean result = AdaptiveYaml.shouldExpand(list);
-
-        assertTrue(result);
+        assertTrue(AdaptiveYaml.shouldExpand(list));
     }
 }

--- a/build_effective_set_generator/effective-set-generator/src/test/java/org/qubership/cloud/devops/cli/utils/yaml/AdaptiveYamlTest.java
+++ b/build_effective_set_generator/effective-set-generator/src/test/java/org/qubership/cloud/devops/cli/utils/yaml/AdaptiveYamlTest.java
@@ -1,0 +1,54 @@
+package org.qubership.cloud.devops.cli.utils.yaml;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AdaptiveYamlTest {
+    @Test
+    void testNoAliasing() {
+        Map<String, Object> root = new HashMap<>();
+        root.put("a", Map.of("x", 1));
+        root.put("b", Map.of("y", 2));
+
+        boolean result = AdaptiveYaml.shouldExpand(root);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testSimpleAlias() {
+        Map<String, Object> shared = new HashMap<>();
+        shared.put("x", 1);
+
+        Map<String, Object> root = new HashMap<>();
+        root.put("a", shared);
+        root.put("b", shared);
+
+        boolean result = AdaptiveYaml.shouldExpand(root);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testExcessiveAliasing() {
+        Map<String, Object> shared = new HashMap<>();
+        shared.put("x", 1);
+
+        List<Object> list = new ArrayList<>();
+
+        for (int i = 0; i < 2000; i++) {
+            list.add(shared);
+        }
+
+        boolean result = AdaptiveYaml.shouldExpand(list);
+
+        assertTrue(result);
+    }
+}

--- a/build_effective_set_generator/parameter-calculator-bom/pom.xml
+++ b/build_effective_set_generator/parameter-calculator-bom/pom.xml
@@ -55,7 +55,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>2.2</version>
+                <version>2.3</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jgit</groupId>


### PR DESCRIPTION
# Pull Request

## Summary

When a YAML file contains excessive aliases, effective set job gets passed, however, Helm fails during deployment with the error:
error converting YAML to JSON: yaml: document contains excessive aliasing
To prevent deployment failures, we now detect excessive aliasing in the YAML structure before serialization. If the alias threshold is exceeded, anchoring and aliasing are disabled to ensure Helm can successfully parse the generated YAML.

## Issue

Link to the issue(s) this PR addresses (e.g., `Fixes #123` or `Closes #456`). If no issue exists, explain why this change is necessary.

## Breaking Change?

- [ ] Yes
- [ X] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

Excessive aliasing is detected by traversing the YAML structure and computing alias-to-decode ratio. When the threshold is exceeded, anchors are disabled using setDereferenceAliases(true) to prevent Helm parsing failures.

Trade-off: larger YAML output due to duplication, but ensures reliable deployments. Logic is consistent with existing ACH handling and is safe for parallel execution..

## Tests / Evidence

Verified by running instance pipeline and ensured that for the deploy_descriptor.yml file where there are too many aliases, anchors and aliases are removed. 

## Additional Notes

Updated the snakeyaml version from 2.2 to 2.3 as 2.2 does not contain feature to remove anchors. 
