### PR TITLE
fix: the double slash issue

### DIFF
--- a/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/utils/BomCommonUtils.java
+++ b/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/utils/BomCommonUtils.java
@@ -136,7 +136,9 @@ public class BomCommonUtils {
         serviceParams.put("TAG", dockerTag != null ? dockerTag : "");
         serviceParams.put("DOCKER_TAG", imageName != null ? imageName : "");
         serviceParams.put("BRANCH", gitBranch);
-        serviceParams.put("IMAGE_REPOSITORY", String.format("%s/%s/%s", registryConfigurationService.getDockerRepoForService(registrySummaryDTO), dockerRepo, imageName));
+        serviceParams.put("IMAGE_REPOSITORY", Stream.of(registryConfigurationService.getDockerRepoForService(registrySummaryDTO), dockerRepo, imageName)
+                .filter(s -> s != null && !s.isEmpty())
+                .collect(Collectors.joining("/")));
         if (isFacadeGateway) {
             serviceParams.put("OPENSHIFT_SERVICE_NAME", component.getName() + "v1");
             serviceParams.put("DEPLOYMENT_RESOURCE_NAME", component.getName() + "v1");


### PR DESCRIPTION

## Summary

Fix double slash // in Docker image path construction when `docker_repository_name` (namespace) is empty. The `IMAGE_REPOSITORY` value was built using `String.format("%s/%s/%s", registry, dockerRepo, imageName)` — if `dockerRepo` is empty this produces `registry//imageName` instead of `registry/imageName`.

The fix filters out null/empty path segments before joining with `/`.



The bug occurs for any service whose SD definition omits `docker_repository_name`, causing deployment failures or incorrect image resolution at runtime.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`build_effective_set_generator` — BomCommonUtils.java, processServiceComponent method, `IMAGE_REPOSITORY` construction.

## Implementation Notes

Replaced:
```java
String.format("%s/%s/%s", registryConfigurationService.getDockerRepoForService(registrySummaryDTO), dockerRepo, imageName)
```

With:
```java
Stream.of(registryConfigurationService.getDockerRepoForService(registrySummaryDTO), dockerRepo, imageName)
    .filter(s -> s != null && !s.isEmpty())
    .collect(Collectors.joining("/"))
```

Minimal, targeted change — no logic restructuring. The stream approach is idiomatic Java and handles all combinations of null/empty parts correctly without special-casing.

## Additional Notes

- Companion fix for the Python SBOM generator set_full_image_name in models.py is in the corresponding `env-generator` MR
- No new dependencies introduced
- No schema or API changes
```