### PR TITLE
docs(agents): codify markdown formatting and prose style rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,31 @@ EnvGene searches these locations - from bottom to top - and uses the first match
 
 ---
 
+#### Semicolons
+
+**Avoid semicolons in prose. Split into separate sentences instead.**
+
+❌ **AVOID:**
+
+```markdown
+Native callouts render with icons; bold-text variants are plain blockquotes.
+```
+
+✅ **PREFER:**
+
+```markdown
+Native callouts render with icons. Bold-text variants are plain blockquotes.
+```
+
+**Scope:** Applies to **new and modified content only**. Existing content using semicolons is
+not affected by this rule and does not need rewriting unless the surrounding lines are being
+edited for other reasons.
+
+**Why:** Two short sentences read more naturally on screen than one compound sentence linked by
+a semicolon. Also reduces AI-stylized rhythm in generated text.
+
+---
+
 #### Callouts (Notes, Warnings, Tips)
 
 **CRITICAL: Always use GitHub-flavored Markdown native callout syntax, not bold-text workarounds.**
@@ -128,7 +153,8 @@ Available types: `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`.
 > Setting `mergeEnvSpecificResourceProfiles: false` replaces the template override entirely.
 ```
 
-**Why:** Native callouts render with icons and colour highlighting on GitHub and other renderers; bold-text variants are plain blockquotes.
+**Why:** Native callouts render with icons and colour highlighting on GitHub and other renderers.
+Bold-text variants are plain blockquotes.
 
 ---
 
@@ -248,6 +274,29 @@ column width for vertical alignment.
 
 ---
 
+#### Avoid AI-Stylistics
+
+**Documentation is written for humans, not stylized like AI output.**
+
+Common AI-stylistics to avoid:
+
+- Em dashes (`—`) and en dashes (`–`). See [Dashes](#dashes).
+- Semicolons. See [Semicolons](#semicolons).
+- Filler intensifiers: `simply`, `just`, `easily`, `truly`, `incredibly`, `seamlessly`,
+  `robust`, `comprehensive`, `cutting-edge`, `leverage`, `delve`, `tapestry`, `landscape`.
+- Throat-clearing openings: `It's worth noting that...`, `It's important to remember...`,
+  `Let's explore...`, `In this section, we'll discuss...`.
+- `Not only X, but also Y` and `Not just X, but Y` patterns.
+- Empty closings: `In conclusion`, `To summarize`, `As we've seen`.
+
+**Scope:** Applies to **new and modified content only**.
+
+**Why:** AI-generated text leans on these patterns heavily. Their absence makes documentation
+feel more direct and trustworthy. Read sentences aloud. If it sounds like a press release or a
+chatbot, rewrite.
+
+---
+
 ## Object Examples in Documentation
 
 ### Source of Truth for Object Schemas
@@ -262,7 +311,9 @@ The two authoritative sources are:
 #### Rules
 
 1. **Before writing any YAML/JSON example** for an EnvGene object, read the corresponding entry in `docs/envgene-objects.md` AND the matching schema file under `schemas/`.
-2. **Validate every example against the schema**: all fields marked `"required"` in the schema must be present; no fields may be included that do not exist in the schema (unless `additionalProperties: true`).
+2. **Validate every example against the schema**: all fields marked `"required"` in the schema
+   must be present. No fields may be included that do not exist in the schema (unless
+   `additionalProperties: true`).
 3. **Do not guess**: if an object is not described in `docs/envgene-objects.md` and has no schema file, write explicitly:
 
    > No schema or description found for this object in `docs/envgene-objects.md` or `schemas/`. Cannot provide a validated example.
@@ -275,7 +326,7 @@ The two authoritative sources are:
 In tutorials and how-to guides, show only the **relevant part** of the object, not the full structure. Use `# ...` comments to signal omitted fields so the reader knows the snippet is intentionally incomplete.
 
 - **Reference docs** → show the full object.
-- **Tutorials / how-to guides** → show only the fields being explained; collapse the rest with `# ...`.
+- **Tutorials / how-to guides** → show only the fields being explained. Collapse the rest with `# ...`.
 
 This keeps examples focused on the concept being taught and avoids becoming outdated when unrelated fields change.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,25 @@ Available types: `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`.
 
 ---
 
+#### Line Length
+
+**Prose lines wrap at 120 characters.**
+
+Excluded from this limit:
+
+- Table rows (lines starting with `|`)
+- Code blocks (fenced)
+- URLs and other continuous tokens longer than 120 characters
+
+**Scope:** Applies to **new and modified content only**. Existing content that exceeds 120 characters
+is not affected by this rule and does not need reformatting unless the surrounding lines are being
+edited for other reasons.
+
+**Why:** Long prose lines complicate diff review and side-by-side comparison. 120 leaves room for
+meaningful wrap without forcing tight columns.
+
+---
+
 #### Tables
 
 **CRITICAL: All Markdown tables MUST have vertically aligned pipe characters (`|`).**
@@ -204,6 +223,27 @@ Available types: `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`.
 | `/environments/<cluster>/<env>/Inventory/parameters/` | Environment-specific | One environment only            |
 | `/environments/<cluster>/parameters/`                 | Cluster-wide         | All environments in cluster     |
 | `/environments/parameters/`                           | Global               | Multiple clusters               |
+```
+
+##### Delimiter Row Style
+
+The delimiter row uses `|---|` form - no spaces between `|` and `-`. Dashes are padded to match
+column width for vertical alignment.
+
+❌ **INCORRECT:**
+
+```markdown
+| Field    | Required |
+| -------- | -------- |
+| `name`   | yes      |
+```
+
+✅ **CORRECT:**
+
+```markdown
+| Field    | Required |
+|----------|----------|
+| `name`   | yes      |
 ```
 
 ---


### PR DESCRIPTION
## Summary

Four markdown / prose style rules added to AGENTS.md:

1. **Table delimiter row style** - `|---|` form (no spaces around dashes). Already practiced across the docs but never written down.
2. **Line length** - 120 characters for prose, scoped to new and modified content only.
3. **Semicolons** - avoid in prose, split into separate sentences. Scoped to new and modified content only.
4. **Avoid AI-stylistics** - meta-section listing common AI-generated patterns to avoid (filler intensifiers, throat-clearing openings, "not only X but also Y" patterns, empty closings).

Plus 3 prose lines in AGENTS.md itself rewritten to comply with the new Semicolons rule, and 2 long lines wrapped to comply with the new Line Length rule.

## Scope

- AGENTS.md only
- No changes to other docs
- No tooling changes
- All new rules are scoped to new/modified content; existing docs are not affected

## Test plan

- [x] No em/en dashes in new prose (verified)
- [x] No semicolons in new prose outside anti-pattern examples (verified)
- [x] No lines over 120 chars in additions (verified)
- [ ] Reviewer confirms wording is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)