### PR TITLE
docs: flatten envgenenullvalue tutorial structure

### DIFF
--- a/docs/tutorials/envgene-null-value.md
+++ b/docs/tutorials/envgene-null-value.md
@@ -5,13 +5,12 @@
   - [Prerequisites](#prerequisites)
   - [Overview](#overview)
   - [Where validation happens](#where-validation-happens)
-  - [Scenario 1: Mandatory parameters in templates](#scenario-1-mandatory-parameters-in-templates)
-    - [Problem (mandatory parameters)](#problem-mandatory-parameters)
+  - [Mandatory parameters in templates](#mandatory-parameters-in-templates)
+    - [Problem](#problem)
     - [Example in template (ParameterSet)](#example-in-template-parameterset)
     - [How to resolve](#how-to-resolve)
     - [Key point](#key-point)
-  - [Scenario 2: Credentials placeholder](#scenario-2-credentials-placeholder)
-    - [Problem (credentials)](#problem-credentials)
+  - [Credentials placeholder](#credentials-placeholder)
   - [Credential type 1: usernamePassword](#credential-type-1-usernamepassword)
     - [Generated `credentials.yml` (username/password)](#generated-credentialsyml-usernamepassword)
   - [Credential type 2: secret](#credential-type-2-secret)
@@ -98,9 +97,9 @@ At each stage the same two scopes are checked, and both stages emit identical lo
 
 A failure at either stage aborts the pipeline until the placeholders are replaced with real values.
 
-## Scenario 1: Mandatory parameters in templates
+## Mandatory parameters in templates
 
-### Problem (mandatory parameters)
+### Problem
 
 Some template values cannot be decided at template-authoring time because they depend on the
 target environment. To make the requirement explicit, templates set such parameters to
@@ -141,9 +140,7 @@ file locations, lookup order, and merge behavior, see
 - Environments supply environment-specific values
 - Missing values are explicitly detected and rejected
 
-## Scenario 2: Credentials placeholder
-
-### Problem (credentials)
+## Credentials placeholder
 
 When EnvGene generates a `credentials.yml` file (for example from Cloud Passport),
 it may not have access to actual secret values.


### PR DESCRIPTION
## Summary

Follow-up to #1185. Resolves a pre-existing structural asymmetry in `docs/tutorials/envgene-null-value.md` that #1185 inherited and did not address.

Before:

- `## Scenario 1: Mandatory parameters in templates` correctly grouped its 4 H3 children.
- `## Scenario 2: Credentials placeholder` was a bare wrapper with no body and only one H3 child (`### Problem (credentials)`); the rest of the credentials content (`## Credential type 1: usernamePassword`, `## Credential type 2: secret`, `## How to resolve credentials`, etc.) sat as H2 siblings outside the wrapper.

After:

- `Scenario 1: Mandatory parameters in templates` renames to `Mandatory parameters in templates` (still groups its 4 H3 children).
- `Scenario 2: Credentials placeholder` H2 is removed; the body of the `Problem (credentials)` H3 is promoted to be the body of a new `Credentials placeholder` H2 directly.
- `Problem (mandatory parameters)` renames to `Problem` (parent H2 already provides the context).

TOC and internal anchors are updated. No body cross-references to the removed/renamed anchors exist.

## Why

The wrapper-then-flat asymmetry made the structure unclear when reading the rendered ToC. Removing the redundant Scenario 2 wrapper and renaming for clarity gives an honest flat structure that matches the file's content.

## Test plan

- [ ] Rendered ToC matches body headings
- [ ] No 404s on internal anchors
- [ ] Reading flow is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)