### PR TITLE
docs: align use-cases README with sentence case heading policy

### DIFF
--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -198,7 +198,7 @@ Use format: `UC-<PREFIX>-<GROUP>-<NUMBER>: <Descriptive Title>`
 
 - **Title**: Concise, descriptive title
   - Should clearly indicate what the use case demonstrates
-  - Use title case
+  - Use sentence case (see [Heading case](/AGENTS.md#heading-case))
 
 ### Numbering Rules
 


### PR DESCRIPTION
## Summary

Follow-up to #1318 (Heading case policy). Resolves the contradicting guidance in `docs/use-cases/README.md` that survived #1318's "AGENTS.md-only" scope.

Before:

```markdown
- **Title**: Concise, descriptive title
  - Should clearly indicate what the use case demonstrates
  - Use title case
```

After:

```markdown
- **Title**: Concise, descriptive title
  - Should clearly indicate what the use case demonstrates
  - Use sentence case (see [Heading case](/AGENTS.md#heading-case))
```

## Why

#1318 codified sentence case as the heading style for all repository Markdown (new and modified content). The use-cases README contained forward-looking guidance "Use title case" for UC titles - a direct conflict. UC authors reading the README would receive misaligned guidance.

## Scope

- One line in `docs/use-cases/README.md`.
- Existing UC titles in Title Case are not migrated. Per #1318 scope, migration happens organically as UCs are edited.

## Test plan

- [ ] Wording reads correctly in context
- [ ] Anchor `/AGENTS.md#heading-case` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)