### PR TITLE
fix: composite schema validaion

### DIFF
--- a/scripts/build_env/env_template/set_template_version.py
+++ b/scripts/build_env/env_template/set_template_version.py
@@ -21,7 +21,7 @@ def update_version(env_definition_dir, version_to_add, update_mode: TemplateVers
                 del data['envTemplate']['templateArtifact']
             data['envTemplate']['artifact'] = version_to_add
         else:
-            logger.error(f"Bad env_definition structure in file {env_definition_path}.")
+            logger.error(f"Invalid ENV_TEMPLATE_VERSION '{version_to_add}': missing or incorrect envTemplate.artifact structure in {env_definition_path}.")
             raise ReferenceError(f"Can't update version in {env_definition_path}. See logs above.")
     else:
         if 'envTemplate' in data and 'templateArtifact' in data['envTemplate'] and 'artifact' in data['envTemplate'][
@@ -32,7 +32,7 @@ def update_version(env_definition_dir, version_to_add, update_mode: TemplateVers
             data['envTemplate']['templateArtifact']['artifact']['version'] = version_to_add
             logger.info(f"Succesfully updated version from {oldVersion} to {version_to_add} in {env_definition_path}")
         else:
-            logger.error(f"Bad env_definition structure in file {env_definition_path}.")
+            logger.error(f"Invalid ENV_TEMPLATE_VERSION: version-only input expects 'envTemplate.templateArtifact.artifact' structure, but it is not present {env_definition_path}.")
             raise ReferenceError(f"Can't update version in {env_definition_path}. See logs above.")
     writeYamlToFile(env_definition_path, data)
     beautifyYaml(env_definition_path)

--- a/scripts/build_env/env_template/set_template_version.py
+++ b/scripts/build_env/env_template/set_template_version.py
@@ -21,7 +21,7 @@ def update_version(env_definition_dir, version_to_add, update_mode: TemplateVers
                 del data['envTemplate']['templateArtifact']
             data['envTemplate']['artifact'] = version_to_add
         else:
-            logger.error(f"Invalid ENV_TEMPLATE_VERSION '{version_to_add}': missing or incorrect envTemplate.artifact structure in {env_definition_path}.")
+            logger.error(f"Bad env_definition structure in file {env_definition_path}.")
             raise ReferenceError(f"Can't update version in {env_definition_path}. See logs above.")
     else:
         if 'envTemplate' in data and 'templateArtifact' in data['envTemplate'] and 'artifact' in data['envTemplate'][
@@ -32,7 +32,7 @@ def update_version(env_definition_dir, version_to_add, update_mode: TemplateVers
             data['envTemplate']['templateArtifact']['artifact']['version'] = version_to_add
             logger.info(f"Succesfully updated version from {oldVersion} to {version_to_add} in {env_definition_path}")
         else:
-            logger.error(f"Invalid ENV_TEMPLATE_VERSION: version-only input expects 'envTemplate.templateArtifact.artifact' structure, but it is not present {env_definition_path}.")
+            logger.error(f"Bad env_definition structure in file {env_definition_path}.")
             raise ReferenceError(f"Can't update version in {env_definition_path}. See logs above.")
     writeYamlToFile(env_definition_path, data)
     beautifyYaml(env_definition_path)

--- a/scripts/build_env/render_config_env.py
+++ b/scripts/build_env/render_config_env.py
@@ -334,7 +334,6 @@ class EnvGenerator:
             self.render_from_obj_to_file(template_override, template_path)
 
     def generate_cloud_file(self):
-
         cloud = self.calculate_cloud_name()
         cloud_template = self.ctx.current_env_template["cloud"]
         current_env_dir = self.ctx.current_env_dir
@@ -406,14 +405,13 @@ class EnvGenerator:
             inv.get("cloudName"),
             inv.get("passportCloudName", "").replace("-", "_") if inv.get("passportCloudName") else "",
             inv.get("cloudPassport", "").replace("-", "_") if inv.get("cloudPassport") else "",
-            # cluster_name.replace("-", "_") if cluster_name else "",
             inv.get("environmentName", "").replace("-", "_"),
             f"{cluster_name}_{inv.get('environmentName', '')}".replace("-", "_")
             if cluster_name and inv.get("environmentName") else ""
         ]
-    
+
         return next((c for c in candidates if c), "")
-      
+
     def get_template_name(self, template_path: str) -> str:
         template_path = Path(template_path)
         return (
@@ -599,10 +597,8 @@ class EnvGenerator:
             self.setup_base_context(extra_env)
             all_vars = self.ctx.env_vars
             current_env = self.ctx.current_env
-          
 
             self.ctx.cloud = self.calculate_cloud_name()
-        
             self.ctx.tenant = current_env.get("tenant", '')
             self.ctx.deployer = current_env.get('deployer', '')
             self.ctx.bgd = current_env.get('bg_domain', '')

--- a/scripts/build_env/render_config_env.py
+++ b/scripts/build_env/render_config_env.py
@@ -334,6 +334,7 @@ class EnvGenerator:
             self.render_from_obj_to_file(template_override, template_path)
 
     def generate_cloud_file(self):
+
         cloud = self.calculate_cloud_name()
         cloud_template = self.ctx.current_env_template["cloud"]
         current_env_dir = self.ctx.current_env_dir
@@ -405,13 +406,14 @@ class EnvGenerator:
             inv.get("cloudName"),
             inv.get("passportCloudName", "").replace("-", "_") if inv.get("passportCloudName") else "",
             inv.get("cloudPassport", "").replace("-", "_") if inv.get("cloudPassport") else "",
+            # cluster_name.replace("-", "_") if cluster_name else "",
             inv.get("environmentName", "").replace("-", "_"),
             f"{cluster_name}_{inv.get('environmentName', '')}".replace("-", "_")
             if cluster_name and inv.get("environmentName") else ""
         ]
-
+    
         return next((c for c in candidates if c), "")
-
+      
     def get_template_name(self, template_path: str) -> str:
         template_path = Path(template_path)
         return (
@@ -597,8 +599,10 @@ class EnvGenerator:
             self.setup_base_context(extra_env)
             all_vars = self.ctx.env_vars
             current_env = self.ctx.current_env
+          
 
             self.ctx.cloud = self.calculate_cloud_name()
+        
             self.ctx.tenant = current_env.get("tenant", '')
             self.ctx.deployer = current_env.get('deployer', '')
             self.ctx.bgd = current_env.get('bg_domain', '')

--- a/scripts/build_env/render_config_env.py
+++ b/scripts/build_env/render_config_env.py
@@ -16,7 +16,7 @@ from jinja.replace_ansible_stuff import replace_ansible_stuff, escaping_quotatio
 SCHEMAS_DIR = Path(__file__).resolve().parents[2] / "schemas"
 APPDEF_SCHEMA = str(SCHEMAS_DIR / "appdef.schema.json")
 TD_SCHEMA = str(SCHEMAS_DIR / "template-descriptor.schema.json")
-Composite_SCHEMA = str(SCHEMAS_DIR / "composite-structure.schema.json")
+COMPOSITE_SCHEMA = str(SCHEMAS_DIR / "composite-structure.schema.json")
 
 yml = create_yaml_processor()
 
@@ -428,7 +428,7 @@ class EnvGenerator:
             cs_file = Path(current_env_dir) / "composite_structure.yml"
             cs_file.parent.mkdir(parents=True, exist_ok=True)
             self.render_from_file_to_file(Template(composite_structure).render(self.ctx.as_dict()), str(cs_file))
-            validate_yaml_by_scheme_or_fail(cs_file, Composite_SCHEMA)
+            validate_yaml_by_scheme_or_fail(cs_file, COMPOSITE_SCHEMA)
 
     def get_rendered_target_path(self, template_path: Path) -> Path:
         path_str = str(template_path)

--- a/scripts/build_env/render_config_env.py
+++ b/scripts/build_env/render_config_env.py
@@ -16,6 +16,7 @@ from jinja.replace_ansible_stuff import replace_ansible_stuff, escaping_quotatio
 SCHEMAS_DIR = Path(__file__).resolve().parents[2] / "schemas"
 APPDEF_SCHEMA = str(SCHEMAS_DIR / "appdef.schema.json")
 TD_SCHEMA = str(SCHEMAS_DIR / "template-descriptor.schema.json")
+Composite_SCHEMA = str(SCHEMAS_DIR / "composite-structure.schema.json")
 
 yml = create_yaml_processor()
 
@@ -427,6 +428,7 @@ class EnvGenerator:
             cs_file = Path(current_env_dir) / "composite_structure.yml"
             cs_file.parent.mkdir(parents=True, exist_ok=True)
             self.render_from_file_to_file(Template(composite_structure).render(self.ctx.as_dict()), str(cs_file))
+            validate_yaml_by_scheme_or_fail(cs_file, Composite_SCHEMA)
 
     def get_rendered_target_path(self, template_path: Path) -> Path:
         path_str = str(template_path)


### PR DESCRIPTION
# Pull Request

## Summary

Fixed missing JSON schema validation for composite structure generation by adding schema validation inside the generate_composite_structure() method in render_config_env.py. Previously, composite structure files were rendered without validation, allowing invalid configurations to pass through the pipeline. The fix ensures rendered composite structure files are validated against the composite structure schema immediately after generation.
Also identified and schema inconsistencies between opensource and internal schemas where internal has the version and id were  as required fields and changed it according to qubership documentation.

## Issue

https://github.com/Netcracker/qubership-envgene/issues/168

## Breaking Change?

- [ ] Yes
- [x] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes
Added schema validation for composite structure
## Tests / Evidence
Tested using instance pipeline
job failed with invalid composite structure
## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
