### PR TITLE
docs: add AGENTS.md rules for heading renames and pre-flight markdownlint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,6 +337,54 @@ chatbot, rewrite.
 
 ---
 
+#### Heading renames and cross-links
+
+When renaming a Markdown heading, the GitHub-generated anchor (`#section-name`) also changes.
+Cross-links in other files that point to the old anchor become broken (CI link-checker fails).
+
+**Before pushing after a heading rename:**
+
+1. Grep the repository for references to the OLD anchor:
+
+   ```bash
+   grep -rnE "#old-anchor-name" --include='*.md' .
+   ```
+
+2. Update each matching cross-link to the NEW anchor in all affected files.
+
+3. Update the link text in `[text](#anchor)` to match the new heading text where appropriate.
+
+For a broader audit of all cross-links in the repo:
+
+```bash
+grep -rhoE '\]\([^)]+#[^)]+\)' --include='*.md' . | sort -u
+```
+
+**Why:** A heading rename inside one file silently breaks references in unrelated files. The
+CI link-checker (lychee) catches this only after push.
+
+---
+
+#### Pre-flight markdownlint check
+
+Before declaring documentation changes done, run markdownlint with the project's config:
+
+```bash
+npx --yes markdownlint-cli@latest --config .github/linters/.markdown-lint.yml <changed-files>
+```
+
+The project config (`.github/linters/.markdown-lint.yml`) relaxes `MD013` line length to 1000,
+and disables `MD012`, `MD033`, `MD051`. Running markdownlint without `--config` uses the
+default settings (line length 80) which produces many false positives unrelated to the project
+rules and may hide real issues like `MD009` (trailing spaces) or `MD040` (fenced block missing
+language).
+
+**Why:** The CI super-linter runs markdownlint with the project config. Running locally with
+the same config gives a true preview of the CI result, catches real issues, and avoids
+distraction from false positives.
+
+---
+
 ## Object Examples in Documentation
 
 ### Source of Truth for Object Schemas


### PR DESCRIPTION
## Summary

Adds two new rules under `AGENTS.md > Documentation Standards`, prompted by a CI link-checker failure where a heading rename in `features/app-reg-defs.md` broke cross-links in `envgene-pipelines.md` (caught only after push).

- **Heading renames and cross-links** - when renaming a heading, the GitHub anchor changes; grep for the old anchor repo-wide and update all cross-links before pushing.
- **Pre-flight markdownlint check** - run with the project config (`.github/linters/.markdown-lint.yml`) to mirror the CI super-linter result and avoid false positives from default settings (line length 80 vs the project's 1000).

## Test plan

- [x] Lint AGENTS.md with project config: clean
- [x] Two new sections placed in `Documentation Standards > Markdown Formatting Rules` after `Avoid AI-Stylistics`
- [x] No existing rules removed or reworded
- [ ] CI lint passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)