### PR TITLE
fix: added descriptive error message for update_version

### DIFF
--- a/scripts/build_env/env_template/set_template_version.py
+++ b/scripts/build_env/env_template/set_template_version.py
@@ -21,7 +21,7 @@ def update_version(env_definition_dir, version_to_add, update_mode: TemplateVers
                 del data['envTemplate']['templateArtifact']
             data['envTemplate']['artifact'] = version_to_add
         else:
-            logger.error(f"Bad env_definition structure in file {env_definition_path}.")
+            logger.error(f"envTemplate is missing in env definition file{env_definition_path}.")
             raise ReferenceError(f"Can't update version in {env_definition_path}. See logs above.")
     else:
         if 'envTemplate' in data and 'templateArtifact' in data['envTemplate'] and 'artifact' in data['envTemplate'][
@@ -32,7 +32,7 @@ def update_version(env_definition_dir, version_to_add, update_mode: TemplateVers
             data['envTemplate']['templateArtifact']['artifact']['version'] = version_to_add
             logger.info(f"Succesfully updated version from {oldVersion} to {version_to_add} in {env_definition_path}")
         else:
-            logger.error(f"Bad env_definition structure in file {env_definition_path}.")
+            logger.error(f"Invalid ENV_TEMPLATE_VERSION: version-only input expects 'envTemplate.templateArtifact.artifact' structure, but it is not present {env_definition_path}.")
             raise ReferenceError(f"Can't update version in {env_definition_path}. See logs above.")
     writeYamlToFile(env_definition_path, data)
     beautifyYaml(env_definition_path)


### PR DESCRIPTION
# Pull Request

## Summary

Improved confusing error handling in set_template_version.py when updating template versions using version-only input. Added a descriptive validation message explaining that version-only updates require the envTemplate.templateArtifact.artifact structure in env_definition.yml .Also identified and reported an unreachable error message scenario for the full template string flow, since envTemplate is already a mandatory field validated during the pipeline generation stage, meaning this message would never be triggered.

## Issue

when updating the template version if  format is not correct  the error message is Bad env_definition structure in file doesn't say anything if wrong ENV_TEMPLATE_VERSION is passed for exact type env definition

## Breaking Change?

- [ ] Yes
- [x] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

Provide details on how the change was implemented, including any technical considerations, trade-offs, or notable design decisions. Leave blank if not applicable.

## Tests / Evidence

Tested using instance pipeline

now displaying a descriptive message
## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.

