### PR TITLE
docs: fix system credentials file location paths

### DIFF
--- a/docs/envgene-objects.md
+++ b/docs/envgene-objects.md
@@ -604,7 +604,7 @@ consul-creds:
 
 This file contains [Credential](#credential) objects used by EnvGene to integrate with external systems like artifact registries, GitLab, GitHub, and others.
 
-**Location:** `/environments/configuration/credentials/credentials.yml|yaml`
+**Location:** `/configuration/credentials/credentials.yml|yaml`
 
 **Example:**
 
@@ -1586,7 +1586,7 @@ This file contains [Credential](#credential) objects used by EnvGene to integrat
 
 Location:
 
-- `/environments/configuration/credentials/credentials.yml|yaml`
+- `/configuration/credentials/credentials.yml|yaml`
 - `/environments/<cluster-name>/app-deployer/<any-string>-creds.yml|yaml`
 
 **Example:**


### PR DESCRIPTION
## Summary

Remove the erroneous `/environments/` prefix on the System Credentials File locations in `docs/envgene-objects.md`:

- `### System Credentials File (in Template repository)` location: `/environments/configuration/credentials/credentials.yml|yaml` -> `/configuration/credentials/credentials.yml|yaml`.
- `### System Credentials File (in Instance repository)` location (first entry): `/environments/configuration/credentials/credentials.yml|yaml` -> `/configuration/credentials/credentials.yml|yaml`.

The prefixed paths contradicted the inline schema comments throughout the same document that reference `/configuration/credentials/credentials.yml` (for example, in Artifact Definition v1.0/v2.0 and Registry Definition v1.0/v2.0 sections).

The per-cluster app-deployer credentials path `/environments/<cluster-name>/app-deployer/<any-string>-creds.yml|yaml` stays unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)