### PR TITLE
refactor: drop tools.components from SBOM schemas and examples

### DIFF
--- a/examples/application.sbom.json
+++ b/examples/application.sbom.json
@@ -29,15 +29,6 @@
           ]
         }
       ]
-    },
-    "tools": {
-      "components": [
-        {
-          "type": "application",
-          "name": "sbom_generator",
-          "version": "0.1.0"
-        }
-      ]
     }
   },
   "components": [

--- a/examples/env-template.sbom.json
+++ b/examples/env-template.sbom.json
@@ -23,15 +23,6 @@
           "purl": "pkg:maven/org.qubership.deploy/env-templates@8518ba0e_20241008-044612?registry_id=sandbox"
         }
       ]
-    },
-    "tools": {
-      "components": [
-        {
-          "type": "application",
-          "name": "sbom_generator",
-          "version": "0.1.0"
-        }
-      ]
     }
   },
   "components": [

--- a/schemas/application.sbom.schema.json
+++ b/schemas/application.sbom.schema.json
@@ -207,8 +207,7 @@
       "description": "Provides additional information about a BOM",
       "required": [
         "timestamp",
-        "component",
-        "tools"
+        "component"
       ],
       "additionalProperties": false,
       "properties": {
@@ -361,54 +360,6 @@
               "uniqueItems": true,
               "title": "Components",
               "description": "A list of software and hardware components included in the parent component. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains"
-            }
-          }
-        },
-        "tools": {
-          "type": "object",
-          "title": "Tools",
-          "description": "The tool(s) used in the creation, enrichment, and validation of the BOM",
-          "additionalProperties": false,
-          "properties": {
-            "components": {
-              "type": "array",
-              "title": "Components",
-              "description": "A list of software and hardware components used as tools",
-              "items": {
-                "type": "object",
-                "title": "Component",
-                "required": [
-                  "type",
-                  "name",
-                  "version"
-                ],
-                "additionalProperties": false,
-                "uniqueItems": true,
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "application"
-                    ],
-                    "title": "Component Type",
-                    "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component"
-                  },
-                  "name": {
-                    "type": "string",
-                    "title": "Component Name",
-                    "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
-                    "examples": [
-                      "tomcat-catalina"
-                    ]
-                  },
-                  "version": {
-                    "$ref": "#/$defs/version",
-                    "title": "Component Version",
-                    "description": "The component version. The version should ideally comply with semantic versioning but is not enforced"
-                  }
-                }
-              },
-              "uniqueItems": true
             }
           }
         }

--- a/schemas/env-template.sbom.schema.json
+++ b/schemas/env-template.sbom.schema.json
@@ -122,8 +122,7 @@
         "description": "Provides additional information about a BOM",
         "required": [
           "timestamp",
-          "component",
-          "tools"
+          "component"
         ],
         "additionalProperties": false,
         "properties": {
@@ -250,55 +249,6 @@
                 "uniqueItems": true,
                 "title": "Components",
                 "description": "A list of software and hardware components included in the parent component. This is not a dependency tree. It provides a way to specify a hierarchical representation of component assemblies, similar to system &#8594; subsystem &#8594; parts assembly in physical supply chains"
-              }
-            }
-          },
-          "tools": {
-            "type": "object",
-            "title": "Tools",
-            "description": "The tool(s) used in the creation, enrichment, and validation of the BOM.",
-            "additionalProperties": false,
-            "properties": {
-              "components": {
-                "type": "array",
-                "title": "Components",
-                "description": "A list of software and hardware components used as tools.",
-                "items": {
-                  "type": "object",
-                  "title": "Component",
-                  "required": [
-                    "type",
-                    "name",
-                    "version"
-                  ],
-                  "additionalProperties": false,
-                  "uniqueItems": true,
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "application"
-                      ],
-                      "title": "Component Type",
-                      "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component"
-                    },
-                    "name": {
-                      "type": "string",
-                      "title": "Component Name",
-                      "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
-                      "examples": [
-                        "tomcat-catalina"
-                      ]
-                    },
-                    "version": {
-                      "$ref": "#/definitions/version",
-                      "title": "Component Version",
-                      "description": "The component version. The version should ideally comply with semantic versioning but is not enforced"
-                    }
-                  }
-                },
-                "uniqueItems": true
-
               }
             }
           }


### PR DESCRIPTION
The SBOM `metadata.tools.components[]` only ever carried a constant `sbom_generator` name plus its version. Once the spec drops the version field (see paired docs change), the `name` becomes pure constant noise. Drop the whole `tools` block from both schemas and examples so the contract matches the spec.

# Pull Request

## Summary

Provide a concise description of what this pull request does and why it is needed.

## Issue

Link to the issue(s) this PR addresses (e.g., `Fixes #123` or `Closes #456`). If no issue exists, explain why this change is necessary.

## Breaking Change?

- [ ] Yes
- [ ] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

Provide details on how the change was implemented, including any technical considerations, trade-offs, or notable design decisions. Leave blank if not applicable.

## Tests / Evidence

Describe how the changes were verified, including:

- Tests added or updated (e.g., unit, integration, end-to-end)
- Manual testing steps or results
- Screenshots, logs, or other evidence (if applicable)

## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
