### PR TITLE
docs: align SBOM retention docs with bugfix/align_retention_with_doc

### DIFF
--- a/docs/envgene-configs.md
+++ b/docs/envgene-configs.md
@@ -252,15 +252,17 @@ app_reg_defs_placement: enum [`dual`, `root`]
 # Optional
 # SBOM retention configuration
 # Runs during Effective Set generation when enabled
-# Applies per-application version retention to subdirectories of `/sboms/`
-# A safety net wipes `/sboms/` if its total size still exceeds 1200 MB after per-application retention
+# Applies per-application SBOM retention to subdirectories of `/sboms/` when `keep_versions_per_app` is set
+# A safety net keeps only the single most recent file per application subdirectory if the total size
+# of `/sboms/` still exceeds 600 MB after per-application SBOM retention
 sbom_retention:
   # Optional. Default value - `false`
   # Enable/disable SBOM retention cleanup
   enabled: boolean
-  # Optional. Default value - `10`
-  # Number of latest versions to keep per application
-  # Used only when enabled is true
+  # Optional. No default value
+  # Number of latest versions to keep per application. Used only when `enabled` is true
+  # When unset or `0`, per-application SBOM retention is skipped and only the total size
+  # safety net runs
   keep_versions_per_app: integer
 # Optional. Default value - `true`
 # Enable or disable partial Effective Set generation in `generate_effective_set`

--- a/docs/envgene-configs.md
+++ b/docs/envgene-configs.md
@@ -253,16 +253,18 @@ app_reg_defs_placement: enum [`dual`, `root`]
 # SBOM retention configuration
 # Runs during Effective Set generation when enabled
 # Applies per-application SBOM retention to subdirectories of `/sboms/` when `keep_versions_per_app` is set
-# A safety net keeps only the single most recent file per application subdirectory if the total size
-# of `/sboms/` still exceeds 600 MB after per-application SBOM retention
+# A total size limit step keeps only the single most recent file per application subdirectory
+# if the total size of `/sboms/` still exceeds 600 MB after per-application SBOM retention
 sbom_retention:
   # Optional. Default value - `false`
   # Enable/disable SBOM retention cleanup
   enabled: boolean
   # Optional. No default value
   # Number of latest versions to keep per application. Used only when `enabled` is true
-  # When unset or `0`, per-application SBOM retention is skipped and only the total size
-  # safety net runs
+  # Per-application SBOM retention runs only when this is set to a positive integer.
+  # If the field is omitted or set to `0`, this step is skipped and only the total size
+  # limit step runs (keeping the most recent file per application subdirectory when /sboms/
+  # exceeds 600 MB)
   keep_versions_per_app: integer
 # Optional. Default value - `true`
 # Enable or disable partial Effective Set generation in `generate_effective_set`

--- a/docs/features/sbom-retention.md
+++ b/docs/features/sbom-retention.md
@@ -7,7 +7,7 @@
   - [When cleanup is triggered](#when-cleanup-is-triggered)
   - [Retention strategy](#retention-strategy)
     - [Per-application version retention](#per-application-version-retention)
-    - [Total size safety net](#total-size-safety-net)
+    - [Total size limit](#total-size-limit)
   - [Configuration](#configuration)
     - [Parameters](#parameters)
     - [Examples](#examples)
@@ -35,7 +35,7 @@ Automatic SBOM retention policy that:
 - Is activated by `sbom_retention.enabled: true`
 - Applies [per-application version retention](#per-application-version-retention) to each
   subdirectory under `/sboms/`, when `keep_versions_per_app` is set
-- Falls back to a [total size safety net](#total-size-safety-net) that keeps only the single most
+- Falls back to a [total size limit](#total-size-limit) step that keeps only the single most
   recently modified file in each per-application subdirectory if the total size of `/sboms/`
   still exceeds 600 MB after per-application SBOM retention
 
@@ -46,9 +46,8 @@ Cleanup runs when both of the following conditions are true:
 1. `GENERATE_EFFECTIVE_SET: true` (retention runs as part of the effective set job)
 2. `sbom_retention.enabled: true` in `/configuration/config.yml`
 
-Cleanup is **not** gated by repository size. The 600 MB threshold is checked only by the
-[total size safety net](#total-size-safety-net) step, after per-application SBOM retention
-has run.
+Cleanup is **not** gated by repository size. The 600 MB limit is checked only by the
+[total size limit](#total-size-limit) step, after per-application SBOM retention has run.
 
 ## Retention strategy
 
@@ -59,13 +58,13 @@ When cleanup is triggered, retention processes `/sboms/` in this order:
    [SBOM Storage Migration](/docs/how-to/sbom-storage-migration.md) for context.
 2. [Per-application version retention](#per-application-version-retention) runs for each
    subdirectory under `/sboms/`.
-3. [Total size safety net](#total-size-safety-net) is evaluated on `/sboms/` as a whole.
+3. [Total size limit](#total-size-limit) is evaluated on `/sboms/` as a whole.
 
 ### Per-application version retention
 
-This step runs only when `keep_versions_per_app` is set to a positive integer. When the value is
-unset or `0`, per-application SBOM retention is skipped and only the
-[total size safety net](#total-size-safety-net) is applied.
+Per-application SBOM retention runs only when `keep_versions_per_app` is set to a positive
+integer. If the field is omitted or set to `0`, this step is skipped and only the
+[total size limit](#total-size-limit) step runs.
 
 For each application subdirectory under `/sboms/`:
 
@@ -78,18 +77,18 @@ For each application subdirectory under `/sboms/`:
 > Ordering is by file modification time. Retention does not parse version strings from
 > filenames and is not aware of SemVer semantics.
 
-### Total size safety net
+### Total size limit
 
 After per-application SBOM retention, the total size of `/sboms/` is compared to the 600 MB
-threshold:
+limit:
 
 - If the total size is at or below 600 MB, no further action is taken
 - If the total size exceeds 600 MB, retention runs over each per-application subdirectory and
   keeps only the single most recently modified file. Older files in each subdirectory are deleted
 
-The 600 MB threshold sits well below the [job artifacts](/docs/dev/job-artifacts.md) 1500 MB
-limit so that retention can keep the cache within bounds before the job artifact size becomes
-a problem.
+The 600 MB limit sits well below the [job artifacts](/docs/dev/job-artifacts.md) 1500 MB
+limit on job artifact size, so that retention can keep the cache within bounds before the job
+artifact size becomes a problem.
 
 ## Configuration
 
@@ -106,9 +105,10 @@ sbom_retention:
   enabled: bool
   # Optional
   # No default value
-  # When unset or `0`, per-application SBOM retention is skipped and only the total size
-  # safety net runs (keeping the most recent file per application subdirectory when /sboms/
-  # exceeds 600 MB)
+  # Per-application SBOM retention runs only when this is set to a positive integer.
+  # If the field is omitted or set to `0`, this step is skipped and only the total size
+  # limit step runs (keeping the most recent file per application subdirectory when
+  # /sboms/ exceeds 600 MB)
   keep_versions_per_app: int
 ```
 

--- a/docs/features/sbom-retention.md
+++ b/docs/features/sbom-retention.md
@@ -34,9 +34,10 @@ Automatic SBOM retention policy that:
   [GENERATE_EFFECTIVE_SET: true](/docs/instance-pipeline-parameters.md#generate_effective_set)
 - Is activated by `sbom_retention.enabled: true`
 - Applies [per-application version retention](#per-application-version-retention) to each
-  subdirectory under `/sboms/`
-- Falls back to a [total size safety net](#total-size-safety-net) that wipes `/sboms/` if its
-  total size still exceeds 1200 MB after per-application retention
+  subdirectory under `/sboms/`, when `keep_versions_per_app` is set
+- Falls back to a [total size safety net](#total-size-safety-net) that keeps only the single most
+  recently modified file in each per-application subdirectory if the total size of `/sboms/`
+  still exceeds 600 MB after per-application SBOM retention
 
 ## When cleanup is triggered
 
@@ -45,8 +46,9 @@ Cleanup runs when both of the following conditions are true:
 1. `GENERATE_EFFECTIVE_SET: true` (retention runs as part of the effective set job)
 2. `sbom_retention.enabled: true` in `/configuration/config.yml`
 
-Cleanup is **not** gated by repository size. The 1200 MB threshold is checked only by the
-[total size safety net](#total-size-safety-net) step, after per-application retention has run.
+Cleanup is **not** gated by repository size. The 600 MB threshold is checked only by the
+[total size safety net](#total-size-safety-net) step, after per-application SBOM retention
+has run.
 
 ## Retention strategy
 
@@ -61,6 +63,10 @@ When cleanup is triggered, retention processes `/sboms/` in this order:
 
 ### Per-application version retention
 
+This step runs only when `keep_versions_per_app` is set to a positive integer. When the value is
+unset or `0`, per-application SBOM retention is skipped and only the
+[total size safety net](#total-size-safety-net) is applied.
+
 For each application subdirectory under `/sboms/`:
 
 - Files are sorted by modification time, newest first
@@ -74,13 +80,16 @@ For each application subdirectory under `/sboms/`:
 
 ### Total size safety net
 
-After per-application retention, the total size of `/sboms/` is compared to the 1200 MB threshold:
+After per-application SBOM retention, the total size of `/sboms/` is compared to the 600 MB
+threshold:
 
-- If the total size is at or below 1200 MB, no further action is taken
-- If the total size exceeds 1200 MB, **all files** under `/sboms/` are deleted as a fail-safe
+- If the total size is at or below 600 MB, no further action is taken
+- If the total size exceeds 600 MB, retention runs over each per-application subdirectory and
+  keeps only the single most recently modified file. Older files in each subdirectory are deleted
 
-The 1200 MB threshold sits below the [job artifacts](/docs/dev/job-artifacts.md) 1500 MB limit so
-that retention can keep the cache within bounds before the job artifact size becomes a problem.
+The 600 MB threshold sits well below the [job artifacts](/docs/dev/job-artifacts.md) 1500 MB
+limit so that retention can keep the cache within bounds before the job artifact size becomes
+a problem.
 
 ## Configuration
 
@@ -96,8 +105,10 @@ sbom_retention:
   # Default value: false
   enabled: bool
   # Optional
-  # Default value: 10
-  # A value of 0 means all files in each per-application subdirectory are deleted
+  # No default value
+  # When unset or `0`, per-application SBOM retention is skipped and only the total size
+  # safety net runs (keeping the most recent file per application subdirectory when /sboms/
+  # exceeds 600 MB)
   keep_versions_per_app: int
 ```
 

--- a/docs/use-cases/sbom-retention.md
+++ b/docs/use-cases/sbom-retention.md
@@ -7,7 +7,7 @@
     - [UC-SBOM-2: All applications within per-application limit - no files deleted](#uc-sbom-2-all-applications-within-per-application-limit---no-files-deleted)
     - [UC-SBOM-3: Per-application retention keeps 10 most recent versions](#uc-sbom-3-per-application-retention-keeps-10-most-recent-versions)
     - [UC-SBOM-4: Per-application retention with custom version count](#uc-sbom-4-per-application-retention-with-custom-version-count)
-    - [UC-SBOM-5: Total /sboms/ size exceeds 600 MB - safety net keeps newest per application](#uc-sbom-5-total-sboms-size-exceeds-600-mb---safety-net-keeps-newest-per-application)
+    - [UC-SBOM-5: Total /sboms/ size exceeds 600 MB - keeps newest per application](#uc-sbom-5-total-sboms-size-exceeds-600-mb---keeps-newest-per-application)
 
 ## Overview
 
@@ -21,8 +21,8 @@ structure.
 
 The cleanup logic runs during effective set generation and depends only on the
 `sbom_retention.enabled` flag. When enabled, per-application SBOM retention runs only if
-`keep_versions_per_app` is set, then a 600 MB safety net is evaluated on the total size
-of `/sboms/`. These use cases demonstrate the observable behavior in each scenario.
+`keep_versions_per_app` is set, then the total size of `/sboms/` is checked against the
+600 MB limit. These use cases demonstrate the observable behavior in each scenario.
 
 ### UC-SBOM-1: SBOM retention disabled - no cleanup
 
@@ -84,7 +84,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
      keep_versions_per_app: 10
    ```
 
-4. Total size of `/sboms/` is 200 MB (at or below the 600 MB safety-net threshold)
+4. Total size of `/sboms/` is 200 MB (at or below the 600 MB limit)
 
 **Trigger:**
 
@@ -100,7 +100,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 3. Any legacy flat SBOM files at the top of `/sboms/` are removed (none in this case).
 4. Per-application SBOM retention runs over each subdirectory. Every subdirectory already
    contains 10 or fewer files, so no files are deleted.
-5. The total size of `/sboms/` is at or below the 600 MB safety-net threshold. The safety net
+5. The total size of `/sboms/` is at or below the 600 MB limit. The total size limit step
    does not run.
 6. The effective set generation completes.
 
@@ -129,7 +129,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
      keep_versions_per_app: 10
    ```
 
-4. Total size of `/sboms/` is 500 MB (below the 600 MB safety-net threshold)
+4. Total size of `/sboms/` is 500 MB (below the 600 MB limit)
 
 **Trigger:**
 
@@ -146,7 +146,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 4. For each per-application subdirectory, the 10 most recent files are kept and older files are
    deleted.
 5. The total size of `/sboms/` after per-application SBOM retention is at or below the 600 MB
-   safety-net threshold. The safety net does not run.
+   limit. The total size limit step does not run.
 6. The effective set generation completes.
 
 **Results:**
@@ -179,7 +179,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
      keep_versions_per_app: 3  # only keep 3 most recent versions
    ```
 
-4. Total size of `/sboms/` is 350 MB (below the 600 MB safety-net threshold)
+4. Total size of `/sboms/` is 350 MB (below the 600 MB limit)
 
 **Trigger:**
 
@@ -195,7 +195,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 3. Any legacy flat SBOM files at the top of `/sboms/` are removed (none in this case).
 4. For `/sboms/postgres/`, the 3 most recent files are kept and the 7 older files are deleted.
 5. The total size of `/sboms/` after per-application SBOM retention is at or below the 600 MB
-   safety-net threshold. The safety net does not run.
+   limit. The total size limit step does not run.
 6. The effective set generation completes.
 
 **Results:**
@@ -211,7 +211,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
      deleted file)
    - `Directory size <X> MB`
 
-### UC-SBOM-5: Total /sboms/ size exceeds 600 MB - safety net keeps newest per application
+### UC-SBOM-5: Total /sboms/ size exceeds 600 MB - keeps newest per application
 
 **Pre-requisites:**
 
@@ -226,9 +226,9 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
      keep_versions_per_app: 10
    ```
 
-4. Total size of `/sboms/` is 700 MB (above the 600 MB safety-net threshold). Per-application
-   retention is not able to reduce the total below the threshold because no per-application
-   subdirectory exceeds `keep_versions_per_app`
+4. Total size of `/sboms/` is 700 MB (above the 600 MB limit). Per-application retention is not
+   able to reduce the total below the limit because no per-application subdirectory exceeds
+   `keep_versions_per_app`
 
 **Trigger:**
 
@@ -244,9 +244,9 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 3. Any legacy flat SBOM files at the top of `/sboms/` are removed (none in this case).
 4. Per-application SBOM retention runs over each subdirectory. No subdirectory exceeds
    `keep_versions_per_app`, so no per-application files are deleted.
-5. The total size of `/sboms/` is above the 600 MB safety-net threshold. Safety-net retention
-   runs over each subdirectory and keeps only the most recently modified file. Older files in
-   each subdirectory are deleted.
+5. The total size of `/sboms/` exceeds the 600 MB limit. The total size limit step runs over
+   each subdirectory and keeps only the most recently modified file. Older files in each
+   subdirectory are deleted.
 6. The effective set generation completes.
 
 **Results:**

--- a/docs/use-cases/sbom-retention.md
+++ b/docs/use-cases/sbom-retention.md
@@ -5,9 +5,9 @@
   - [SBOM cleanup execution](#sbom-cleanup-execution)
     - [UC-SBOM-1: SBOM retention disabled - no cleanup](#uc-sbom-1-sbom-retention-disabled---no-cleanup)
     - [UC-SBOM-2: All applications within per-application limit - no files deleted](#uc-sbom-2-all-applications-within-per-application-limit---no-files-deleted)
-    - [UC-SBOM-3: Per-application retention with default settings](#uc-sbom-3-per-application-retention-with-default-settings)
+    - [UC-SBOM-3: Per-application retention keeps 10 most recent versions](#uc-sbom-3-per-application-retention-keeps-10-most-recent-versions)
     - [UC-SBOM-4: Per-application retention with custom version count](#uc-sbom-4-per-application-retention-with-custom-version-count)
-    - [UC-SBOM-5: Total /sboms/ size exceeds 1200 MB after per-application retention - full cache wipe](#uc-sbom-5-total-sboms-size-exceeds-1200-mb-after-per-application-retention---full-cache-wipe)
+    - [UC-SBOM-5: Total /sboms/ size exceeds 600 MB - safety net keeps newest per application](#uc-sbom-5-total-sboms-size-exceeds-600-mb---safety-net-keeps-newest-per-application)
 
 ## Overview
 
@@ -20,9 +20,9 @@ structure.
 ## SBOM cleanup execution
 
 The cleanup logic runs during effective set generation and depends only on the
-`sbom_retention.enabled` flag. When enabled, retention always applies per-application version
-retention, then evaluates a 1200 MB safety net on the total size of `/sboms/`. These use cases
-demonstrate the observable behavior in each scenario.
+`sbom_retention.enabled` flag. When enabled, per-application SBOM retention runs only if
+`keep_versions_per_app` is set, then a 600 MB safety net is evaluated on the total size
+of `/sboms/`. These use cases demonstrate the observable behavior in each scenario.
 
 ### UC-SBOM-1: SBOM retention disabled - no cleanup
 
@@ -63,7 +63,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 
 1. Effective set is generated successfully
 2. No SBOM files are deleted
-3. Pipeline log shows: `SBOMs retention policy is disabled`
+3. Pipeline log shows: `SBOM retention policy is disabled`
 
 ### UC-SBOM-2: All applications within per-application limit - no files deleted
 
@@ -84,7 +84,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
      keep_versions_per_app: 10
    ```
 
-4. Total size of `/sboms/` is 200 MB (at or below the 1200 MB safety-net threshold)
+4. Total size of `/sboms/` is 200 MB (at or below the 600 MB safety-net threshold)
 
 **Trigger:**
 
@@ -98,10 +98,10 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 1. The `generate_effective_set` job runs.
 2. SBOM retention is enabled with `keep_versions_per_app: 10`. The cleanup procedure starts.
 3. Any legacy flat SBOM files at the top of `/sboms/` are removed (none in this case).
-4. Per-application retention runs over each subdirectory. Every subdirectory already contains 10
-   or fewer files, so no files are deleted.
-5. The total size of `/sboms/` is at or below the 1200 MB safety-net threshold. No safety-net
-   wipe is performed.
+4. Per-application SBOM retention runs over each subdirectory. Every subdirectory already
+   contains 10 or fewer files, so no files are deleted.
+5. The total size of `/sboms/` is at or below the 600 MB safety-net threshold. The safety net
+   does not run.
 6. The effective set generation completes.
 
 **Results:**
@@ -109,10 +109,10 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 1. Effective set is generated successfully
 2. No SBOM files are deleted
 3. Pipeline log shows:
-   - `SBOMs retention policy is enabled`
-   - `Directory size 200.00 mb within limit 1200 mb`
+   - `SBOM retention policy is enabled for directory <path>/sboms`
+   - `Directory size 200.00 MB`
 
-### UC-SBOM-3: Per-application retention with default settings
+### UC-SBOM-3: Per-application retention keeps 10 most recent versions
 
 **Pre-requisites:**
 
@@ -121,15 +121,15 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
    - `/sboms/app-a/`: 15 SBOM files
    - `/sboms/app-b/`: 12 SBOM files
    - `/sboms/app-c/`: 8 SBOM files
-3. SBOM retention is **enabled** with default settings in `/configuration/config.yml`:
+3. SBOM retention is **enabled** in `/configuration/config.yml`:
 
    ```yaml
    sbom_retention:
      enabled: true
-     keep_versions_per_app: 10  # default value
+     keep_versions_per_app: 10
    ```
 
-4. Total size of `/sboms/` is 1100 MB (below the 1200 MB safety-net threshold)
+4. Total size of `/sboms/` is 500 MB (below the 600 MB safety-net threshold)
 
 **Trigger:**
 
@@ -145,8 +145,8 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 3. Any legacy flat SBOM files at the top of `/sboms/` are removed (none in this case).
 4. For each per-application subdirectory, the 10 most recent files are kept and older files are
    deleted.
-5. The total size of `/sboms/` after per-application retention is at or below the 1200 MB
-   safety-net threshold. No safety-net wipe is performed.
+5. The total size of `/sboms/` after per-application SBOM retention is at or below the 600 MB
+   safety-net threshold. The safety net does not run.
 6. The effective set generation completes.
 
 **Results:**
@@ -158,12 +158,12 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
    - `/sboms/app-c/`: all 8 files are kept (count is at or below `keep_versions_per_app`)
 3. Total files deleted: 7 SBOM files
 4. Pipeline log shows:
-   - `SBOMs retention policy is enabled`
+   - `SBOM retention policy is enabled for directory <path>/sboms`
    - `Only 10 files will remain in <path>/sboms/app-a` (and a `Removing file:` line per deleted
      file)
    - `Only 10 files will remain in <path>/sboms/app-b` (and a `Removing file:` line per deleted
      file)
-   - `Directory size <X> mb within limit 1200 mb`
+   - `Directory size <X> MB`
 
 ### UC-SBOM-4: Per-application retention with custom version count
 
@@ -179,7 +179,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
      keep_versions_per_app: 3  # only keep 3 most recent versions
    ```
 
-4. Total size of `/sboms/` is 350 MB (below the 1200 MB safety-net threshold)
+4. Total size of `/sboms/` is 350 MB (below the 600 MB safety-net threshold)
 
 **Trigger:**
 
@@ -194,8 +194,8 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 2. SBOM retention is enabled with `keep_versions_per_app: 3`. The cleanup procedure starts.
 3. Any legacy flat SBOM files at the top of `/sboms/` are removed (none in this case).
 4. For `/sboms/postgres/`, the 3 most recent files are kept and the 7 older files are deleted.
-5. The total size of `/sboms/` after per-application retention is at or below the 1200 MB
-   safety-net threshold. No safety-net wipe is performed.
+5. The total size of `/sboms/` after per-application SBOM retention is at or below the 600 MB
+   safety-net threshold. The safety net does not run.
 6. The effective set generation completes.
 
 **Results:**
@@ -206,12 +206,12 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
    - 7 oldest files are deleted
 3. Total files deleted: 7 SBOM files
 4. Pipeline log shows:
-   - `SBOMs retention policy is enabled`
+   - `SBOM retention policy is enabled for directory <path>/sboms`
    - `Only 3 files will remain in <path>/sboms/postgres` (and a `Removing file:` line per
      deleted file)
-   - `Directory size <X> mb within limit 1200 mb`
+   - `Directory size <X> MB`
 
-### UC-SBOM-5: Total /sboms/ size exceeds 1200 MB after per-application retention - full cache wipe
+### UC-SBOM-5: Total /sboms/ size exceeds 600 MB - safety net keeps newest per application
 
 **Pre-requisites:**
 
@@ -226,7 +226,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
      keep_versions_per_app: 10
    ```
 
-4. Total size of `/sboms/` is 1400 MB (above the 1200 MB safety-net threshold). Per-application
+4. Total size of `/sboms/` is 700 MB (above the 600 MB safety-net threshold). Per-application
    retention is not able to reduce the total below the threshold because no per-application
    subdirectory exceeds `keep_versions_per_app`
 
@@ -242,18 +242,22 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 1. The `generate_effective_set` job runs.
 2. SBOM retention is enabled with `keep_versions_per_app: 10`. The cleanup procedure starts.
 3. Any legacy flat SBOM files at the top of `/sboms/` are removed (none in this case).
-4. Per-application retention runs over each subdirectory. No subdirectory exceeds
+4. Per-application SBOM retention runs over each subdirectory. No subdirectory exceeds
    `keep_versions_per_app`, so no per-application files are deleted.
-5. The total size of `/sboms/` is above the 1200 MB safety-net threshold. All files under
-   `/sboms/` are deleted as a fail-safe.
+5. The total size of `/sboms/` is above the 600 MB safety-net threshold. Safety-net retention
+   runs over each subdirectory and keeps only the most recently modified file. Older files in
+   each subdirectory are deleted.
 6. The effective set generation completes.
 
 **Results:**
 
 1. Effective set is generated successfully
-2. All cached SBOM files are deleted. The next pipeline run that needs SBOMs will regenerate
+2. Only the single most recent SBOM file remains under each `/sboms/<application-name>/`. Older
+   versions are deleted. Subsequent pipeline runs that need previous versions will regenerate
    them, which is a costly operation
 3. Pipeline log shows:
-   - `SBOMs retention policy is enabled`
-   - `Directory size 1400.00 mb exceeds limit 1200 mb, deleting all files in <path>/sboms`
-   - One `Removing file: <path>` line per deleted file
+   - `SBOM retention policy is enabled for directory <path>/sboms`
+   - `Directory size 700.00 MB`
+   - `SBOM directory exceeds size limit, starting cleanup: <path>/sboms`
+   - `Only 1 files will remain in <path>/sboms/<application-name>` (one per subdirectory that
+     had more than one file), and a `Removing file: <path>` line per deleted file

--- a/gsf_packages/envgene_instance_project/git-system-follower-package/scripts/templates/default/{{ cookiecutter.gsf_repository_name }}/example/configuration/config.yml
+++ b/gsf_packages/envgene_instance_project/git-system-follower-package/scripts/templates/default/{{ cookiecutter.gsf_repository_name }}/example/configuration/config.yml
@@ -12,6 +12,10 @@ crypt: false
   # Optional, default value - false
   # If `true`, SBOM retention will be enabled
   # enabled: false
-  # Optional, default value - 10
+  # Optional, no default value
   # Number of latest versions to keep per application when enabled
+  # Per-application SBOM retention runs only when this is set to a positive integer.
+  # If the field is omitted or set to 0, this step is skipped and only the total
+  # size limit step runs (keeping the most recent file per application subdirectory
+  # when /sboms/ exceeds 600 MB)
   # keep_versions_per_app: 10

--- a/gsf_packages/envgene_instance_project/git-system-follower-package/scripts/templates/default/{{ cookiecutter.gsf_repository_name }}/git_hooks/config.schema.json
+++ b/gsf_packages/envgene_instance_project/git-system-follower-package/scripts/templates/default/{{ cookiecutter.gsf_repository_name }}/git_hooks/config.schema.json
@@ -61,7 +61,7 @@
     "sbom_retention": {
       "type": "object",
       "title": "SBOM Retention Configuration",
-      "description": "Configuration for automatic SBOM file cleanup. When enabled, applies per-application version retention to subdirectories of /sboms/. A safety net wipes /sboms/ if its total size still exceeds 1200 MB after per-application retention.",
+      "description": "Configuration for automatic SBOM file cleanup. When enabled, per-application SBOM retention is applied to subdirectories of /sboms/ if keep_versions_per_app is set. A total size limit step then keeps only the most recently modified file in each per-application subdirectory if the total size of /sboms/ still exceeds 600 MB.",
       "additionalProperties": false,
       "properties": {
         "enabled": {
@@ -77,9 +77,8 @@
         "keep_versions_per_app": {
           "type": "integer",
           "title": "Versions to Keep",
-          "description": "Number of latest versions to keep per application subdirectory. Used only when enabled is true. A value of 0 means all files in each per-application subdirectory are deleted.",
+          "description": "Number of latest versions to keep per application subdirectory. Used only when enabled is true. Per-application SBOM retention runs only when this is set to a positive integer. If the field is omitted or set to 0, per-application SBOM retention is skipped and only the total size limit step runs.",
           "minimum": 0,
-          "default": 10,
           "examples": [
             5,
             10,

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -61,7 +61,7 @@
     "sbom_retention": {
       "type": "object",
       "title": "SBOM Retention Configuration",
-      "description": "Configuration for automatic SBOM file cleanup. When enabled, applies per-application version retention to subdirectories of /sboms/. A safety net wipes /sboms/ if its total size still exceeds 1200 MB after per-application retention.",
+      "description": "Configuration for automatic SBOM file cleanup. When enabled, per-application SBOM retention is applied to subdirectories of /sboms/ if keep_versions_per_app is set. A total size limit step then keeps only the most recently modified file in each per-application subdirectory if the total size of /sboms/ still exceeds 600 MB.",
       "additionalProperties": false,
       "properties": {
         "enabled": {
@@ -77,9 +77,8 @@
         "keep_versions_per_app": {
           "type": "integer",
           "title": "Versions to Keep",
-          "description": "Number of latest versions to keep per application subdirectory. Used only when enabled is true. A value of 0 means all files in each per-application subdirectory are deleted.",
+          "description": "Number of latest versions to keep per application subdirectory. Used only when enabled is true. Per-application SBOM retention runs only when this is set to a positive integer. If the field is omitted or set to 0, per-application SBOM retention is skipped and only the total size limit step runs.",
           "minimum": 0,
-          "default": 10,
           "examples": [
             5,
             10,


### PR DESCRIPTION
## Summary

Align the SBOM retention docs with the code on
[`bugfix/align_retention_with_doc`](https://github.com/Netcracker/qubership-envgene/tree/bugfix/align_retention_with_doc).
The doc previously described pre-change behavior of the retention policy.

## Doc changes

`docs/features/sbom-retention.md`, `docs/use-cases/sbom-retention.md`,
`docs/envgene-configs.md`:

- `keep_versions_per_app`: `Default value: 10` -> `No default value`. Per-application
  SBOM retention runs only when this is set to a positive integer. When omitted
  or set to `0`, the step is skipped
- Size threshold: `1200 MB` -> `600 MB` (matches the new `CI_JOB_ARTIFACT_MAX_SIZE_MB`
  constant)
- Action when the threshold is exceeded: "all files deleted as a fail-safe" -> "keeps
  the single most recently modified file in each per-application subdirectory"
- Section renamed: `Total size safety net` -> `Total size limit`. "Safety-net threshold"
  / "Safety-net retention" replaced with "the 600 MB limit" / "total size limit step"
- UC-SBOM-3 retitled (`with default settings` -> `keeps 10 most recent versions`),
  pre-req sizes adjusted
- UC-SBOM-5 retitled (`full cache wipe` -> `keeps newest per application`), Steps
  and Results rewritten for the new behavior
- Pipeline log strings refreshed to match the new logger output:
  - `SBOMs retention policy is disabled` -> `SBOM retention policy is disabled`
  - `SBOMs retention policy is enabled` -> `SBOM retention policy is enabled for directory /sboms`
  - `Directory size X mb within limit 1200 mb` -> `Directory size X MB`
  - `Directory size X mb exceeds limit 1200 mb, deleting all files in ...` -> `SBOM directory exceeds size limit, starting cleanup: ...` plus per-app `Only 1 files will remain in ...`

## Schema and gsf example changes

`schemas/config.schema.json` and the gsf cookiecutter copy at
`gsf_packages/.../git_hooks/config.schema.json`:

- Remove `default: 10` from `keep_versions_per_app`
- Rewrite the `sbom_retention` and `keep_versions_per_app` descriptions to match
  the new behavior and terminology (`Total size limit`, 600 MB, keep newest per
  application subdirectory)

`gsf_packages/.../example/configuration/config.yml`:

- Update the commented-out `keep_versions_per_app` example: `default value - 10`
  -> `no default value`, plus a note that omitting the field or setting `0`
  skips per-application SBOM retention

🤖 Generated with [Claude Code](https://claude.com/claude-code)