### PR TITLE
docs: replace partial_effective_set_generation bool with strategy enum

### DIFF
--- a/docs/envgene-configs.md
+++ b/docs/envgene-configs.md
@@ -387,13 +387,14 @@ sbom_retention:
   # limit step runs (keeping the most recent file per application subdirectory when /sboms/
   # exceeds 600 MB)
   keep_versions_per_app: integer
-# Optional. Default value - `true`
-# Enable or disable partial Effective Set generation in `generate_effective_set`
+# Optional. Default value - `partial`
+# Defines the Effective Set generation strategy used by `generate_effective_set`
+# `partial` - Partial Generation is enabled. Selected automatically when applicable, otherwise Full Generation is used
+# `full` - Partial Generation is disabled, only Full Generation is used
 # See [Partial Generation](/docs/features/effective-set-generation.md#partial-generation)
 # and [Full Generation](/docs/features/effective-set-generation.md#full-generation)
 # for generation mode behavior
-# When `false`, Partial Generation is disabled and only Full Generation is used
-partial_effective_set_generation: boolean
+effective_set_generation_strategy: enum [`full`, `partial`]
 ```
 
 ## `integration.yml`

--- a/docs/features/effective-set-generation.md
+++ b/docs/features/effective-set-generation.md
@@ -88,7 +88,7 @@ Applied when SD processing produces a Delta SD — that is, `SD_REPO_MERGE_MODE`
 
 Application and Registry Definitions for every application in the Delta SD must be available.
 
-This mode is available only when `partial_effective_set_generation=true` or not set in [`config.yml`](/docs/envgene-configs.md#configyml).
+This mode is available only when `effective_set_generation_strategy=partial` or not set in [`config.yml`](/docs/envgene-configs.md#configyml).
 
 #### Forward merge
 


### PR DESCRIPTION
## Summary

- Rename `partial_effective_set_generation: boolean` to `effective_set_generation_strategy: enum [full, partial]` in the `config.yml` schema documentation (`docs/envgene-configs.md`).
- Update the cross-reference in `docs/features/effective-set-generation.md` (Partial Generation section) to use the new field name.
- Default behavior is unchanged: `partial` (Partial Generation enabled, auto-selected when applicable, otherwise Full Generation).

Rationale: the enum form removes the implicit-fallback reading of the boolean name (where `false` meant "use Full Generation" without naming it).
