### PR TITLE
fix: cloud name updation in envdefinition file

### DIFF
--- a/scripts/build_env/env_inventory_generation.py
+++ b/scripts/build_env/env_inventory_generation.py
@@ -89,20 +89,23 @@ def handle_env_specific_params(env, env_specific_params, schemas_dir):
     creds = params.get("credentials")
     tenantName = params.get("tenantName")
     deployer = params.get("deployer")
+    cloudName = params.get("cloudName")
     logger.info(f"ENV_SPECIFIC_PARAMS TenantName is {tenantName}")
     logger.info(f"ENV_SPECIFIC_PARAMS deployer is {deployer}")
+    logger.info(f"ENV_SPECIFIC_PARAMS cloudname is {cloudName}")
 
     handle_cluster_params(env, clusterParams)
     helper.set_nested_yaml_attribute(env.inventory, 'inventory.tenantName', tenantName)
     helper.set_nested_yaml_attribute(env.inventory, 'inventory.deployer', deployer)
+    helper.set_nested_yaml_attribute(env.inventory, 'inventory.cloudName', cloudName)
     helper.merge_yaml_into_target(env.inventory, 'envTemplate.additionalTemplateVariables', additionalTemplateVariables)
     helper.merge_yaml_into_target(env.inventory, 'envTemplate.envSpecificParamsets', envSpecificParamsets)
     logger.info("ENV_SPECIFIC_PARAMS env details ", vars(env))
     handle_credentials(env, creds)
     create_paramset_files(env, paramsets, schemas_dir)
 
-    helper.set_nested_yaml_attribute(env.inventory, 'inventory.tenantName', tenantName)
-    helper.set_nested_yaml_attribute(env.inventory, 'inventory.tenantName', tenantName)
+    
+   
 
     logger.info(f"ENV_SPECIFIC_PARAMS env details : {vars(env)}")
 


### PR DESCRIPTION
# Pull Request

## Summary

Fixed missing cloudName propagation from ENV_SPECIFIC_PARAMS during environment inventory generation. Previously, even when cloudName was passed through pipeline parameters as ENV_SPECIFIC_PARAMS, the generated env_definition.yml was not updated because handle_env_specific_params() in env_inventory_generation.py did not process cloudName updates.Added explicit cloudName update handling in handle_env_specific_params() by extracting the value from ENV_SPECIFIC_PARAMS and updating inventory.cloudName in the generated env_definition.yml using set_nested_yaml_attribute(), ensuring the final inventory correctly reflects the cloud configuration passed from the pipeline.

## Issue
when passing cloud name in the env specific params the cloud name is not being update in the env_definition file after the pipeline run 

## Breaking Change?

- [ ] Yes
- [x] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

Provide details on how the change was implemented, including any technical considerations, trade-offs, or notable design decisions. Leave blank if not applicable.

## Tests / Evidence
Tested using instance pipeline
now cloudname  is updated in env_definition file after the pipeline run 

## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
