### PR TITLE
fix: deployment session id in ES

### DIFF
--- a/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/CmdbCli.java
+++ b/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/CmdbCli.java
@@ -164,6 +164,9 @@ public class CmdbCli implements Callable<Integer> {
                 }
             });
         }
+        if (StringUtils.isEmpty(sharedData.getDeploymentSessionId())) {
+            sharedData.setDeploymentSessionId(UUID.randomUUID().toString());
+        }
     }
 
     static class EnvCommandSpace {

--- a/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/parser/CliParameterParser.java
+++ b/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/parser/CliParameterParser.java
@@ -272,7 +272,7 @@ public class CliParameterParser {
 
     public void generateOutput(String tenantName, String cloudName, String namespaceName, String appName,
                                String appVersion, String appFileRef, Map<String, String> k8TokenMap) throws IOException {
-        DeployerInputs deployerInputs = DeployerInputs.builder().appVersion(appVersion).appFileRef(appFileRef).build();
+        DeployerInputs deployerInputs = DeployerInputs.builder().appVersion(appVersion).appFileRef(appFileRef).deploySessionId(sharedData.getDeploymentSessionId()).build();
         String originalNamespace = inputData.getNamespaceDTOMap().get(namespaceName).getName();
         ParameterBundle parameterBundle;
         if (EffectiveSetVersion.V2_0 == sharedData.getEffectiveSetVersion()) {

--- a/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/utils/BomReaderUtilsImplV2.java
+++ b/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/utils/BomReaderUtilsImplV2.java
@@ -295,6 +295,8 @@ public class BomReaderUtilsImplV2 {
         if (MapUtils.isNotEmpty(profileValues)) {
             serviceParams.putAll(profileValues);
         }
+        serviceParams.put("DEPLOYMENT_SESSION_ID", sharedData.getDeploymentSessionId());
+        serviceParams.put("MANAGED_BY", "argocd");
         serviceMap.put(component.getName(), serviceParams);
     }
 
@@ -326,6 +328,8 @@ public class BomReaderUtilsImplV2 {
         if (MapUtils.isNotEmpty(profileValues)) {
             serviceParams.putAll(profileValues);
         }
+        serviceParams.put("DEPLOYMENT_SESSION_ID", sharedData.getDeploymentSessionId());
+        serviceParams.put("MANAGED_BY", "argocd");
         perServiceMap.put(component.getName(), serviceParams);
     }
 

--- a/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/deployment/monitoring-origin/MONITORING/values/per-service-parameters/monitoring-sf/deployment-parameters.yaml
+++ b/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/deployment/monitoring-origin/MONITORING/values/per-service-parameters/monitoring-sf/deployment-parameters.yaml
@@ -1,361 +1,451 @@
 alertmanager:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: alertmanager-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/prom/alertmanager:v0.28.1
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/prom/alertmanager
+  MANAGED_BY: argocd
   SERVICE_NAME: alertmanager
   TAG: v0.28.1
 blackbox-exporter:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: blackbox-exporter-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/prom/blackbox-exporter:v0.26.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/prom/blackbox-exporter
+  MANAGED_BY: argocd
   SERVICE_NAME: blackbox-exporter
   TAG: v0.26.0
 cert-exporter:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: cert-exporter-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/joeelliott/cert-exporter:v2.15.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/joeelliott/cert-exporter
+  MANAGED_BY: argocd
   SERVICE_NAME: cert-exporter
   TAG: v2.15.0
 cloud-events-exporter:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: cloud-events-exporter-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_monitoring-operator:0.91.0_20241115-141230
   IMAGE_REPOSITORY: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_monitoring-operator
+  MANAGED_BY: argocd
   SERVICE_NAME: cloud-events-exporter
   TAG: 0.91.0_20241115-141230
 cloud-events-reader:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: cloud-events-reader-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17125/product/prod.platform.logging_cloud-events-reader:2.5.6_20241113-123045
   IMAGE_REPOSITORY: artifactory.qubership.org:17125/product/prod.platform.logging_cloud-events-reader
+  MANAGED_BY: argocd
   SERVICE_NAME: cloud-events-reader
   TAG: 2.5.6_20241113-123045
 cloudwatch-exporter:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: cloudwatch-exporter-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/prom/cloudwatch-exporter:v0.16.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/prom/cloudwatch-exporter
+  MANAGED_BY: argocd
   SERVICE_NAME: cloudwatch-exporter
   TAG: v0.16.0
 common-dashboards:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: common-dashboards-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_monitoring-operator:0.91.0_20241115-141230
   IMAGE_REPOSITORY: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_monitoring-operator
+  MANAGED_BY: argocd
   SERVICE_NAME: common-dashboards
   TAG: 0.91.0_20241115-141230
 configmap-reload:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: configmap-reload-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/jimmidyson/configmap-reload:v0.15.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/jimmidyson/configmap-reload
+  MANAGED_BY: argocd
   SERVICE_NAME: configmap-reload
   TAG: v0.15.0
 configurations-streamer:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: configurations-streamer-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_configurations-streamer:0.13.3_20241113-134520
   IMAGE_REPOSITORY: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_configurations-streamer
+  MANAGED_BY: argocd
   SERVICE_NAME: configurations-streamer
   TAG: 0.13.3_20241113-134520
 grafana:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: grafana-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/grafana/grafana:11.5.2
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/grafana/grafana
+  MANAGED_BY: argocd
   SERVICE_NAME: grafana
   TAG: 11.5.2
 grafana-image-renderer:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: grafana-image-renderer-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/grafana/grafana-image-renderer:3.12.6
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/grafana/grafana-image-renderer
+  MANAGED_BY: argocd
   SERVICE_NAME: grafana-image-renderer
   TAG: 3.12.6
 grafana-operator:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: grafana-operator-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/grafana-operator/grafana-operator:v4.10.1
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/grafana-operator/grafana-operator
+  MANAGED_BY: argocd
   SERVICE_NAME: grafana-operator
   TAG: v4.10.1
 grafana-plugins-init:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: grafana-plugins-init-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_grafana-plugins-init:0.13.2_20241113-134320
   IMAGE_REPOSITORY: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_grafana-plugins-init
+  MANAGED_BY: argocd
   SERVICE_NAME: grafana-plugins-init
   TAG: 0.13.2_20241113-134320
 graphite-remote-adapter:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: graphite-remote-adapter-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_graphite-remote-adapter:0.6.3_20241113-134430
   IMAGE_REPOSITORY: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_graphite-remote-adapter
+  MANAGED_BY: argocd
   SERVICE_NAME: graphite-remote-adapter
   TAG: 0.6.3_20241113-134430
 json-exporter:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: json-exporter-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/prometheuscommunity/json-exporter:v0.7.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/prometheuscommunity/json-exporter
+  MANAGED_BY: argocd
   SERVICE_NAME: json-exporter
   TAG: v0.7.0
 kube-rbac-proxy:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: kube-rbac-proxy-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/brancz/kube-rbac-proxy:v0.19.1
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/brancz/kube-rbac-proxy
+  MANAGED_BY: argocd
   SERVICE_NAME: kube-rbac-proxy
   TAG: v0.19.1
 kube-state-metrics:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: kube-state-metrics-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/kube-state-metrics/kube-state-metrics:v2.15.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/kube-state-metrics/kube-state-metrics
+  MANAGED_BY: argocd
   SERVICE_NAME: kube-state-metrics
   TAG: v2.15.0
 monitoring-operator:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: monitoring-operator-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_monitoring-operator:0.91.0_20241115-141230
   IMAGE_REPOSITORY: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_monitoring-operator
+  MANAGED_BY: argocd
   SERVICE_NAME: monitoring-operator
   TAG: 0.91.0_20241115-141230
   type: dev
 network-latency-exporter:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: network-latency-exporter-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_exporters_network-latency-exporter:2.6.3_20241113-134440
   IMAGE_REPOSITORY: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_exporters_network-latency-exporter
+  MANAGED_BY: argocd
   SERVICE_NAME: network-latency-exporter
   TAG: 2.6.3_20241113-134440
 node-exporter:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: node-exporter-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/prom/node-exporter:v1.9.1
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/prom/node-exporter
+  MANAGED_BY: argocd
   SERVICE_NAME: node-exporter
   TAG: v1.9.1
 oauth2-proxy:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: oauth2-proxy-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/oauth2-proxy/oauth2-proxy:v7.9.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/oauth2-proxy/oauth2-proxy
+  MANAGED_BY: argocd
   SERVICE_NAME: oauth2-proxy
   TAG: v7.9.0
 platform_monitoring_tests:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: platform_monitoring_tests-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17125/product/prod.platform.system.monitoring_tests_platform-monitoring-tests:0.8.1_20241010-130200
   IMAGE_REPOSITORY: artifactory.qubership.org:17125/product/prod.platform.system.monitoring_tests_platform-monitoring-tests
+  MANAGED_BY: argocd
   SERVICE_NAME: platform_monitoring_tests
   TAG: 0.8.1_20241010-130200
 prometheus:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: prometheus-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/prom/prometheus:v3.4.1
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/prom/prometheus
+  MANAGED_BY: argocd
   SERVICE_NAME: prometheus
   TAG: v3.4.1
 prometheus-adapter:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: prometheus-adapter-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_k8s-scaling_prometheus-adapter:0.7.2_20241113-134300
   IMAGE_REPOSITORY: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_k8s-scaling_prometheus-adapter
+  MANAGED_BY: argocd
   SERVICE_NAME: prometheus-adapter
   TAG: 0.7.2_20241113-134300
 prometheus-adapter-converter:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: prometheus-adapter-converter-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_k8s-scaling_prometheus-adapter-converter:0.1.0_20241113-134325
   IMAGE_REPOSITORY: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_k8s-scaling_prometheus-adapter-converter
+  MANAGED_BY: argocd
   SERVICE_NAME: prometheus-adapter-converter
   TAG: 0.1.0_20241113-134325
 prometheus-adapter-operator:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: prometheus-adapter-operator-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17125/product/prod.platform.system.monitoring_k8s-scaling_prometheus-adapter-operator:0.10.0_20241010-125000
   IMAGE_REPOSITORY: artifactory.qubership.org:17125/product/prod.platform.system.monitoring_k8s-scaling_prometheus-adapter-operator
+  MANAGED_BY: argocd
   SERVICE_NAME: prometheus-adapter-operator
   TAG: 0.10.0_20241010-125000
 prometheus-config-reloader:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: prometheus-config-reloader-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/prometheus-operator/prometheus-config-reloader:v0.82.2
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/prometheus-operator/prometheus-config-reloader
+  MANAGED_BY: argocd
   SERVICE_NAME: prometheus-config-reloader
   TAG: v0.82.2
 prometheus-operator:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: prometheus-operator-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/prometheus-operator/prometheus-operator:v0.82.2
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/prometheus-operator/prometheus-operator
+  MANAGED_BY: argocd
   SERVICE_NAME: prometheus-operator
   TAG: v0.82.2
 promitor-agent-resource-discovery:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: promitor-agent-resource-discovery-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/tomkerkhove/promitor-agent-resource-discovery:0.14.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/tomkerkhove/promitor-agent-resource-discovery
+  MANAGED_BY: argocd
   SERVICE_NAME: promitor-agent-resource-discovery
   TAG: 0.14.0
 promitor-agent-scraper:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: promitor-agent-scraper-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/tomkerkhove/promitor-agent-scraper:2.14.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/tomkerkhove/promitor-agent-scraper
+  MANAGED_BY: argocd
   SERVICE_NAME: promitor-agent-scraper
   TAG: 2.14.0
 promxy:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: promxy-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/jacksontj/promxy:v0.0.93
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/jacksontj/promxy
+  MANAGED_BY: argocd
   SERVICE_NAME: promxy
   TAG: v0.0.93
 pushgateway:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: pushgateway-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/prom/pushgateway:v1.11.1
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/prom/pushgateway
+  MANAGED_BY: argocd
   SERVICE_NAME: pushgateway
   TAG: v1.11.1
 stackdriver-exporter:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: stackdriver-exporter-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/prometheuscommunity/stackdriver-exporter:v0.18.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/prometheuscommunity/stackdriver-exporter
+  MANAGED_BY: argocd
   SERVICE_NAME: stackdriver-exporter
   TAG: v0.18.0
 version-exporter:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: version-exporter-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_exporters_version-exporter:0.2.3_20241113-134457
   IMAGE_REPOSITORY: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_exporters_version-exporter
+  MANAGED_BY: argocd
   SERVICE_NAME: version-exporter
   TAG: 0.2.3_20241113-134457
 victoriametrics-operator:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: victoriametrics-operator-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_monitoring-operator:0.91.0_20241115-141230
   IMAGE_REPOSITORY: artifactory.qubership.org:17208/product/prod.platform.system.monitoring_monitoring-operator
+  MANAGED_BY: argocd
   SERVICE_NAME: victoriametrics-operator
   TAG: 0.91.0_20241115-141230
 vmagent:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: vmagent-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/victoriametrics/vmagent:v1.118.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/victoriametrics/vmagent
+  MANAGED_BY: argocd
   SERVICE_NAME: vmagent
   TAG: v1.118.0
 vmalert:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: vmalert-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/victoriametrics/vmalert:v1.118.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/victoriametrics/vmalert
+  MANAGED_BY: argocd
   SERVICE_NAME: vmalert
   TAG: v1.118.0
 vmauth:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: vmauth-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/victoriametrics/vmauth:v1.118.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/victoriametrics/vmauth
+  MANAGED_BY: argocd
   SERVICE_NAME: vmauth
   TAG: v1.118.0
 vmcleanup:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: vmcleanup-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/bitnami/kubectl:1.33.1
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/bitnami/kubectl
+  MANAGED_BY: argocd
   SERVICE_NAME: vmcleanup
   TAG: 1.33.1
 vminsert:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: vminsert-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/victoriametrics/vminsert:v1.118.0-cluster
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/victoriametrics/vminsert
+  MANAGED_BY: argocd
   SERVICE_NAME: vminsert
   TAG: v1.118.0-cluster
 vmoperator:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: vmoperator-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/victoriametrics/operator:v0.59.2
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/victoriametrics/operator
+  MANAGED_BY: argocd
   SERVICE_NAME: vmoperator
   TAG: v0.59.2
 vmoperator_config_reloader:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: vmoperator_config_reloader-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/victoriametrics/operator:config-reloader-v0.59.2
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/victoriametrics/operator
+  MANAGED_BY: argocd
   SERVICE_NAME: vmoperator_config_reloader
   TAG: config-reloader-v0.59.2
 vmselect:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: vmselect-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/victoriametrics/vmselect:v1.118.0-cluster
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/victoriametrics/vmselect
+  MANAGED_BY: argocd
   SERVICE_NAME: vmselect
   TAG: v1.118.0-cluster
 vmsingle:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: vmsingle-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/victoriametrics/victoria-metrics:v1.118.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/victoriametrics/victoria-metrics
+  MANAGED_BY: argocd
   SERVICE_NAME: vmsingle
   TAG: v1.118.0
 vmstorage:
   ARTIFACT_DESCRIPTOR_VERSION: 0.91.0-delivery-20241115.141230-4-RELEASE
   DEPLOYMENT_RESOURCE_NAME: vmstorage-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17215/victoriametrics/vmstorage:v1.118.0-cluster
   IMAGE_REPOSITORY: artifactory.qubership.org:17215/victoriametrics/vmstorage
+  MANAGED_BY: argocd
   SERVICE_NAME: vmstorage
   TAG: v1.118.0-cluster

--- a/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/deployment/pg/postgres/values/per-service-parameters/postgres/deployment-parameters.yaml
+++ b/build_effective_set_generator/effective-set-generator/src/test/resources/environments/cluster-01/pl-01/effective-set/deployment/pg/postgres/values/per-service-parameters/postgres/deployment-parameters.yaml
@@ -1,57 +1,71 @@
 patroni-core:
   ARTIFACT_DESCRIPTOR_VERSION: pg16-2.10.5-20241215.141230-3-RELEASE
   DEPLOYMENT_RESOURCE_NAME: patroni-core-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17208/product/prod.platform.ha_postgres-operator:2.10.5_20241215-141230_patroni-core-operator
   IMAGE_REPOSITORY: artifactory.qubership.org:17208/product/prod.platform.ha_postgres-operator
+  MANAGED_BY: argocd
   SERVICE_NAME: patroni-core
   TAG: 2.10.5_20241215-141230_patroni-core-operator
   type: dev
 pg_patroni:
   ARTIFACT_DESCRIPTOR_VERSION: pg16-2.10.5-20241215.141230-3-RELEASE
   DEPLOYMENT_RESOURCE_NAME: pg_patroni-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17125/product/prod.platform.ha_pg-patroni:release-2024.2-2.10.0_20240715-123045_pg16
   IMAGE_REPOSITORY: artifactory.qubership.org:17125/product/prod.platform.ha_pg-patroni
+  MANAGED_BY: argocd
   SERVICE_NAME: pg_patroni
   TAG: release-2024.2-2.10.0_20240715-123045_pg16
 pg_upgrade:
   ARTIFACT_DESCRIPTOR_VERSION: pg16-2.10.5-20241215.141230-3-RELEASE
   DEPLOYMENT_RESOURCE_NAME: pg_upgrade-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17125/product/prod.platform.ha_pg-service:release-2024.2-2.10.0_20240716-142315_pg-upgrade
   IMAGE_REPOSITORY: artifactory.qubership.org:17125/product/prod.platform.ha_pg-service
+  MANAGED_BY: argocd
   SERVICE_NAME: pg_upgrade
   TAG: release-2024.2-2.10.0_20240716-142315_pg-upgrade
 pgbackrest_sidecar:
   ARTIFACT_DESCRIPTOR_VERSION: pg16-2.10.5-20241215.141230-3-RELEASE
   DEPLOYMENT_RESOURCE_NAME: pgbackrest_sidecar-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17263/qubership/pgskipper-pgbackrest-sidecar:release-2024.2-2.10.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17263/qubership/pgskipper-pgbackrest-sidecar
+  MANAGED_BY: argocd
   SERVICE_NAME: pgbackrest_sidecar
   TAG: release-2024.2-2.10.0
 postgres_operator_init:
   ARTIFACT_DESCRIPTOR_VERSION: pg16-2.10.5-20241215.141230-3-RELEASE
   DEPLOYMENT_RESOURCE_NAME: postgres_operator_init-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17208/product/prod.platform.ha_postgres-operator:2.10.5_20241215-141230_init
   IMAGE_REPOSITORY: artifactory.qubership.org:17208/product/prod.platform.ha_postgres-operator
+  MANAGED_BY: argocd
   SERVICE_NAME: postgres_operator_init
   TAG: 2.10.5_20241215-141230_init
 postgres_operator_tests:
   ARTIFACT_DESCRIPTOR_VERSION: pg16-2.10.5-20241215.141230-3-RELEASE
   DEPLOYMENT_RESOURCE_NAME: postgres_operator_tests-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17263/qubership/pgskipper-operator-tests:release-2024.2-2.10.0
   IMAGE_REPOSITORY: artifactory.qubership.org:17263/qubership/pgskipper-operator-tests
+  MANAGED_BY: argocd
   SERVICE_NAME: postgres_operator_tests
   TAG: release-2024.2-2.10.0
 vault_env:
   ARTIFACT_DESCRIPTOR_VERSION: pg16-2.10.5-20241215.141230-3-RELEASE
   DEPLOYMENT_RESOURCE_NAME: vault_env-v1
+  DEPLOYMENT_SESSION_ID: 6d5a6ce9-0b55-429d-8877-f7a88dae3d9c
   DEPLOYMENT_VERSION: v1
   DOCKER_TAG: artifactory.qubership.org:17175/banzaicloud/vault-env:2.5.1
   IMAGE_REPOSITORY: artifactory.qubership.org:17175/banzaicloud/vault-env
+  MANAGED_BY: argocd
   SERVICE_NAME: vault_env
   TAG: 2.5.1

--- a/build_effective_set_generator/parameters-processor/src/main/java/org/qubership/cloud/parameters/processor/expression/binding/NamespaceApplicationMap.java
+++ b/build_effective_set_generator/parameters-processor/src/main/java/org/qubership/cloud/parameters/processor/expression/binding/NamespaceApplicationMap.java
@@ -84,7 +84,6 @@ public class NamespaceApplicationMap extends DynamicMap {
             map.put("ARTIFACT_DESCRIPTOR_GROUP_ID", applicationBomDto.getGroupId());
             map.put("ARTIFACT_DESCRIPTOR_VERSION", applicationBomDto.getVersion());
             map.put("ARTIFACT_DESCRIPTOR_MAVEN_REPO", applicationBomDto.getMavenRepo());
-            map.put("DEPLOYMENT_SESSION_ID", applicationBomDto.getDeployerSessionId());
             map.put(APPR_CHART_NAME, applicationBomDto.getAppChartName());
             map.put(SERVICES, applicationBomDto.getServices());
             map.put(CONFIGURATIONS, applicationBomDto.getConfigurations());
@@ -101,6 +100,7 @@ public class NamespaceApplicationMap extends DynamicMap {
                 });
             }
         }
+        map.put("DEPLOYMENT_SESSION_ID", binding.getDeployerInputs().getDeploySessionId());
     }
 
     private ApplicationBomDTO getApplicationBomDto(String appName, String appFileRef) {


### PR DESCRIPTION
# Pull Request

## Summary

Due to an existing bug, DEPLOYMENT_SESSION_ID is not populated in the deployment-parameters.yaml file when no application is present in the namespace.

## Issue

Internally raised as bug

## Breaking Change?

- [ ] Yes
- [x] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

Removed conditional population of DEPLOYMENT_SESSION_ID.
Consolidated DEPLOYMENT_SESSION_ID to a single source of truth.

 (https://github.com/Netcracker/qubership-envgene/blob/main/docs/features/calculator-cli.md#rules-for-adding-comments)

## Tests / Evidence

- Ran instance pipeline 


## Additional Notes

