### PR TITLE
docs: replace appDef metadata enum with free-form hashmap

### DIFF
--- a/docs/envgene-objects.md
+++ b/docs/envgene-objects.md
@@ -2837,15 +2837,8 @@ Application Definitions can also be supplied as user-provided files at `/configu
 
 ```yaml
 # Optional
-metadata:
-  # Optional
-  # Describes the strategy for generating the Helm release name.
-  # Deployment automation relies on this attribute to form a unique Helm release name.
-  # Available options:
-  #   `perApplication` - Unique per application
-  #   `perVersion` - Unique per application version
-  #   `perDeployment` - Unique per deployment of this application
-  helmReleaseNameStrategy: enum[ perApplication, perVersion, perDeployment ]
+# Free-form metadata map. Structure is not specified.
+metadata: hashmap
 # Mandatory
 # Name of the artifact application. This corresponds to the `application` part in the `application:version` notation.
 name: string


### PR DESCRIPTION
# Pull Request

## Summary

Document Application Definition metadata as a free-form hashmap instead of a fixed helmReleaseNameStrategy enum. Aligns the object reference with the intended use case where customers store arbitrary deployment metadata (for example, Argo CD annotations).

## Issue

https://github.com/Netcracker/qubership-envgene/issues/1484

## Breaking Change?

- [ ] Yes
- [X] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

docs
