### PR TITLE
docs: external creds provisioning CLI integration

### DIFF
--- a/docs/envgene-pipelines.md
+++ b/docs/envgene-pipelines.md
@@ -91,6 +91,9 @@ flowchart TB
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
 9. **generate_effective_set**:
+   - **What happens in this job**:
+       1. Generates the Effective Set
+       2. Invokes the [External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md) to materialize each external Credential in its target Secret Store. See [Credential provisioning](/docs/features/external-creds.md#credential-provisioning) for the CI/CD variable contract and failure semantics.
    - **Condition**: Runs if [`GENERATE_EFFECTIVE_SET: true`](/docs/instance-pipeline-parameters.md#generate_effective_set)
    - **Docker image**: [`qubership-effective-set-generator`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-effective-set-generator)
 

--- a/docs/envgene-repository-variables.md
+++ b/docs/envgene-repository-variables.md
@@ -17,6 +17,10 @@
     - [`DOCKER_REGISTRY` (in instance repository)](#docker_registry-in-instance-repository)
     - [`DOCKER_CLOUD_REGISTRY_PROVIDER`](#docker_cloud_registry_provider)
     - [`GCP_SA_KEY`](#gcp_sa_key)
+    - [`VAULT_TOKEN`](#vault_token)
+    - [`GOOGLE_APPLICATION_CREDENTIALS`](#google_application_credentials)
+    - [`AWS_ACCESS_KEY_ID`](#aws_access_key_id)
+    - [`AWS_SECRET_ACCESS_KEY`](#aws_secret_access_key)
   - [Template EnvGene Repository](#template-envgene-repository)
     - [`ENV_TEMPLATE_TEST`](#env_template_test)
     - [`ENVGENE_LOG_LEVEL` (in template repository)](#envgene_log_level-in-template-repository)
@@ -199,6 +203,60 @@ CALCULATOR_CLI_JAVA_OPTIONS="-Djava.util.concurrent.ForkJoinPool.common.parallel
 **Example**: `{"type":"service_account","project_id":"...",...}`
 
 **Note**: Store as a secret (GitHub Actions Secrets) or masked variable. Never commit to the repository. Use a service account with at least `Artifact Registry Reader` role. See [Docker Registry Configuration](/docs/how-to/docker-registry-configuration.md) for details.
+
+### `VAULT_TOKEN`
+
+**Description**: Vault authentication token used by the
+[External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md) to read and write
+credentials in a Vault [Secret Store](/docs/features/external-creds.md#secret-store). When the Secret Store
+identifier is not `default_store`, set the prefixed variant `<id>_VAULT_TOKEN` instead (one set per store). See
+[Store identifier and CI/CD variables](/docs/features/external-creds.md#store-identifier-and-cicd-variables).
+
+**Default Value**: None
+
+**Mandatory**: Yes, if any external Credential references a Vault Secret Store
+
+### `GOOGLE_APPLICATION_CREDENTIALS`
+
+**Description**: GCP service account credentials used by the
+[External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md) to read and write
+credentials in a GCP Secret Manager [Secret Store](/docs/features/external-creds.md#secret-store). When the
+Secret Store identifier is not `default_store`, set the prefixed variant `<id>_GOOGLE_APPLICATION_CREDENTIALS`
+instead. See
+[Store identifier and CI/CD variables](/docs/features/external-creds.md#store-identifier-and-cicd-variables).
+
+The variable holds the full JSON content of the service account key, not a file path - the CLI consumes the
+JSON directly.
+
+**Default Value**: None
+
+**Mandatory**: Yes, if any external Credential references a GCP Secret Manager Secret Store
+
+### `AWS_ACCESS_KEY_ID`
+
+**Description**: AWS access key id used by the
+[External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md) to authenticate to AWS
+Secrets Manager for an AWS [Secret Store](/docs/features/external-creds.md#secret-store). When the Secret Store
+identifier is not `default_store`, set the prefixed variant `<id>_AWS_ACCESS_KEY_ID` instead. Paired with
+[`AWS_SECRET_ACCESS_KEY`](#aws_secret_access_key). See
+[Store identifier and CI/CD variables](/docs/features/external-creds.md#store-identifier-and-cicd-variables).
+
+**Default Value**: None
+
+**Mandatory**: Yes, if any external Credential references an AWS Secrets Manager Secret Store
+
+### `AWS_SECRET_ACCESS_KEY`
+
+**Description**: AWS secret access key used by the
+[External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md) to authenticate to AWS
+Secrets Manager for an AWS [Secret Store](/docs/features/external-creds.md#secret-store). When the Secret Store
+identifier is not `default_store`, set the prefixed variant `<id>_AWS_SECRET_ACCESS_KEY` instead. Paired with
+[`AWS_ACCESS_KEY_ID`](#aws_access_key_id). See
+[Store identifier and CI/CD variables](/docs/features/external-creds.md#store-identifier-and-cicd-variables).
+
+**Default Value**: None
+
+**Mandatory**: Yes, if any external Credential references an AWS Secrets Manager Secret Store
 
 ## Template EnvGene Repository
 

--- a/docs/envgene-repository-variables.md
+++ b/docs/envgene-repository-variables.md
@@ -234,7 +234,7 @@ JSON directly.
 
 ### `AWS_ACCESS_KEY_ID`
 
-**Description**: AWS access key id used by the
+**Description**: AWS access key ID used by the
 [External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md) to authenticate to AWS
 Secrets Manager for an AWS [Secret Store](/docs/features/external-creds.md#secret-store). When the Secret Store
 identifier is not `default_store`, set the prefixed variant `<id>_AWS_ACCESS_KEY_ID` instead. Paired with

--- a/docs/features/external-creds.md
+++ b/docs/features/external-creds.md
@@ -15,8 +15,6 @@
       - [Parameter with VALS reference](#parameter-with-vals-reference)
       - [Parameter with ESO reference](#parameter-with-eso-reference)
       - [External Credential Context](#external-credential-context)
-        - [External Credential Context `credentials` entry](#external-credential-context-credentials-entry)
-        - [External Credential Context `secretStores` entry](#external-credential-context-secretstores-entry)
       - [Pipeline context](#pipeline-context)
       - [Topology context](#topology-context)
       - [EnvGene System Credentials](#envgene-system-credentials)
@@ -38,6 +36,11 @@
       - [External Credential Context `credentials` entry generation](#external-credential-context-credentials-entry-generation)
       - [Pipeline context generation](#pipeline-context-generation)
       - [Topology context generation](#topology-context-generation)
+    - [Credential provisioning](#credential-provisioning)
+      - [Invocation scenarios](#invocation-scenarios)
+      - [Strategy derivation](#strategy-derivation)
+      - [Store identifier and CI/CD variables](#store-identifier-and-cicd-variables)
+      - [Phases and failure handling](#phases-and-failure-handling)
     - [KV Store Structure](#kv-store-structure)
     - [Credential in BG Deployment Cases](#credential-in-bg-deployment-cases)
     - [Use Cases](#use-cases)
@@ -46,6 +49,7 @@
     - [Validation](#validation)
       - [During Environment Instance generation](#during-environment-instance-generation)
       - [During Effective Set generation](#during-effective-set-generation)
+      - [During credential provisioning](#during-credential-provisioning)
       - [During system credentials read](#during-system-credentials-read)
       - [During CMDB import](#during-cmdb-import)
       - [During Credential Rotation](#during-credential-rotation)
@@ -54,8 +58,9 @@
 
 ## Description
 
-This document specifies external credentials for EnvGene: object schemas, Effective Set outputs, and the
-generation algorithms.
+This document specifies external credentials for EnvGene: object schemas, Effective Set outputs, the
+generation algorithms, and credential provisioning into external secret stores via the
+[External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md).
 
 A minimal end-to-end sample (template, instance repository, Effective Set deployment `values/credentials.yaml`
 and `values/external-credentials.yaml` for VALS vs ESO) lives under
@@ -81,8 +86,6 @@ It is necessary to extend EnvGene to support management of Credentials that resi
    supported for template-repository system credentials.
 7. External Secret Store entries for system credentials are pre-created somehow. EnvGene reads them
    but does not create them.
-8. All external Credentials reside in the default Secret Store. Multi-store support is a future step (see
-   [To Do](#to-do)).
 
 ## Proposed Approach
 
@@ -117,12 +120,16 @@ Items 1 and 2 are generated during environment instance generation, 3 is created
 
 When generating the Effective Set, the deployment context contains sensitive parameters whose values are [Parameter with VALS reference](#parameter-with-vals-reference) values when the effective `SECRET_FLOW` for the application is `helm-values`, or [Parameter with ESO reference](#parameter-with-eso-reference) values when the effective `SECRET_FLOW` is `external-values`. See [Deciding between VALS and ESO references](#deciding-between-vals-and-eso-references).
 
-The pipeline context emits sensitive `e2eParameters` whose values resolve to external Credentials into [Pipeline context](#pipeline-context), grouped by the Credential's `secretStore`.
+The pipeline context emits sensitive `e2eParameters` whose values resolve to external Credentials as VALS references into [Pipeline context](#pipeline-context).
 
-In the [External Credential Context](#external-credential-context):
+In the [External Credential Context](#external-credential-context), one `credentials` entry is emitted for each
+[Credential](#credential) with `type: external`. The `create` flag controls the emitted strategy, not whether
+the entry appears.
 
-1. One [External Credential Context `credentials` entry](#external-credential-context-credentials-entry) for each [Credential](#credential) with `type: external` and `create: true`
-2. The [Secret Store](#secret-store) definitions copied for each store referenced by those Credentials
+EnvGene invokes the
+[External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md) against this context
+inside the job that generates the Effective Set. The CLI materializes each Credential in its target Secret
+Store according to the per-entry strategy. See [Credential provisioning](#credential-provisioning).
 
 ### Objects
 
@@ -259,7 +266,7 @@ A [Credential](/docs/envgene-objects.md#credential) of `type: external`:
   type: enum [ usernamePassword, secret, external ]
   # Optional
   # Only for `type: external`
-  # Default: default-store
+  # Default: default_store
   secretStore: string
   # Required when type is `external` (a default may be applied at render time if omitted in the template)
   remoteRefPath: string
@@ -307,6 +314,16 @@ It may contain several secret store objects:
   # Required when type is gcp
   projectId: string
 ```
+
+The map key `<secret-store-name>` is the **store identifier**. It must match the regular expression
+`[A-Za-z_][A-Za-z0-9_]*`, so it is usable as a CI/CD variable prefix at provisioning time (see
+[Store identifier and CI/CD variables](#store-identifier-and-cicd-variables)). Dashes and other characters
+outside that set are rejected by the schema.
+
+The identifier `default_store` is a conventional well-known identifier. The calculator omits the
+`?secret_store_id=` query parameter from emitted VALS URIs when a [Credential](#credential) references
+`secretStore: default_store`. See [VALS reference generation](#vals-reference-generation) for the URI
+construction rule.
 
 > [!WARNING]
 > A detailed description of the Secret Store, its location, and the principles of interacting with it will be added later.
@@ -407,27 +424,29 @@ The Effective Set calculator builds each ESO reference value from:
 ```yaml
 # Example (multi-field credential: one parameter per property)
 global.secrets.streamingPlatform.username:
-  secretStoreId: default-store
+  secretStoreId: default_store
   normalizedSecretName: ocp-05/env-1/env-1-data-management/cdc/cdc-streaming-cred
   secretKeys:
     - remoteKeyName: username
 
 global.secrets.streamingPlatform.password:
-  secretStoreId: default-store
+  secretStoreId: default_store
   normalizedSecretName: ocp-05/env-1/env-1-data-management/cdc/cdc-streaming-cred
   secretKeys:
     - remoteKeyName: password
 
 CONSUL_ADMIN_TOKEN:
-  secretStoreId: default-store
+  secretStoreId: default_store
   normalizedSecretName: ocp-05/postgres-password
 ```
 
 #### External Credential Context
 
 **External Credential Context** is a separate Effective Set context consisting of a single YAML file that the
-Effective Set calculator emits for [Credential](#credential) objects with `type: external` and `create: true`,
-and for the [Secret Store](#secret-store) objects referenced by those Credentials.
+Effective Set calculator emits for every [Credential](#credential) with `type: external`. The context is
+consumed by the [External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md).
+The context shape is a `credentials` map. Secret Store definitions and authentication are out of band - the
+CLI reads them from the job environment.
 
 This context is located at:
 
@@ -440,55 +459,85 @@ This context is located at:
                     └── external-credentials.yaml
 ```
 
-This context, like the others, is produced by the Effective Set calculator.
-
 ```yaml
-# Only Secret Stores that are referenced
-secretStores:
-  <secret-store-name>:
-    type: enum [ vault, azure, aws, gcp ]
-    url: URL
-    # Required when type is vault
-    mountPath: string
-    # Required when type is azure
-    vaultName: string
-    # Required when type is aws
-    region: string
-    # Required when type is gcp
-    projectId: string
-# Only Credential entries with type: external and create: true
+# One entry per Credential with type: external
 credentials:
   <cred-id>:
-    secretStoreId: string
-    normalizedSecretName: string
-    # Omit when the Credential is single-value (no `properties` in the Credential)
-    properties:
-      - name: enum [ username, password ]
+    # Mandatory
+    # VALS reference string that addresses the secret. The string is a path only
+    # (no `#` fragment - the CLI computes per-field paths from the Credential
+    # shape). Carries the `?secret_store_id=<id>` query parameter when the
+    # Credential's secretStore is not `default_store`.
+    vals: string
+    # Mandatory
+    # Derived from Credential.create at generation time:
+    #   - absent or false -> `fail_if_absent`
+    #   - true            -> `create_if_absent`
+    # `overwrite` is reserved for a future rotation flow and is not emitted by
+    # the calculator.
+    strategy: enum [fail_if_absent, create_if_absent, overwrite]
+    # Emitted only when `strategy` is `create_if_absent` (or `overwrite`).
+    # Omitted for `fail_if_absent` because the CLI does not write.
+    #
+    # Calculator-emitted Context carries the reserved marker `_generateValue`.
+    # Two shapes are accepted by the CLI:
+    #
+    #   - Scalar `_generateValue` for a single-value credential in a store that
+    #     addresses the secret directly (gcp, aws, azure).
+    #
+    #   - Map of named field markers for multi-field credentials, or for a
+    #     single-value credential in a store that requires a named field
+    #     (vault, where the secret path must carry a field segment - the
+    #     calculator emits a single `value` field for that case).
+    #
+    # External consumers writing the same context format may substitute concrete
+    # plaintext for any marker - the CLI accepts either.
+    data: string | map
 ```
 
-##### External Credential Context `credentials` entry
+Examples:
 
-An **External Credential Context `credentials` entry** is one map entry under `credentials` in the External
-Credential Context.
+```yaml
+credentials:
+  # Vault multi-field credential, default store, Credential.create: true.
+  cdc-streaming-cred:
+    vals: "ref+vault://kv/data/ocp-05/env-1/env-1-data-management/cdc/cdc-streaming-cred"
+    strategy: create_if_absent
+    data:
+      username: _generateValue
+      password: _generateValue
 
-The Effective Set calculator builds each `credentials` entry from:
+  # Vault single-value credential, default store, Credential.create: true.
+  monitoring-token:
+    vals: "ref+vault://kv/data/ocp-05/monitoring-token"
+    strategy: create_if_absent
+    data:
+      value: _generateValue
 
-1. External [Credential](#credential) with `create: true`
-2. [Secret Store](#secret-store)
+  # Vault single-value credential, default store, Credential.create: false.
+  consul-creds:
+    vals: "ref+vault://kv/data/ocp-05/consul-creds"
+    strategy: fail_if_absent
 
-The step-by-step algorithm is
-[External Credential Context `credentials` entry generation](#external-credential-context-credentials-entry-generation).
+  # GCP single-value credential, default store, Credential.create: true.
+  postgres-password:
+    vals: "ref+gcpsecrets://468649328578/ocp-05--postgres-password"
+    strategy: create_if_absent
+    data: _generateValue
 
-##### External Credential Context `secretStores` entry
+  # GCP multi-field credential, default store, Credential.create: true.
+  smtp-relay-cred:
+    vals: "ref+gcpsecrets://468649328578/ocp-05--smtp-relay-cred"
+    strategy: create_if_absent
+    data:
+      username: _generateValue
+      password: _generateValue
 
-An **External Credential Context `secretStores` entry** is one map entry under `secretStores` in the External
-Credential Context.
-
-The Effective Set calculator copies it from the corresponding [Secret Store](#secret-store) in the instance
-repository for each store ID referenced by a
-[`credentials` entry](#external-credential-context-credentials-entry) in the same file (same keys and fields
-as in the store definition: `type`, `url`, and type-specific settings such as `mountPath`, `vaultName`,
-`region`, `projectId`). Only stores that are actually referenced are included.
+  # AWS single-value credential, named store `prod_store`, Credential.create: false.
+  third-party-api-token:
+    vals: "ref+awssecrets://ocp-05/third-party-api-token?region=eu-west-1&secret_store_id=prod_store"
+    strategy: fail_if_absent
+```
 
 #### Pipeline context
 
@@ -647,7 +696,7 @@ artifactory-cred:
 ##### Authentication to the Secret Store
 
 To read system credentials, EnvGene authenticates to the Secret Store. Each Credential entry selects its
-store through the `secretStore` field on the [Credential](#credential) (default: `default-store`).
+store through the `secretStore` field on the [Credential](#credential) (default: `default_store`).
 Authentication parameters for that store come from two sources:
 
 - the [Secret Store](#secret-store) object in `/configuration/secret-stores.yml` for non-sensitive values.
@@ -865,9 +914,14 @@ Effective Set output is determined by the invoking context.
 **Inputs (per target parameter):**
 
 1. The parameter key.
-2. The resolved [Credential Reference](#credential-reference): `credId`, optional `property` (`username` or `password` when the Credential declares multiple fields).
-3. The rendered [Credential](#credential) for that `credId`: `remoteRefPath`, `secretStore`, and whether the Credential has a `properties` list (multi-field vs single-value secret).
-4. The [Secret Store](#secret-store) entry `secretStores[<secretStoreId>]` for `Credential.secretStore`, including `type` and type-specific fields (`mountPath`, `vaultName`, `region`, `projectId`).
+2. The resolved [Credential Reference](#credential-reference).
+3. The rendered [Credential](#credential) for that `credId`.
+4. The [Secret Store](#secret-store) entry referenced by the Credential's `secretStore`.
+
+> [!NOTE]
+> Step 1 (normalization) and step 3 (base URI plus multi-store query) below are reused by
+> [External Credential Context `credentials` entry generation](#external-credential-context-credentials-entry-generation),
+> which builds VALS references for a different output and without a Credential Reference (no fragment suffix).
 
 **Algorithm:**
 
@@ -884,7 +938,9 @@ Effective Set output is determined by the invoking context.
        - **`vault`**: use `#/value` as the logical key for the single JSON field vals should read.
        - **`azure`, `aws`, `gcp`**: the secret is treated as plain text. **Omit** the `#/...` fragment entirely.
 
-3. Build the **vals URI** by concatenating a **base URI** (scheme, host path, and store-specific segments) with the **fragment suffix** from step 2, if any:
+3. Build the **vals URI** by concatenating, in order, a **base URI** (scheme, host path, and store-specific
+   segments), a **multi-store query** for the target [Secret Store](#secret-store), and the **fragment
+   suffix** from step 2:
 
    - **Base URI** depends on the [Secret Store](#secret-store) `type` (use `normalizedSecretName` from step 1 and fields from the Secret Store):
      - **`vault`:** `ref+vault://<mountPath>/data/<normalizedSecretName>` (`mountPath` = KV mount, for example `secret`).
@@ -892,15 +948,20 @@ Effective Set output is determined by the invoking context.
      - **`aws`:** `ref+awssecrets://<normalizedSecretName>?region=<region>` (`region` from the Secret Store as a query parameter).
      - **`gcp`:** `ref+gcpsecrets://<projectId>/<normalizedSecretName>` (`projectId` from the Secret Store).
 
-   - **Fragment suffix:** whatever step 2 produced as the string starting with `#` (for example `#/username` or `#/value`). If step 2 said to **omit** the fragment (single-value plain text on Azure, AWS, or GCP), the suffix is empty - the final URI is exactly the base URI with no `#/...` part.
+   - **Multi-store query:** append `?secret_store_id=<Credential.secretStore>` when `Credential.secretStore` is
+     not `default_store`. Otherwise, the multi-store query is empty. For `aws`, the base URI already carries
+     `?region=<region>`, so use `&secret_store_id=<id>` instead. The provisioning CLI uses this query to look up
+     the right per-store CI/CD variable prefix (see
+     [Store identifier and CI/CD variables](#store-identifier-and-cicd-variables)). VALS Argo recognizes the
+     same query parameter at deploy time for multi-store routing.
 
-   - **Final URI:** `base URI` + `fragment suffix`.
+   - **Fragment suffix:** whatever step 2 produced as the string starting with `#` (for example `#/username` or `#/value`). If step 2 said to **omit** the fragment (single-value plain text on Azure, AWS, or GCP), the suffix is empty - the final URI has no `#/...` part.
+
+   - **Final URI:** `base URI` + `multi-store query` + `fragment suffix`.
 
 4. Produce `<parameter-key>: "<vals-uri>"` (string scalar). The exact key is the same path as in the
    source parameter (for example `global.secrets.streamingPlatform.username`). Placement in the
-   Effective Set output is the responsibility of the invoking context (deployment context: per-application
-   `external-credentials.yaml`. Pipeline context: under the `<secret-store-id>` group in
-   `effective-set/pipeline/external-credentials.yaml`).
+   Effective Set output is the responsibility of the invoking context.
 
 #### ESO reference generation
 
@@ -914,9 +975,9 @@ The emitted shape per parameter is the object described under [Parameter with ES
 **Inputs (per target parameter in the deployment context):**
 
 1. The parameter key.
-2. The resolved [Credential Reference](#credential-reference): `credId`, optional `property` (`username` or `password` when the Credential declares multiple fields).
-3. The rendered [Credential](#credential) for that `credId`: `remoteRefPath`, `secretStore`, and whether the Credential has a `properties` list (multi-field vs single-value secret).
-4. The [Secret Store](#secret-store) entry `secretStores[<secretStoreId>]` for `Credential.secretStore`, including `type` and type-specific fields.
+2. The resolved [Credential Reference](#credential-reference).
+3. The rendered [Credential](#credential) for that `credId`.
+4. The [Secret Store](#secret-store) entry referenced by the Credential's `secretStore`.
 
 **Algorithm:**
 
@@ -951,43 +1012,53 @@ The emitted shape per parameter is the object described under [Parameter with ES
 
 #### External Credential Context `credentials` entry generation
 
-This applies while the Effective Set calculator builds the **[External Credential Context](#external-credential-context)**.
+This applies while the Effective Set calculator builds the
+**[External Credential Context](#external-credential-context)**. The emitted shape per `credId` is the YAML
+schema shown under [External Credential Context](#external-credential-context).
 
-1. The Effective Set External Credential Context includes [Credentials](#credential) with `type: external` and `create: true`.
-2. Credential References are **not** inputs: each `credentials` entry is derived from [Credential](#credential) and [Secret Store](#secret-store) data only.
+**Inputs (for each external Credential):**
 
-The emitted shape per `credId` is the object described under [External Credential Context `credentials` entry](#external-credential-context-credentials-entry).
-
-**Inputs (per Credential):**
-
-1. The rendered [Credential](#credential): `remoteRefPath`, `credId`, `secretStore`, optional `properties`, and `create: true`.
-2. The [Secret Store](#secret-store) entry `secretStores[<secretStoreId>]` for `Credential.secretStore`, including `type`.
+1. The rendered [Credential](#credential).
+2. The [Secret Store](#secret-store) entry referenced by the Credential's `secretStore`.
 
 **Algorithm:**
 
-1. Select every [Credential](#credential) that is `type: external`, `create: true`. If there are none, emit an empty `credentials` map.
+1. Select every [Credential](#credential) that is `type: external`. If there are none, emit an empty
+   `credentials` map.
 
-2. **Top-level `secretStores`:** for each distinct `secretStoreId` referenced by the selected Credentials, copy the [Secret Store](#secret-store) definition from the instance repository.
+2. For each selected Credential, build the entry as follows.
 
-3. For each selected Credential, emit the following at `credentials.<credId>`:
+   **`vals`** is built by reusing [VALS reference generation](#vals-reference-generation) sub-steps:
 
-   ```yaml
-   # Multi-field Credential
-   <credId>:
-     secretStoreId: <Credential.secretStore>
-     normalizedSecretName: <computed>
-     properties: <Credential.properties>
+   1. Apply step 1 to compute `normalizedSecretName`.
+   2. Apply the **Base URI** and **Multi-store query** sub-components of step 3, joined in order. The
+      **Fragment suffix** sub-component is **empty** for the Context - it addresses the secret as a whole, and the
+      CLI computes per-field paths from the Credential shape and from `data`.
 
-   # Single-value Credential
-   <credId>:
-     secretStoreId: <Credential.secretStore>
-     normalizedSecretName: <computed>
-   ```
+   **`strategy`** is derived from `Credential.create`:
 
-   - `normalizedSecretName` is computed via [Normalization to `normalizedSecretName`](#normalization-to-normalizedsecretname). If normalization fails, fail the Effective Set generation.
-   - The `properties` key is present only when `Credential.properties` is defined (multi-field); it is omitted for single-value Credentials.
+   | `Credential.create`   | Emitted `strategy` |
+   |-----------------------|--------------------|
+   | absent or `false`     | `fail_if_absent`   |
+   | `true`                | `create_if_absent` |
 
-4. Write the combined payload (`secretStores` from step 2, `credentials` from step 3) to `external-credentials.yaml` at the path defined in [External Credential Context](#external-credential-context).
+   The `overwrite` strategy is reserved for a future rotation flow and is not emitted by the calculator in this
+   release. The CLI accepts it for forward compatibility (see [Credential provisioning](#credential-provisioning)).
+
+   **`data`** is emitted only when `strategy` is `create_if_absent`. For `fail_if_absent`, omit the `data`
+   field entirely - the CLI does not write, so `data` has no use. When emitted, the value is the reserved
+   marker `_generateValue`, packaged according to the Credential and Secret Store shape:
+
+   - **Multi-field Credential** (`Credential.properties` is present): emit a map with one entry per property
+     `name`, each value set to `_generateValue`.
+   - **Single-value Credential** in a store that addresses the secret directly (`gcp`, `aws`, `azure`): emit the
+     scalar marker `_generateValue`.
+   - **Single-value Credential** in `vault` (the Vault path must carry a field segment): emit a map with a single
+     `value` field set to `_generateValue`. The `value` field name matches the convention used by
+     [VALS reference generation](#vals-reference-generation) for single-value vault secrets.
+
+3. Write the `credentials` map from step 2 to `external-credentials.yaml` at the path defined in
+   [External Credential Context](#external-credential-context).
 
 #### Pipeline context generation
 
@@ -1013,9 +1084,52 @@ resolves to an external Credential, the Effective Set calculator constructs a VA
 The file is emitted at `effective-set/topology/external-credentials.yaml` regardless of whether any
 Topology field resolves to an external Credential.
 
+### Credential provisioning
+
+Provisioning is the act of materializing each external [Credential](#credential) in its target
+[Secret Store](#secret-store). The Effective Set calculator does not perform writes - it emits the
+[External Credential Context](#external-credential-context) describing what to provision. A dedicated CLI reads
+that context and applies the strategy attached to each entry.
+
+The CLI is specified in [External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md).
+This section describes how EnvGene generates the context and invokes the CLI.
+
+#### Invocation scenarios
+
+EnvGene invokes the CLI in apply mode inside the
+[`generate_effective_set`](/docs/envgene-pipelines.md) job, once per Environment Instance, after the calculator
+writes the External Credential Context. External consumers can produce the same context format (hand-authored
+or generated by a non-EnvGene system) and run the CLI directly.
+
+#### Strategy derivation
+
+Per-entry strategies and their semantics are defined by the calculator in
+[External Credential Context `credentials` entry generation](#external-credential-context-credentials-entry-generation)
+and executed by the
+[CLI strategy enum](/docs/features/external-creds-provisioning-cli.md#strategy-enum).
+
+#### Store identifier and CI/CD variables
+
+The operator sets per-store authentication variables on the EnvGene Instance repository before running the
+pipeline:
+[`VAULT_TOKEN`](/docs/envgene-repository-variables.md#vault_token),
+[`GOOGLE_APPLICATION_CREDENTIALS`](/docs/envgene-repository-variables.md#google_application_credentials),
+[`AWS_ACCESS_KEY_ID`](/docs/envgene-repository-variables.md#aws_access_key_id),
+[`AWS_SECRET_ACCESS_KEY`](/docs/envgene-repository-variables.md#aws_secret_access_key). For Credentials
+referencing a non-default store, the CLI reads the prefixed variants (`<id>_VAULT_TOKEN`, and so on) - see
+[Secret Store](#secret-store) and
+[CLI environment variables](/docs/features/external-creds-provisioning-cli.md#environment-variables).
+
+#### Phases and failure handling
+
+A pre-flight or dry-run failure short-circuits the CLI before any write and fails the job. Per-credential
+failures during processing do not stop the run - the CLI continues and exits non-zero at the end. EnvGene
+propagates the CLI exit code as the job result. See
+[CLI behaviour](/docs/features/external-creds-provisioning-cli.md#behaviour) for phase details.
+
 ### KV Store Structure
 
-The location of a Credential within the KV Store structure is determined at the moment the Credential is created, i.e., during the deployment of the system/application that the Credential describes.
+The location of a Credential within the KV Store structure is determined at the moment the Credential is created, that is, during the deployment of the system/application that the Credential describes.
 
 ```text
 ├── services
@@ -1115,9 +1229,6 @@ Example:
    (`$type: credRef`) appears in `technicalConfigurationParameters`. The runtime context does not support
    sensitive parameters via external Credentials.
 
-5. **Default store only.** Every external [Credential](#credential) has `secretStore` unset or equal to
-   `default-store`. Multi-store support is a future step (see [To Do](#to-do)).
-
 #### During Effective Set generation
 
 1. **Secret store binding.** Every `Credential.secretStore` matches an entry in
@@ -1143,6 +1254,28 @@ Example:
    A reference that reads one value matches a Credential without `properties`. A reference that reads
    multiple named fields matches a Credential whose `properties` lists every required name. Per-reference
    fields are documented in the [Built-in credential references](#built-in-credential-references) section.
+
+#### During credential provisioning
+
+These checks are performed by the
+[External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md), not by the Effective
+Set calculator. Failures surface in the [`generate_effective_set`](/docs/envgene-pipelines.md) job log and fail
+the job. See [CLI behaviour](/docs/features/external-creds-provisioning-cli.md#behaviour) for exact phase
+semantics.
+
+1. **CI/CD variables present.** For every distinct Secret Store referenced by `vals` fields in the External
+   Credential Context, the corresponding environment variables (see
+   [Store identifier and CI/CD variables](#store-identifier-and-cicd-variables)) are present in the job
+   environment.
+
+2. **Store authentication.** Every referenced Secret Store accepts authentication with its environment
+   variables.
+
+3. **Per-strategy prerequisite.** Every `credentials` entry satisfies the prerequisite check defined for its
+   `strategy`: existence for `fail_if_absent`, write authorization for `create_if_absent` and `overwrite`.
+
+A per-credential prerequisite failure does not stop the run. The CLI continues with the remaining entries and
+exits non-zero at the end.
 
 #### During system credentials read
 
@@ -1175,13 +1308,6 @@ Git operations, and others).
 2. Support template composition
 3. Support AWS Secrets Manager as a Secret Store for system credentials
 4. Support Azure Key Vault as a Secret Store for system credentials
-5. Support multi-store for external Credentials. Encode store identity in the VALS URL via a
-   `?secret_store_id=<store-id>` query parameter, extending
-   [VALS reference generation](#vals-reference-generation) to emit it for non-default stores. Applies to
-   the deploy, pipeline, and topology contexts.
-6. Revisit the [External Credential Context](#external-credential-context) shape after the multi-store
-   decision lands. With per-Credential `secret_store_id` in the VALS URL, the current `secretStores` map
-   and `secretStoreId` field may need restructuring.
 
 ## Open questions
 

--- a/schemas/secret-stores.schema.json
+++ b/schemas/secret-stores.schema.json
@@ -3,54 +3,57 @@
   "type": "object",
   "title": "Secret Stores configuration",
   "description": "Instance repository configuration for external secret stores used by external Credentials. See /docs/features/external-creds.md",
-  "additionalProperties": {
-    "type": "object",
-    "required": ["type", "url"],
-    "additionalProperties": false,
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": ["vault", "azure", "aws", "gcp"],
-        "description": "Backend type"
+  "additionalProperties": false,
+  "patternProperties": {
+    "^[A-Za-z_][A-Za-z0-9_]*$": {
+      "type": "object",
+      "required": ["type", "url"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["vault", "azure", "aws", "gcp"],
+          "description": "Backend type"
+        },
+        "url": {
+          "type": "string",
+          "description": "Endpoint or connection URL for the store"
+        },
+        "mountPath": {
+          "type": "string",
+          "description": "Required when type is vault (KV mount path)"
+        },
+        "vaultName": {
+          "type": "string",
+          "description": "Required when type is azure"
+        },
+        "region": {
+          "type": "string",
+          "description": "Required when type is aws"
+        },
+        "projectId": {
+          "type": "string",
+          "description": "Required when type is gcp"
+        }
       },
-      "url": {
-        "type": "string",
-        "description": "Endpoint or connection URL for the store"
-      },
-      "mountPath": {
-        "type": "string",
-        "description": "Required when type is vault (KV mount path)"
-      },
-      "vaultName": {
-        "type": "string",
-        "description": "Required when type is azure"
-      },
-      "region": {
-        "type": "string",
-        "description": "Required when type is aws"
-      },
-      "projectId": {
-        "type": "string",
-        "description": "Required when type is gcp"
-      }
-    },
-    "allOf": [
-      {
-        "if": { "properties": { "type": { "const": "vault" } } },
-        "then": { "required": ["mountPath"] }
-      },
-      {
-        "if": { "properties": { "type": { "const": "azure" } } },
-        "then": { "required": ["vaultName"] }
-      },
-      {
-        "if": { "properties": { "type": { "const": "aws" } } },
-        "then": { "required": ["region"] }
-      },
-      {
-        "if": { "properties": { "type": { "const": "gcp" } } },
-        "then": { "required": ["projectId"] }
-      }
-    ]
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "vault" } } },
+          "then": { "required": ["mountPath"] }
+        },
+        {
+          "if": { "properties": { "type": { "const": "azure" } } },
+          "then": { "required": ["vaultName"] }
+        },
+        {
+          "if": { "properties": { "type": { "const": "aws" } } },
+          "then": { "required": ["region"] }
+        },
+        {
+          "if": { "properties": { "type": { "const": "gcp" } } },
+          "then": { "required": ["projectId"] }
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary

Wire the [External Credentials provisioning CLI](https://github.com/Netcracker/qubership-envgene/blob/main/docs/features/external-creds-provisioning-cli.md) into the EnvGene instance pipeline. The Effective Set calculator emits an External Credential Context that the CLI consumes to materialize each external Credential in its target Secret Store.

Tracks #1494, #1495, #1496 under umbrella #1380.

## Changes

- **`docs/features/external-creds.md`**:
  - Reshape the External Credential Context to a `credentials` map of `{vals, strategy, data}` entries. Drop the `secretStores` block and the separate `secretStoreId` / `normalizedSecretName` fields - the CLI infers the target store from the VALS reference scheme.
  - Rewrite the `External Credential Context credentials entry generation` algorithm. Every external Credential is emitted; `strategy` is derived from `Credential.create`; `data` carries the reserved `_generateValue` marker only for write strategies.
  - Extend VALS reference generation step 3 with a multi-store query sub-component: `?secret_store_id=<id>` is appended for non-default stores (`&secret_store_id=<id>` after the AWS `?region=` query).
  - Add a `Credential provisioning` section covering invocation, strategy derivation, store identifier and CI/CD variables, and failure handling.
  - Add a `During credential provisioning` validation phase.
  - Internal consistency fixes: `default-store` → `default_store`, remove the `Default store only` rule that contradicted multi-store, drop stale Pipeline-context-grouped-by-secretStore wording, remove obsolete To Do items now in scope.
- **`schemas/secret-stores.schema.json`**: constrain Secret Store map keys to `^[A-Za-z_][A-Za-z0-9_]*$` so each identifier is usable as a CI/CD variable prefix.
- **`docs/envgene-repository-variables.md`**: document the four per-store authentication CI/CD variables (`VAULT_TOKEN`, `GOOGLE_APPLICATION_CREDENTIALS`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) and their prefixed variants for non-default stores.
- **`docs/envgene-pipelines.md`**: update `generate_effective_set` job description to mention the CLI invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)