### PR TITLE
docs: deploy_param image param under global on service-name collision

### DIFF
--- a/docs/features/calculator-cli.md
+++ b/docs/features/calculator-cli.md
@@ -763,7 +763,11 @@ For each component with the MIME type `application/octet-stream`, if its `.compo
 - The key is the value of `.components[].properties[?name=deploy_param].value`.
 - The value is the value of `.components[].properties[?name=full_image_name].value`.
 
-If the key of such parameter (i.e., `.components[].properties[?name=deploy_param].value`) matches the name of one of the [services](#version-20-service-inclusion-criteria-and-naming-convention), the parameter is **not** added.
+If the key of such parameter (i.e., `.components[].properties[?name=deploy_param].value`) matches the name of one of
+the [services](#version-20-service-inclusion-criteria-and-naming-convention), it is **not** added at the root level,
+because that root-level key is already occupied by the service's section. Instead, it is added only under the `global`
+key. Through the per-service alias (`<service-name>: *id001`), the parameter remains available within each service's
+section under the same key.
 
 All such parameters are added to `deployment-parameters.yaml` as `<image-params-key>: <image-params-value>`, as described in the structure [above](#version-20deployment-parameter-context-deployment-parametersyaml).
 


### PR DESCRIPTION
## What

Updates [Image parameters derived from `deploy_param`](https://github.com/Netcracker/qubership-envgene/blob/main/docs/features/calculator-cli.md#version-20-image-parameters-derived-from-deploy_param)
in `calculator-cli.md`.

Previously, when a `deploy_param`-derived image parameter key matched a service name, the parameter was
dropped. This documents the corrected behavior: the parameter is emitted only under the `global` key, so the
root-level `<service-name>` key stays the per-service section, and the image remains reachable within each
service's section through the `<service-name>: *id001` alias.

## Why

Dropping the parameter left charts that read the image via `.Values.<service-name>` (resolved inside the
service scope) with no value. Placing it under `global` resolves the collision without losing the image.

Implementation tracked in #1504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)