### PR TITLE
feat: Add duplicate check validation for SD processing

### DIFF
--- a/scripts/build_env/process_sd.py
+++ b/scripts/build_env/process_sd.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+from collections import Counter
 from os import path, getenv
 from pathlib import Path
 
@@ -30,6 +31,49 @@ WORK_DIR = getenv_with_error('CI_PROJECT_DIR')
 BASE_ENV_PATH = f"{WORK_DIR}/environments/{CLUSTER_NAME}/{ENVIRONMENT_NAME}"
 APP_DEFS_PATH = f"{BASE_ENV_PATH}/AppDefs"
 REG_DEFS_PATH = f"{BASE_ENV_PATH}/RegDefs"
+
+
+def collect_duplicate_apps(applications: list) -> dict:
+    counter = Counter()
+    for app in applications:
+        if isinstance(app, dict):
+            counter[(app.get("version", ""), app.get("deployPostfix", ""))] += 1
+    return {k: v for k, v in counter.items() if v > 1}
+
+
+def validate_input_sd_no_duplicates(sds: list):
+    for idx, sd in enumerate(sds):
+        duplicates = collect_duplicate_apps(sd.get("applications", []))
+        if duplicates:
+            lines = "\n".join(
+                f"  - '{name_ver}' with deployPostfix '{postfix}' appears {count} time(s)"
+                for (name_ver, postfix), count in duplicates.items()
+            )
+            msg = (
+                f"Duplicate applications detected in SD[{idx}]:\n"
+                f"{lines}\n"
+                "Each application must be uniquely identified by its name,version and deployPostfix.\n"
+                "Remove the duplicate entries and re-run the pipeline."
+            )
+            logger.error(msg)
+            raise ValueError(msg)
+
+
+def validate_full_sd_no_duplicates(sd_path: Path, full_sd: dict):
+    duplicates = collect_duplicate_apps(full_sd.get("applications", []))
+    if duplicates:
+        lines = "\n".join(
+            f"  - '{name_ver}' with deployPostfix '{postfix}' appears {count} time(s)"
+            for (name_ver, postfix), count in duplicates.items()
+        )
+        msg = (
+            f"Duplicate applications detected in the existing Full SD ({sd_path}):\n"
+            f"{lines}\n"
+            "Each application must be uniquely identified by its name, version, and deployPostfix.\n"
+            "Remove the duplicate entries and re-run the pipeline."
+        )
+        logger.error(msg)
+        raise ValueError(msg)
 
 
 def handle_deploy_postfix_namespace_transformation(sd_data: dict, namespace_dict: dict) -> dict:
@@ -199,6 +243,8 @@ def extract_sds_from_json(env, base_sd_path: Path, sd_data, effective_merge_mode
             transformed_data.append(transformed_item)
     else:
         transformed_data = handle_deploy_postfix_namespace_transformation(sds_from_pipe, namespace_dict)
+    sds_list = transformed_data if isinstance(transformed_data, list) else [transformed_data]
+    validate_input_sd_no_duplicates(sds_list)
     full_sd_from_pipe = multiply_sds_to_single(transformed_data, effective_merge_mode)
     validate_applications(full_sd_from_pipe, effective_merge_mode)
 
@@ -220,6 +266,8 @@ def extract_sds_from_json(env, base_sd_path: Path, sd_data, effective_merge_mode
         if not helper.check_file_exists(sd_path):
             helper.writeYamlToFile(sd_path, full_sd_from_pipe)
         else:
+            full_sd_yaml = helper.openYaml(sd_path)
+            validate_full_sd_no_duplicates(sd_path, full_sd_yaml)
             helper.writeYamlToFile(sd_delta_path, full_sd_from_pipe)
             # Call merge_sd with correct merge function
             selected_merge_function = MERGE_METHODS.get(effective_merge_mode)

--- a/scripts/build_env/tests/sd/test_process_sd_local.py
+++ b/scripts/build_env/tests/sd/test_process_sd_local.py
@@ -25,12 +25,18 @@ TEST_CASES_POSITIVE = [
     "TC-001-017",
 ]
 
+TEST_CASES_NEGATIVE = {
+    "TC-001-018": ValueError,
+    "TC-001-019": ValueError,
+}
+
 test_suits_map = {
     "basic_not_first": ["TC-001-010", "TC-001-012"],
     "basic_first": ["TC-001-002", "TC-001-004"],
     "exclude": ["TC-001-014", "TC-001-016"],
     "extended": ["TC-001-017"],
-    "replace": ["TC-001-008", "TC-001-006"]
+    "replace": ["TC-001-008", "TC-001-006"],
+    "full_sd_duplicate": ["TC-001-019"],
 }
 
 FEATURE_TEST_DIR = "test_handle_sd"
@@ -60,4 +66,16 @@ class TestSdProcessArtifact(BaseTest):
         handle_sd(env, sd_source_type, sd_version, sd_data, sd_delta, sd_merge_mode)
 
         assert_sd_contents(self.test_data_dir, env.env_path, test_case_name, test_suits_map)
+        logger.info(f"=====SUCCESS - {test_case_name}======")
+
+    @pytest.mark.parametrize("test_case_name,expected_exception", [(k, v) for k, v in TEST_CASES_NEGATIVE.items()])
+    def test_sd_negative(self, test_case_name, expected_exception):
+        env = Environment(self.output_dir, "cluster-01", "env-01")
+        do_prerequisites(SD_FILE_NAME, self.test_data_dir, self.output_dir, test_case_name, env, test_suits_map)
+        logger.info(f"Starting SD test:\n\tTest case: {test_case_name}")
+
+        sd_data, sd_source_type, sd_version, sd_delta, sd_merge_mode = load_test_pipeline_sd_data(self.test_data_dir, test_case_name)
+        with pytest.raises(expected_exception):
+            handle_sd(env, sd_source_type, sd_version, sd_data, sd_delta, sd_merge_mode)
+
         logger.info(f"=====SUCCESS - {test_case_name}======")

--- a/scripts/build_env/tests/sd/test_sd_helpers.py
+++ b/scripts/build_env/tests/sd/test_sd_helpers.py
@@ -29,6 +29,8 @@ def do_prerequisites(sd, test_sd_dir, output_dir, test_case_name, env, test_suit
         writeYamlToFile(target_sd_dir.joinpath(sd), openYaml(pr_dir.joinpath("exclude").joinpath(sd)))
     elif test_case_name in test_suits_map["extended"]:
         writeYamlToFile(target_sd_dir.joinpath(sd), openYaml(pr_dir.joinpath("extended").joinpath(sd)))
+    elif test_case_name in test_suits_map.get("full_sd_duplicate", []):
+        writeYamlToFile(target_sd_dir.joinpath(sd), openYaml(pr_dir.joinpath("duplicate").joinpath(sd)))
 
 
 def assert_sd_contents(test_sd_dir, output_dir, test_case_name, test_suits_map):

--- a/test_data/test_handle_sd/TC-001-018/TC-001-018.yaml
+++ b/test_data/test_handle_sd/TC-001-018/TC-001-018.yaml
@@ -1,0 +1,3 @@
+SD_DATA: '[{"version":2.1,"type":"solutionDeploy","deployMode":"composite","applications":[{"version":"resource-inventory.topology-analysis:1.2.3","deployPostfix":"oss"},{"version":"resource-inventory.topology-analysis:1.2.3","deployPostfix":"oss"}]}]'
+SD_SOURCE_TYPE: 'json'
+SD_DELTA: False

--- a/test_data/test_handle_sd/TC-001-019/TC-001-019.yaml
+++ b/test_data/test_handle_sd/TC-001-019/TC-001-019.yaml
@@ -1,0 +1,4 @@
+SD_DATA: '{"version":2.1,"type":"solutionDeploy","deployMode":"composite","applications":[{"version":"postgres:1.32.7","deployPostfix":"postgresql-new"}]}'
+SD_SOURCE_TYPE: 'json'
+SD_DELTA: False
+SD_REPO_MERGE_MODE: 'basic-merge'

--- a/test_data/test_handle_sd/prerequisites/duplicate/sd.yaml
+++ b/test_data/test_handle_sd/prerequisites/duplicate/sd.yaml
@@ -1,0 +1,8 @@
+version: 2.1
+type: solutionDeploy
+deployMode: composite
+applications:
+  - version: resource-inventory.topology-analysis:1.2.3
+    deployPostfix: oss
+  - version: resource-inventory.topology-analysis:1.2.3
+    deployPostfix: oss


### PR DESCRIPTION
## Summary

Add duplicate application validation to SD processing to prevent cryptic Java deserialization errors. Two checks: (1) Input SD check validates incoming SDs for duplicate `(name, version, deployPostfix)` before any write, and (2) Full SD check validates existing `sd.yaml` for duplicates before merge. Both raise clear error messages and abort without writing.

## Issue

Fixes PDPLDEVOPS-25568

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`scripts/build_env` — SD processing logic and tests

## Implementation Notes

- Added `collect_duplicate_apps`, `validate_input_sd_no_duplicates`, `validate_full_sd_no_duplicates` to `process_sd.py`
- Input SD check hooks into `extract_sds_from_json` after namespace transformation
- Full SD check hooks into merge branch after reading existing `sd.yaml`, before delta write
- `REPLACE` mode excluded from full SD check (no merge occurs)
- Error messages match ticket specification

## Tests / Evidence

- Added `TEST_CASES_NEGATIVE` with TC-001-018 (input duplicate) and TC-001-019 (full SD duplicate)
- Added `test_sd_negative1 parametrized test expecting `ValueError`
- Extended `do_prerequisites` with `"full_sd_duplicate"` category
- Created test data for both scenarios

## Additional Notes

