### PR TITLE
docs: align app-reg-defs with implementation, rename term to definition overrides

### DIFF
--- a/docs/envgene-objects.md
+++ b/docs/envgene-objects.md
@@ -2262,7 +2262,7 @@ The filename must match the value of the `name` attribute.
 
 **Location:** `/regdefs/<registry-name>.yml`
 
-Registry Definitions can also be supplied as user-provided files at `/configuration/regdefs/<registry-name>.yml`. A user-provided file replaces a template-rendered definition with a matching filename, or adds a new effective definition when no template counterpart exists. See [User-provided files](/docs/features/app-reg-defs.md#user-provided-files) for the file-based mechanism.
+Registry Definitions can also be supplied as definition overrides at `/configuration/regdefs/<registry-name>.yml`. A definition override replaces a template-rendered definition with a matching filename, or adds a new effective definition when no template counterpart exists. See [Definition overrides](/docs/features/app-reg-defs.md#definition-overrides) for the file-based mechanism.
 
 The `credentialsId` field may reference an external Credential. See
 [EnvGene System Credentials](/docs/features/external-creds.md#envgene-system-credentials).
@@ -2843,7 +2843,7 @@ The filename must match the value of the `name` attribute.
 
 **Location:** `/appdefs/<application-name>.yml`
 
-Application Definitions can also be supplied as user-provided files at `/configuration/appdefs/<application-name>.yml`. A user-provided file replaces a template-rendered definition with a matching filename, or adds a new effective definition when no template counterpart exists. See [User-provided files](/docs/features/app-reg-defs.md#user-provided-files) for the file-based mechanism.
+Application Definitions can also be supplied as definition overrides at `/configuration/appdefs/<application-name>.yml`. A definition override replaces a template-rendered definition with a matching filename, or adds a new effective definition when no template counterpart exists. See [Definition overrides](/docs/features/app-reg-defs.md#definition-overrides) for the file-based mechanism.
 
 ```yaml
 # Optional

--- a/docs/features/app-reg-defs.md
+++ b/docs/features/app-reg-defs.md
@@ -1,320 +1,223 @@
 # Application and Registry Definition
 
 - [Application and Registry Definition](#application-and-registry-definition)
-  - [Problem statement](#problem-statement)
-  - [Proposed approach](#proposed-approach)
+  - [Overview](#overview)
   - [Definition sources](#definition-sources)
     - [Templates](#templates)
-    - [User-provided files](#user-provided-files)
-      - [Filename matching](#filename-matching)
-      - [Replacement semantics](#replacement-semantics)
-      - [Interaction with appdefs.overrides macro](#interaction-with-appdefsoverrides-macro)
+    - [Definition overrides](#definition-overrides)
     - [External Job (deprecated)](#external-job-deprecated)
-  - [Processing order](#processing-order)
+  - [Processing](#processing)
   - [Output layout](#output-layout)
-    - [Rendered output](#rendered-output)
     - [Placement modes](#placement-modes)
-  - [Migration from per-environment layout](#migration-from-per-environment-layout)
   - [Consumers](#consumers)
     - [EnvGene](#envgene)
     - [External systems](#external-systems)
-    - [Export to external CMDB systems](#export-to-external-cmdb-systems)
+    - [Import into external CMDB systems](#import-into-external-cmdb-systems)
   - [Template transformation](#template-transformation)
+  - [See also](#see-also)
 
-## Problem statement
+## Overview
 
-To work with artifacts, a short, human-readable identifier in the format `application:version` is used. This identifier
-should uniquely specify the artifact and where it is stored.
-
-Using this kind of identifier means need to:
-
-1. Make sure that each `application` in `application:version` is unique
-2. Be able to resolve `application:version` into all the parameters needed to download the artifact (like registry URL,
-   registry credentials, Maven GAV coordinates, Docker image group/name/tag, etc.)
-
-Also need to support:
-
-1. Identifying artifacts of different types (Maven, Docker, npm, etc.)
-2. Identifying artifacts stored in different registries (Artifactory, Nexus, GCR, etc.)
-
-## Proposed approach
-
-EnvGene uses two types of objects to resolve `application:version` pointers into all the parameters needed to download
-an artifact:
+Using Application and Registry Definition, EnvGene resolves an `application:version` pointer into the parameters
+needed to download the artifact:
 
 1. [Application Definition](/docs/envgene-objects.md#application-definition) (AppDef) - describes an application
-   artifact (artifact ID, group ID) and references a Registry Definition. Lives in `/appdefs/<application-name>.yml`.
-2. [Registry Definition](/docs/envgene-objects.md#registry-definition) (RegDef) - describes a registry (URL,
-   credentials, type). Lives in `/regdefs/<registry-name>.yml`.
+   artifact and references a Registry Definition.
+2. [Registry Definition](/docs/envgene-objects.md#registry-definition) (RegDef) - describes a registry and its access
+   parameters.
 
-EnvGene assembles effective definitions from three sources:
+An AppDef, and a RegDef for its registry, must exist for every Solution Descriptor (SD) used in the repository and
+for every application the SDs reference.
+
+Effective definitions live in the root-level folders of the instance repository:
+
+```text
+/appdefs/<name>.yml
+/regdefs/<name>.yml
+```
+
+Depending on the [placement mode](#placement-modes), EnvGene also maintains the per-environment folders
+`/environments/<cluster>/<env>/AppDefs/` and `/environments/<cluster>/<env>/RegDefs/`, which hold the
+definitions of the current build rather than a copy of the root-level content.
+
+EnvGene assembles effective definitions from two sources:
 
 - **Templates** - Jinja or plain YAML files in the template repository, rendered with the current environment context.
-- **User-provided files** (YAML in `/configuration/appdefs/`, `/configuration/regdefs/`) - replace template-rendered
-  definitions or add new ones, matched by filename.
-- **External Job** (deprecated) - files extracted from a job artifact.
+- **Definition overrides** - plain YAML files in the instance repository that replace template-rendered definitions or
+  add new ones.
 
-Effective definitions are written to `/appdefs/` and `/regdefs/` at the repository root, where EnvGene itself and
-external systems read them.
+A deprecated [External Job](#external-job-deprecated) path can supply definitions instead of these sources.
 
 ## Definition sources
 
-EnvGene assembles Application and Registry Definitions from three sources, described below. When two sources produce a
-file with the same name, **user-provided files win over template-rendered definitions**. The External Job is a
-deprecated alternative path that should not be combined with the template + user-provided file flow in the same
-repository.
-
 ### Templates
 
-Templates are stored in the template repository at:
-
-- `/templates/appdefs/<application-name>.yaml|yml|yml.j2|yaml.j2`
-- `/templates/regdefs/<registry-name>.yaml|yml|yml.j2|yaml.j2`
+Templates are stored in the template repository:
 
 ```text
 /templates/
- ├── appdefs/                        # Application Definitions templates
+ ├── appdefs/                        # Application Definition templates
  │   ├── app1.yml.j2
  │   └── app2.yml.j2
- └── regdefs/                        # Registry Definitions templates
+ └── regdefs/                        # Registry Definition templates
      ├── registry1.yml.j2
      └── registry2.yml.j2
 ```
 
-These files can be either:
+EnvGene processes files matching `*.yaml.j2`, `*.yml.j2`, `*.j2`, `*.yaml`, or `*.yml`. A template is either a Jinja
+template or a plain YAML definition without parameterization. All EnvGene
+[Jinja macros](/docs/template-macros.md#jinja-macros) are available during rendering. Each definition is a separate
+file.
 
-- Jinja templates
-- plain YAML definitions without parameterization
+Templates are rendered during the [`app_reg_def_process`](/docs/envgene-pipelines.md#instance-pipeline) pipeline stage.
+In GitLab pipelines the stage runs as the `app_reg_def_render.<cluster>/<env>` job. In GitHub Actions it runs as the
+`APP_REG_DEF_PROCESS` step.
 
-All EnvGene [Jinja macros](/docs/template-macros.md#jinja-macros) are available during template rendering.
+A template-rendered definition is written as `<name>.yml`, where `<name>` is the value of the `name` field of the
+rendered YAML, not the template filename. Template-rendered definitions are schema-validated after rendering, and
+the stage fails on a violation.
 
-Each Application and Registry Definition is created as a separate file.
+### Definition overrides
 
-During the [`app_reg_def_process`](/docs/envgene-pipelines.md#instance-pipeline) job execution, EnvGene renders these
-templates and generates rendered definitions.
-
-### User-provided files
-
-User-provided files are stored in the instance repository at:
-
-- `/configuration/appdefs/<application-name>.yaml|yml`
-- `/configuration/regdefs/<registry-name>.yaml|yml`
-
-User-provided files are plain YAML and used as-is. They are **not** rendered as Jinja templates: file-based processing
-applies after Jinja template rendering is completed (see [Processing order](#processing-order)), so no Jinja context is
-available.
-
-Each user-provided file is matched by filename against the template-rendered definitions:
-
-- **Match exists** - the user-provided file fully replaces the template-rendered definition. The user-provided file
-  becomes the effective definition.
-- **No match** - the user-provided file is added as a new effective definition with no template counterpart.
-
-In both cases, the resulting effective definition is used during downstream pipeline processing (CMDB export & Generate
-Effective Set).
-
-> [!NOTE]
-> User-provided files apply repository-wide, not per-environment. The same file affects all environments in the
-> repository.
-
-#### Filename matching
-
-Files are matched by filename only. The YAML `name` field is not used for matching.
-
-For example:
+Definition overrides are stored in the instance repository:
 
 ```text
-/appdefs/application-1.yml
-/configuration/appdefs/application-1.yml
+/configuration/
+ ├── appdefs/
+ └── regdefs/
 ```
 
-In this case, the user-provided file replaces the template-rendered definition.
+EnvGene processes files with the `.yml` or `.yaml` extension. Nested directories are not scanned. Definition
+overrides are plain YAML and are used as-is. They are never rendered as Jinja: they apply after template rendering
+completes, so no Jinja context is available.
 
-If the filename and YAML `name` field differ, filename matching still determines the target.
+Each definition override is copied over the output of template rendering:
 
-#### Replacement semantics
+- A file with the same filename as a template-rendered definition fully replaces it. There is no field-level merge:
+  fields omitted from the definition override are lost.
+- A file with no counterpart is added as a new effective definition.
 
-User-provided files use full-file replacement: every field that should remain in the final definition must be present in
-the user-provided file. Fields omitted from the user-provided file are lost - there is no field-level merge.
+Because template-rendered definitions are named by their `name` field, a definition override that replaces one must
+match that name, not the template filename.
 
-#### Interaction with appdefs.overrides macro
+Definition overrides apply repository-wide: the same files are applied on every environment build. They are not
+schema-validated, because validation runs on the render output before definition overrides are applied.
 
-The `appdefs.overrides` Jinja-based mechanism and file-based user-provided processing are independent features.
-`appdefs.overrides` applies during Jinja template rendering.
-
-File-based processing applies after rendering is completed. If both mechanisms modify the same definition, the
-file-based user-provided file takes precedence because it is applied later in the processing flow.
-
-See [Template transformation](#template-transformation) for the typical use case of the `appdefs.overrides` and
-`regdefs.overrides` macros.
+The [`appdefs.overrides` and `regdefs.overrides`](#template-transformation) macros apply during template rendering. A
+definition override applies later and replaces the whole definition, including any values the macros produced.
 
 ### External Job (deprecated)
 
 > [!WARNING]
-> The External Job-based mechanism is **deprecated**, is not recommended for use in new or actively maintained
-> environments, and is planned to be removed in a future EnvGene release. Consumers should migrate to template-based
-> Application and Registry Definitions as soon as reasonably possible.
+> The External Job mechanism is **deprecated** and is planned to be removed in a future EnvGene release. Migrate to
+> template-based Application and Registry Definitions as soon as reasonably possible.
 
-An external job (not implemented in EnvGene itself, but serves as an extension point) that somehow
-creates/discovers/generates Application and Registry Definitions as YAML files and saves them in its artifact with the
-contract name `definitions.zip`.
+An External Job is an extension point: a job, not implemented by EnvGene, produces AppDef and RegDef YAML files in its
+job artifact. The following Instance pipeline parameters configure it:
 
-During the [`app_reg_def_process`](/docs/envgene-pipelines.md#instance-pipeline) job execution, EnvGene retrieves the
-Application and Registry Definitions from this artifact and saves them in the instance repository at:
-
-- `/appdefs/`
-- `/regdefs/`
-
-EnvGene uses the following instance repository pipeline parameters:
-
-- [`APP_REG_DEFS_JOB`](/docs/instance-pipeline-parameters.md#app_reg_defs_job) - specifies which job to use
+- [`APP_REG_DEFS_JOB`](/docs/instance-pipeline-parameters.md#app_reg_defs_job) - specifies the job that produces the
+  artifact
 - [`APP_DEFS_PATH`](/docs/instance-pipeline-parameters.md#app_defs_path) - specifies the path within the artifact where
   Application Definitions are located
 - [`REG_DEFS_PATH`](/docs/instance-pipeline-parameters.md#reg_defs_path) - specifies the path within the artifact where
   Registry Definitions are located
 
-The External Job must be configured as part of the EnvGene Instance pipeline.
+The pipeline copies the files from the artifact into the per-environment folders before Solution Descriptor processing
+and Effective Set generation. GitLab pipelines additionally copy them into the root-level folders.
 
-## Processing order
+The External Job path is not handled by the `app_reg_def_process` stage. It should not be combined with the template
+and definition override flow in the same repository.
 
-The `app_reg_def_process` job assembles effective definitions:
+## Processing
 
-1. Render templates from `/templates/appdefs/`, `/templates/regdefs/` using the current environment context, producing
-   definitions in `/appdefs/`, `/regdefs/`.
-2. Apply user-provided files from `/configuration/appdefs/`, `/configuration/regdefs/`:
-   - For each user-provided file with a matching template-rendered definition (by filename), replace the
-     template-rendered definition.
-   - For each user-provided file with no matching template-rendered definition, add it as a new effective definition.
-3. Apply [placement mode](#placement-modes):
-   - In `dual` mode: write per-environment compatibility copies of effective definitions to
-     `/environments/<cluster>/<env>/AppDefs|RegDefs/*`.
-   - In `root` mode: remove any pre-existing files from `/environments/<cluster>/<env>/AppDefs|RegDefs/*`.
+For each environment, the `app_reg_def_process` stage:
 
-This post-render processing model allows user-provided files to operate on fully rendered environment-specific values
-and avoids requiring Jinja-aware user-provided files.
-
-If the [External Job (deprecated)](#external-job-deprecated) is configured, files extracted from its artifact are
-written directly to `/appdefs/`, `/regdefs/`. The External Job is a deprecated alternative path and should not be
-combined with the template + user-provided file flow in the same repository.
+1. Renders templates and validates the result (see [Templates](#templates)).
+2. Merges the render output into the root-level folders. Files with the same name are overwritten. Other files are
+   kept.
+3. Deletes the per-environment folders. In [`dual` placement mode](#placement-modes), recreates them as an exact copy
+   of the render output.
+4. Copies definition overrides into the root-level folders, and in `dual` mode also into the per-environment folders.
 
 ## Output layout
 
-### Rendered output
+The root-level folders hold the effective definitions and are committed to the instance repository. Because they are
+merged into and never cleaned (see [Processing](#processing)), a definition whose template was removed persists at the
+root level until deleted manually. This applies in both placement modes.
 
-Final effective rendered definitions are generated in:
-
-```text
-/appdefs/
-/regdefs/
-```
-
-These definitions contain the final rendered output after:
-
-1. Jinja template rendering
-2. User-provided file processing
-
-The rendered definitions are used during downstream deployment and CMDB integration workflows.
+In `dual` mode the per-environment folders always mirror the current render output plus definition overrides, so
+deletions are propagated there.
 
 ### Placement modes
 
-EnvGene can write rendered definitions to per-environment compatibility folders alongside the root-level locations, for
-backward compatibility with external consumers that still depend on the legacy per-environment folder structure. This is
-controlled by the `app_reg_defs_placement` attribute in [`config.yml`](/docs/envgene-configs.md#configyml):
+The `app_reg_defs_placement` attribute in [`config.yml`](/docs/envgene-configs.md#configyml) selects the placement
+mode. It is set at the repository level and applies to all environments.
 
-```yaml
-app_reg_defs_placement: dual   # default
-# or
-app_reg_defs_placement: root
-```
-
-- **`dual` (default)** - writes to root-level folders (`/appdefs/`, `/regdefs/`) AND to per-environment compatibility
-  folders (`/environments/<cluster>/<env>/AppDefs|RegDefs/`). Deletions are not synced to per-environment folders - old
-  copies persist until manually deleted or the environment is regenerated (last-write-wins).
-- **`root`** - writes only to root-level folders. No files are written into per-environment compatibility folders.
-  Existing per-environment files are removed by `app_reg_def_process` on each run (see
-  [Migration](#migration-from-per-environment-layout)). When switching from `dual` to `root`, regenerate all
-  environments first to ensure root-level definitions are complete.
-
-The setting is configured at the repository level and applies to all environments. Per-environment granularity would add
-complexity without benefits, since compatibility requirements are typically the same across all environments.
-
-> [!NOTE]
-> Placement modes only control **where rendered files are written**. EnvGene itself always reads Application and
-> Registry Definitions from `/appdefs/` and `/regdefs/` regardless of the selected mode. In `dual` mode, the
-> per-environment folders are compatibility copies for external consumers - EnvGene does not read from them.
-
-## Migration from per-environment layout
-
-Earlier EnvGene versions stored generated AppDefs and RegDefs in per-environment directories
-(`/environments/<cluster>/<env>/AppDefs|RegDefs/*`). These directories are handled depending on the configured
-[placement mode](#placement-modes):
-
-- **`root` mode** - the `app_reg_def_process` job removes any files found in these directories on each run. The cleanup
-  is idempotent and requires no manual migration steps.
-- **`dual` mode** - no migration cleanup is performed. The per-environment folders are actively used as compatibility
-  copies managed by the [placement mode](#placement-modes) itself.
+- **`dual` (default)** - root-level folders plus per-environment compatibility copies. The mode exists for backward
+  compatibility only and is planned to be removed in a future EnvGene release together with the per-environment
+  folders. Migrate consumers to the root-level folders and switch to `root`.
+- **`root`** - root-level folders only. No per-environment copies are maintained.
 
 ## Consumers
 
 ### EnvGene
 
-EnvGene itself uses Application and Registry Definitions to download artifacts (Environment Template, Solution
-Descriptor, etc.) from `/appdefs/` and `/regdefs/`.
+EnvGene resolves `application:version` references through the definitions in two operations:
+
+- SD download.
+- [Effective Set generation](/docs/features/effective-set-generation.md), which resolves every application referenced
+  by the SDs it processes.
+
+Resolution reads the root-level folders first and falls back to the per-environment folders. The fallback exists for
+backward compatibility only: all consumers must migrate to the root-level folders.
+
+> [!NOTE]
+> The Environment Template artifact is also downloaded by `application:version`, but its resolution uses an
+> [Artifact Definition](/docs/envgene-objects.md#artifact-definition) stored at
+> `/configuration/artifact_definitions/`, not an AppDef. AppDefs are delivered by the Environment Template artifact
+> itself, so they cannot drive its own download. An Artifact Definition is authored manually for each such artifact
+> used in the repository.
 
 ### External systems
 
-External systems can read Application and Registry Definitions directly from `/appdefs/` and `/regdefs/` in the instance
-repository (via Git API or repository checkout).
+External systems read the root-level folders from the instance repository, via Git API or repository checkout. Legacy
+consumers that depend on the per-environment layout are served by `dual` mode.
 
-For external consumers that still depend on the legacy per-environment folder structure, EnvGene can also write
-compatibility copies to `/environments/<cluster>/<env>/AppDefs|RegDefs/` via the `dual` [placement
-mode](#placement-modes).
+### Import into external CMDB systems
 
-### Export to external CMDB systems
+CMDB import is an extension point. EnvGene does not implement the integration itself. The configuration contract:
 
-EnvGene provides an extension point for integration with external CMDB systems, but does not implement the integration
-itself. As part of such integration, it is possible to create Application and Registry Definitions or their equivalents.
-
-The `cmdb_import` job reads Application and Registry Definitions from `/appdefs/` and `/regdefs/` (the root-level
-locations, regardless of placement mode) and pushes them to the configured CMDB endpoint.
-
-For this integration, the following configuration is used:
-
-- [`CMDB_IMPORT`](/docs/instance-pipeline-parameters.md#cmdb_import): an Instance pipeline parameter that triggers the
-  export operation
-- `inventory.deployer`: an attribute in the [Environment Inventory](/docs/envgene-configs.md#env_definitionyml) that
+- [`CMDB_IMPORT`](/docs/instance-pipeline-parameters.md#cmdb_import) - an Instance pipeline parameter that triggers
+  the import operation
+- `inventory.deployer` - an attribute in the [Environment Inventory](/docs/envgene-configs.md#env_definitionyml) that
   points to the CMDB instance configuration
-- [`deployer.yml`](/docs/envgene-configs.md#deployeryml): a configuration file that describes the parameters of the CMDB
-  instance
+- [`deployer.yml`](/docs/envgene-configs.md#deployeryml) - a configuration file that describes the parameters of the
+  CMDB instance
 
 ## Template transformation
 
-When delivering a solution from one site to another, the solution artifacts are transferred from one registry to
-another, which affects the Application and Registry Definitions.
-
-Usually (and best practice), the following attributes typically remain unchanged during delivery:
-
-- group
-- name
-- version
-
-However, the following attributes are usually changed:
-
-- registry URL
-- registry access parameters
-
-To avoid recreating these definitions from scratch, it is recommended to enable transformation of the Definitions using
-Jinja parameterization and macros that are available exclusively for rendering Definitions:
+Site-to-site delivery transfers solution artifacts from one registry to another. The artifact group, name, and version
+stay the same, while the registry URL and registry access parameters change. Instead of recreating the definitions for
+each site, parameterize the templates with macros available exclusively when rendering definitions:
 
 - [`appdefs.overrides`](/docs/template-macros.md#appdefsoverrides)
 - [`regdefs.overrides`](/docs/template-macros.md#regdefsoverrides)
 
-The values for these macros are set in [`appregdef_config.yaml`](/docs/envgene-configs.md#appregdef_configyaml).
-
-Other Jinja [macros](/docs/template-macros.md#jinja-macros) are also available.
+The values for these macros come from [`appregdef_config.yaml`](/docs/envgene-configs.md#appregdef_configyaml).
 
 For example:
 
 - [`appregdef_config.yaml` example](/test_data/configuration/appregdef_config.yaml)
 - [Application Definition template](/test_data/test_templates/appdefs/application-1.yaml.j2)
 - [Registry Definition template](/test_data/test_templates/regdefs/registry-1.yaml.j2)
+
+## See also
+
+- [Add Application or Registry Definitions to the template repository](/docs/how-to/app-reg-defs-add-to-template.md) -
+  how-to for authoring definition templates.
+- [Add an Application or Registry Definition without a template](/docs/how-to/app-reg-defs-add-without-template.md) -
+  how-to for adding a definition override in the instance repository.
+- [Application and Registry Definitions use cases](/docs/use-cases/app-reg-defs.md) - rendering, override, and
+  placement-mode scenarios.
+- [Artifact downloading use cases](/docs/use-cases/artifact-downloading.md) - supported registries and authentication
+  for SD and Environment Template downloads.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -6,6 +6,9 @@
   - [Environment](#environment)
   - [Environment Inventory](#environment-inventory)
   - [Environment Template](#environment-template)
+  - [Template-rendered Definition](#template-rendered-definition)
+  - [Definition Override](#definition-override)
+  - [Effective Definition](#effective-definition)
   - [Effective Set](#effective-set)
   - [Instance Repository](#instance-repository)
   - [Namespace](#namespace)
@@ -34,6 +37,18 @@ The configuration file describing a specific Environment, including template ref
 A file structure within the Template Repository describing the structure and parameters of a solution type. Consists of a Template Descriptor and component templates (Tenant, Cloud, Namespaces). Template Descriptors can be Jinja templates (`.yml.j2`, `.yaml.j2`) or static YAML files (`.yml`, `.yaml`).
 
 A single Environment Template can be used for multiple projects or environment types (commonly referred to as a "unified Environment Template"), with namespace filtering used to include only relevant components for each specific deployment. See [Environment Template Objects](/docs/envgene-objects.md#environment-template-objects) and [Namespace Filtering in Template Descriptor](/docs/features/namespace-filtering-in-template-descriptor.md).
+
+## Template-rendered Definition
+
+An Application or Registry Definition produced by rendering a template from the template repository. The filename comes from the definition's `name` field. See [Templates](/docs/features/app-reg-defs.md#templates).
+
+## Definition Override
+
+A plain YAML file in the instance repository that replaces a Template-rendered Definition with the same filename, or adds a new definition. Applied as-is, never rendered. See [Definition overrides](/docs/features/app-reg-defs.md#definition-overrides).
+
+## Effective Definition
+
+An Application or Registry Definition after template rendering and Definition Overrides are applied. Lives in the root-level `/appdefs/` and `/regdefs/` folders. See [Output layout](/docs/features/app-reg-defs.md#output-layout).
 
 ## Effective Set
 

--- a/docs/how-to/app-reg-defs-add-to-template.md
+++ b/docs/how-to/app-reg-defs-add-to-template.md
@@ -21,7 +21,7 @@ You need to add a template for each AppDef and RegDef the template repository de
 - An **AppDef** template is required for every application whose configuration is maintained in this template
   repository.
 - A **RegDef** template is required only for off-site registries that those AppDefs reference. The on-site RegDef is
-  added as a user-provided file in the instance repository (see
+  added as a definition override in the instance repository (see
   [Add an Application or Registry Definition without a template](/docs/how-to/app-reg-defs-add-without-template.md)).
 
 ### 2. Get base definitions from the centralized storage
@@ -80,7 +80,7 @@ The `default('off-site-registry-A')` preserves the value from the downloaded bas
 
 > [!NOTE]
 > The on-site RegDef itself is **not** added to the template repository. It is created in the instance repository as a
-> user-provided file - see
+> definition override - see
 > [Add an Application or Registry Definition without a template](/docs/how-to/app-reg-defs-add-without-template.md).
 > The template repository holds only off-site RegDef templates.
 
@@ -99,7 +99,7 @@ appdefs:
     registryName: customer-onsite-registry
 ```
 
-Then create the on-site RegDef as a user-provided file at `/configuration/regdefs/customer-onsite-registry.yml` -
+Then create the on-site RegDef as a definition override at `/configuration/regdefs/customer-onsite-registry.yml` -
 see [Add an Application or Registry Definition without a template](/docs/how-to/app-reg-defs-add-without-template.md)
 for the procedure.
 

--- a/docs/how-to/app-reg-defs-add-without-template.md
+++ b/docs/how-to/app-reg-defs-add-without-template.md
@@ -4,8 +4,8 @@ This guide shows how to add a new Application Definition (AppDef) or Registry De
 repository without modifying the template repository. The new definition is provided as a YAML file under
 `/configuration/` and is added to the effective definitions during the next pipeline run.
 
-For background on the user-provided file mechanism, see
-[Application and Registry Definition - User-provided files](/docs/features/app-reg-defs.md#user-provided-files).
+For background on the definition override mechanism, see
+[Application and Registry Definition - Definition overrides](/docs/features/app-reg-defs.md#definition-overrides).
 
 ## Steps
 
@@ -30,7 +30,7 @@ For background on the user-provided file mechanism, see
    ```
 
    Use a filename that does **not** match any existing template-rendered definition in `/appdefs/` or `/regdefs/`. If
-   the filename matches, the user-provided file will **replace** the template-rendered one instead of adding a new one.
+   the filename matches, the definition override will **replace** the template-rendered one instead of adding a new one.
 
    For the full set of required and optional fields, see
    [Application Definition](/docs/envgene-objects.md#application-definition) and
@@ -38,23 +38,23 @@ For background on the user-provided file mechanism, see
 
 2. **Commit and push** the new file to the instance repository.
 
-3. **Trigger the instance pipeline.** The `app_reg_def_process` job picks up the user-provided file and adds it as a
+3. **Trigger the instance pipeline.** The `app_reg_def_process` job picks up the definition override and adds it as a
    new effective definition.
 
 4. **Verify** the new effective definition appears at:
    - `/appdefs/<filename>.yml` (for AppDef), or
    - `/regdefs/<filename>.yml` (for RegDef)
 
-   with the contents of your user-provided file.
+   with the contents of your definition override.
 
 ## Notes
 
-- User-provided files are plain YAML used as-is. They are **not** rendered as Jinja templates.
-- User-provided files apply repository-wide, not per-environment.
+- Definition overrides are plain YAML used as-is. They are **not** rendered as Jinja templates.
+- Definition overrides apply repository-wide, not per-environment.
 - The new definition is available to downstream pipeline processing (CMDB export, Generate Effective Set) in the same
   way as template-rendered definitions.
 
 ## Related
 
 - [Application and Registry Definition (feature)](/docs/features/app-reg-defs.md) - full specification
-- [UC-ARD-UD-3](/docs/use-cases/app-reg-defs.md#uc-ard-ud-3-add-new-definition-via-user-provided-file-with-no-matching-template) - use case scenario
+- [UC-ARD-DO-3](/docs/use-cases/app-reg-defs.md#uc-ard-do-3-add-new-definition-via-definition-override-with-no-matching-template) - use case scenario

--- a/docs/use-cases/app-reg-defs.md
+++ b/docs/use-cases/app-reg-defs.md
@@ -8,10 +8,10 @@
     - [UC-ARD-TR-2: Basic AppDef/RegDef template delete](#uc-ard-tr-2-basic-appdefregdef-template-delete)
     - [UC-ARD-TR-3: Shared template repository, off-site instance rendering](#uc-ard-tr-3-shared-template-repository-off-site-instance-rendering)
     - [UC-ARD-TR-4: Shared template repository, on-site instance rendering](#uc-ard-tr-4-shared-template-repository-on-site-instance-rendering)
-  - [User-provided definitions](#user-provided-definitions)
-    - [UC-ARD-UD-1: Replace template-rendered definition with user-provided file](#uc-ard-ud-1-replace-template-rendered-definition-with-user-provided-file)
-    - [UC-ARD-UD-2: Delete user-provided file](#uc-ard-ud-2-delete-user-provided-file)
-    - [UC-ARD-UD-3: Add new definition via user-provided file with no matching template](#uc-ard-ud-3-add-new-definition-via-user-provided-file-with-no-matching-template)
+  - [Definition overrides](#definition-overrides)
+    - [UC-ARD-DO-1: Replace template-rendered definition with definition override](#uc-ard-do-1-replace-template-rendered-definition-with-definition-override)
+    - [UC-ARD-DO-2: Delete definition override](#uc-ard-do-2-delete-definition-override)
+    - [UC-ARD-DO-3: Add new definition via definition override with no matching template](#uc-ard-do-3-add-new-definition-via-definition-override-with-no-matching-template)
   - [Placement modes](#placement-modes)
     - [UC-ARD-PM-1: Root mode behavior (auto-migration from legacy layout)](#uc-ard-pm-1-root-mode-behavior-auto-migration-from-legacy-layout)
     - [UC-ARD-PM-2: Dual mode behavior (upgrade with no cleanup)](#uc-ard-pm-2-dual-mode-behavior-upgrade-with-no-cleanup)
@@ -26,7 +26,7 @@ The use cases cover:
 
 1. Template rendering
 2. Centralized definition generation
-3. User-provided file processing (replace and add)
+3. Definition override processing (replace and add)
 4. Placement mode behavior (root and dual, includes auto-migration from legacy layout)
 5. CMDB integration
 6. Definition lifecycle handling
@@ -41,12 +41,12 @@ The use cases cover:
 
 This document is organized into the following functional groups:
 
-| Group                          | Description                                                              |
-|--------------------------------|--------------------------------------------------------------------------|
-| Template Rendering (TR)        | Generation of AppDef and RegDef objects from templates                   |
-| User-Provided Definitions (UD) | Replace or add definitions using user-provided files                     |
-| Placement Modes (PM)           | Behavior of `app_reg_def_process` in root and dual placement modes       |
-| CMDB Integration (CI)          | Export and synchronization of definitions to CMDB systems                |
+| Group                     | Description                                                        |
+|---------------------------|--------------------------------------------------------------------|
+| Template Rendering (TR)   | Generation of AppDef and RegDef objects from templates             |
+| Definition Overrides (DO) | Replace or add definitions using definition overrides              |
+| Placement Modes (PM)      | Behavior of `app_reg_def_process` in root and dual placement modes |
+| CMDB Integration (CI)     | Export and synchronization of definitions to CMDB systems          |
 
 ## Template rendering
 
@@ -206,13 +206,13 @@ a single on-site registry via `appregdef_config.yaml` overrides.
 2. The on-site RegDef is generated in `/regdefs/*` and referenced by all AppDefs
 3. RegDefs for off-site registries are still generated and remain in `/regdefs/*` (unused after redirection)
 
-## User-provided definitions
+## Definition overrides
 
-This group covers customizing template-rendered definitions via user-provided files placed in `/configuration/appdefs/`,
-`/configuration/regdefs/`. A user-provided file can either replace an existing template-rendered definition or add a new
+This group covers customizing template-rendered definitions via definition overrides placed in `/configuration/appdefs/`,
+`/configuration/regdefs/`. A definition override can either replace an existing template-rendered definition or add a new
 definition that has no template counterpart.
 
-### UC-ARD-UD-1: Replace template-rendered definition with user-provided file
+### UC-ARD-DO-1: Replace template-rendered definition with definition override
 
 **Pre-requisites:**
 
@@ -220,7 +220,7 @@ definition that has no template counterpart.
    - `/appdefs/*`
    - `/regdefs/*`
 
-2. User-provided files with filenames matching existing template-rendered definitions exist in the instance repository
+2. Definition overrides with filenames matching existing template-rendered definitions exist in the instance repository
    at:
    - `/configuration/appdefs/*`
    - `/configuration/regdefs/*`
@@ -243,23 +243,23 @@ ENV_BUILDER: true
    2. Writes template-rendered definitions into:
       - `/appdefs/*`
       - `/regdefs/*`
-   3. Discovers user-provided files in:
+   3. Discovers definition overrides in:
       - `/configuration/appdefs/*`
       - `/configuration/regdefs/*`
-   4. Replaces template-rendered definitions with user-provided files (filename-matched)
+   4. Replaces template-rendered definitions with definition overrides (filename-matched)
 
 **Results:**
 
-1. User-provided files from:
+1. Definition overrides from:
    - `/configuration/appdefs/*`
    - `/configuration/regdefs/*`
    replace template-rendered definitions in:
    - `/appdefs/*`
    - `/regdefs/*`
-2. User-provided files take precedence during downstream processing
-3. Final effective definitions contain user-provided file content
+2. Definition overrides take precedence during downstream processing
+3. Final effective definitions contain definition override content
 
-### UC-ARD-UD-2: Delete user-provided file
+### UC-ARD-DO-2: Delete definition override
 
 **Pre-requisites:**
 
@@ -267,7 +267,7 @@ ENV_BUILDER: true
    - `/appdefs/*`
    - `/regdefs/*`
 
-2. User-provided files previously existed in the instance repository at:
+2. Definition overrides previously existed in the instance repository at:
    - `/configuration/appdefs/*`
    - `/configuration/regdefs/*`
 
@@ -293,8 +293,8 @@ ENV_BUILDER: true
    2. Writes template-rendered definitions into:
       - `/appdefs/*`
       - `/regdefs/*`
-   3. Detects deleted user-provided files
-   4. Skips user-provided file processing for deleted files
+   3. Detects deleted definition overrides
+   4. Skips definition override processing for deleted files
    5. Retains template-rendered definitions as effective definitions
 
 **Results:**
@@ -302,23 +302,23 @@ ENV_BUILDER: true
 1. No deletion is performed in:
    - `/appdefs/*`
    - `/regdefs/*`
-2. Existing template-rendered definitions remain active when user-provided files are deleted
-3. Effective definitions revert back to template-rendered definitions for entries where the user-provided file was
+2. Existing template-rendered definitions remain active when definition overrides are deleted
+3. Effective definitions revert back to template-rendered definitions for entries where the definition override was
    replacing a template-rendered one
-4. Deleting a user-provided file only removes its replacement behavior and does not delete template-rendered definitions
+4. Deleting a definition override only removes its replacement behavior and does not delete template-rendered definitions
 
-### UC-ARD-UD-3: Add new definition via user-provided file with no matching template
+### UC-ARD-DO-3: Add new definition via definition override with no matching template
 
 **Description:**
 
-A user-provided file is placed in `/configuration/appdefs/*` or `/configuration/regdefs/*` and has no corresponding
-template-rendered definition at the same filename. The user-provided file becomes a new effective definition alongside
+A definition override is placed in `/configuration/appdefs/*` or `/configuration/regdefs/*` and has no corresponding
+template-rendered definition at the same filename. The definition override becomes a new effective definition alongside
 template-rendered ones.
 
 **Pre-requisites:**
 
 1. Template-rendered definitions exist in the instance repository at `/appdefs/*`, `/regdefs/*`.
-2. A user-provided file is placed in the instance repository at `/configuration/appdefs/new-app.yml` (or
+2. A definition override is placed in the instance repository at `/configuration/appdefs/new-app.yml` (or
    `/configuration/regdefs/new-registry.yml`) where the filename does not match any rendered template output.
 
 **Trigger:** Instance pipeline (GitLab or GitHub) is started with `ENV_NAMES`, `ENV_BUILDER: true`.
@@ -328,14 +328,14 @@ template-rendered ones.
 1. The `app_reg_def_process` job runs:
    1. Renders templates from `/templates/appdefs/*`, `/templates/regdefs/*`
    2. Writes template-rendered definitions into `/appdefs/*`, `/regdefs/*`
-   3. Discovers user-provided files in `/configuration/appdefs/*`, `/configuration/regdefs/*`
-   4. For each user-provided file, looks up the matching template-rendered definition by filename
+   3. Discovers definition overrides in `/configuration/appdefs/*`, `/configuration/regdefs/*`
+   4. For each definition override, looks up the matching template-rendered definition by filename
    5. For files with no matching template, adds them as new effective definitions at `/appdefs/<filename>` (or
       `/regdefs/<filename>`)
 
 **Results:**
 
-1. User-provided file `/configuration/appdefs/new-app.yml` becomes a new effective definition at `/appdefs/new-app.yml`
+1. Definition override `/configuration/appdefs/new-app.yml` becomes a new effective definition at `/appdefs/new-app.yml`
 2. Existing template-rendered definitions remain unchanged
 
 ## Placement modes
@@ -373,7 +373,7 @@ per-environment AppDef/RegDef files and writes effective definitions only at the
 
 1. The `app_reg_def_process` job runs:
    1. Renders AppDef and RegDef templates with current environment context
-   2. Applies user-provided files from `/configuration/appdefs/*`, `/configuration/regdefs/*` (if present)
+   2. Applies definition overrides from `/configuration/appdefs/*`, `/configuration/regdefs/*` (if present)
    3. Writes final effective definitions into `/appdefs/*`, `/regdefs/*`
    4. Removes any files in:
       - `/environments/<cluster>/<env>/AppDefs/*`
@@ -415,12 +415,12 @@ Legacy per-environment files coexist with new dual-mode compatibility copies.
 
 1. The `app_reg_def_process` job runs:
    1. Renders AppDef and RegDef templates with current environment context
-   2. Applies user-provided files from `/configuration/appdefs/*`, `/configuration/regdefs/*` (if present)
+   2. Applies definition overrides from `/configuration/appdefs/*`, `/configuration/regdefs/*` (if present)
    3. Writes effective definitions to `/appdefs/*`, `/regdefs/*`
    4. Writes per-environment compatibility copies to `/environments/<cluster>/<env>/AppDefs/*`,
       `/environments/<cluster>/<env>/RegDefs/*`, overwriting any pre-existing files with matching names
-   5. Does not touch per-environment files whose names do not match any current template-rendered or user-provided
-      definition
+   5. Does not touch per-environment files whose names do not match any current template-rendered definition or
+      definition override
 
 **Results:**
 
@@ -453,10 +453,10 @@ Instance pipeline (GitLab or GitHub) is started.
 
 1. During pipeline execution, the `app_reg_def_process` job renders
 template-rendered AppDefs and RegDefs from templates.
-If matching user-provided files exist in:
+If matching definition overrides exist in:
    - `/configuration/appdefs/*`
    - `/configuration/regdefs/*`
-the user-provided files fully replace the corresponding template-rendered
+the definition overrides fully replace the corresponding template-rendered
 definitions in:
    - `/appdefs/*`
    - `/regdefs/*`

--- a/docs/use-cases/artifact-downloading.md
+++ b/docs/use-cases/artifact-downloading.md
@@ -1054,14 +1054,14 @@ Instance pipeline (GitLab or GitHub) is started with parameters that trigger art
 **Steps:**
 
 1. Artifact download process attempts to resolve Application Definition
-2. Definition file is not found at expected location
+2. Definition file is not found in the root-level folder or in the per-environment folder
 3. Pipeline job fails with clear error message indicating missing AppDef
 
 **Results:**
 
 1. Pipeline execution fails
 2. Error message clearly indicates which Application Definition is missing
-3. Error message includes expected file path
+3. Error message includes both checked locations
 
 ### UC-AD-ERR-2: Handle Missing Registry Definition
 
@@ -1077,14 +1077,14 @@ Instance pipeline (GitLab or GitHub) is started with parameters that trigger art
 **Steps:**
 
 1. Artifact download process attempts to resolve Registry Definition
-2. Definition file is not found at expected location
+2. Definition file is not found in the root-level folder or in the per-environment folder
 3. Pipeline job fails with clear error message indicating missing RegDef
 
 **Results:**
 
 1. Pipeline execution fails
 2. Error message clearly indicates which Registry Definition is missing
-3. Error message includes expected file path and registry name
+3. Error message includes both checked locations and the registry name
 
 ### UC-AD-ERR-3: Handle Authentication Failure
 


### PR DESCRIPTION
# Pull Request

## Summary

Rewrites `docs/features/app-reg-defs.md` so it matches the shipped behaviour and reads as a reference document, and
renames the "user-provided files" term to "definition overrides" across the documentation.

Factual corrections, each verified against the code:

- Deletions propagate to the per-environment folders (rebuilt on every run), while the root-level folders are merged
  into and never cleaned - the old doc stated the opposite.
- External Job definitions are delivered by the SD processing and Effective Set generation steps, not by
  `app_reg_def_process`. The `definitions.zip` contract does not exist in the implementation.
- A rendered definition is named by its `name` field, not by the template filename. Bare `*.j2` templates are also
  processed.
- Definition overrides bypass schema validation (validation runs on the render output before they are applied).
- Environment Template resolution uses Artifact Definitions, not AppDefs (bootstrap constraint, now a NOTE).

The doc also states the decided read contract: root-level folders are canonical, the per-environment folders are a
temporary backward-compatibility fallback. The lookup implementation is tracked in #1550.

Also: declarative Overview instead of design-proposal scaffolding, deduplicated rules, scope invariant (AppDef and
RegDef must cover every SD and every application the SDs reference), `See also` section, three glossary terms, and
UC-AD-ERR-1/2 updated for the two-location lookup.

## Issue

Part of #1550

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

docs

## Implementation Notes

The term rename covers the feature doc, `envgene-objects.md`, both how-to guides, and the use cases. UC IDs
`UC-ARD-UD-*` become `UC-ARD-DO-*`. No external references to the old anchors or IDs existed (verified by grep across
the repository).

## Tests / Evidence

- `markdownlint` (project config) passes on all seven changed files.
- Inbound anchors preserved and verified: `#templates`, `#definition-overrides` (renamed from
  `#user-provided-files`, all three inbound links updated), `#external-job-deprecated`, `#placement-modes`,
  `#template-transformation`.
- ToC checked against actual headings in both restructured files.

## Additional Notes

Follow-ups, intentionally not in this PR: `envgene-configs.md` drift for `appregdef_config.yaml` location and
cluster-level merge, `envgene-pipelines.md` claim that the External Job is handled by `app_reg_def_process`, and the
lookup-order ticket for the repository that resolves applications during Effective Set generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)