### PR TITLE
docs: prescribe collapsed-Gherkin acceptance notation in CR guide

### DIFF
--- a/docs/dev/creating-cr.md
+++ b/docs/dev/creating-cr.md
@@ -166,20 +166,32 @@ Required. Observable, testable conditions that determine the CR is complete.
 
 Each condition should be:
 
-- **Observable.** Verifiable by someone external to the implementer.
+- **Observable.** Verifiable by someone external to the implementer, through an existing channel: a
+  job log, a mock registry, an emitted request, or an error message. Name the observed channel, not
+  internal state. Prefer "the artifact is requested from registry X" over "resolution uses the X copy".
+  Give fixtures distinguishing traits so the outcome is checkable, for example a distinct registry name
+  per copy so the request target reveals which copy won.
 - **Specific.** Names concrete values, files, or behaviors, not generalities like "works well".
 - **Falsifiable.** Binary yes/no, not subjective.
 - **Independent.** Verifiable without depending on other conditions where possible.
 - **Distinct from implementation.** States what is true, not how it was built.
 
-Cover both happy path and failure cases.
+Cover both happy path and failure cases. Enumerate every case that can fail independently. A
+condition is redundant only when it cannot fail independently of the others, not when it is logically
+derivable from them. Do not fold distinct failure modes, such as a missing folder versus a missing
+file, into one condition.
 
 Each condition is self-contained. State the test context (backend, fixture, mode) inline within
-the conditions that depend on it, not as a global preamble. Test context that applies to every
-condition uniformly belongs in Implementation notes.
+the conditions that depend on it, not as a global preamble. Do not link to use cases or design
+sections from inside a condition - inline the observable contract instead. Test context that applies
+to every condition uniformly belongs in Implementation notes. When a placement or run mode appears in
+a condition, treat it as setup only. The rule "do not branch the implementation on the mode" is
+implementer guidance for Implementation notes, not an acceptance condition.
 
-Use either declarative form ("X resolves to Y") or Given/When/Then. Both are valid - the
-principles above apply equally.
+Write each condition in collapsed Gherkin: `Given <fixture>, <observable outcome>`. The Given states
+the prepared state, committed fixtures, and any run or placement mode. The rest collapses Gherkin's
+When and Then into one observable-outcome clause. The declarative form ("X resolves to Y") is also
+valid for a simple condition. The principles above apply to both.
 
 Good:
 


### PR DESCRIPTION
## Summary

Codify the acceptance notation adopted while filing #1550 into the `Acceptance` section of
`docs/dev/creating-cr.md`, so every CR author writes acceptance the same way. The change integrates the
notation into the existing acceptance principles rather than adding a duplicate block.

Added guidance:

- Write each condition in collapsed Gherkin: `Given <fixture>, <observable outcome>`. The Given states the
  prepared state, committed fixtures, and any run or placement mode. The rest collapses When and Then into
  one observable-outcome clause.
- Outcomes must be observable through an existing channel (a job log, a mock registry, an emitted request,
  an error message), not internal state. Fixtures get distinguishing traits so the outcome is checkable.
- Conditions stay self-contained: no links to use cases or design sections from inside a bullet.
- Enumerate every case that can fail independently. A condition is redundant only when it cannot fail
  independently, not when it is logically derivable. Do not fold distinct failure modes into one bullet.
- A placement or run mode in a condition is setup only. The "do not branch on the mode" rule moves to
  Implementation notes.

## Issue

No issue. This codifies the notation used in #1550 so the convention doc matches practice.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`docs`.

## Implementation Notes

Documentation only, one file (`docs/dev/creating-cr.md`). The local skill `doc-pr-to-issue` already carries
the same notation and references this guide as the source of truth.

## Tests / Evidence

- Markdown house rules verified on the changed section: no em or en dashes, no semicolons, prose wrapped at
  120 characters.
- The pre-existing `Good` example already uses the collapsed-Gherkin form, so it needs no change.

## Additional Notes

The notation was settled while scoping #1550 (root-first AppDef/RegDef lookup), whose acceptance is written
entirely in this form.
