### PR TITLE
docs: align system-certificate docs with implementation, split feature and how-to

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ After the pipeline finishes, the Environment configuration will be generated and
 - [**Filter Namespaces in Template Descriptor**](/docs/how-to/filter-ns-in-template-descriptor.md) - Generate Environments with selected namespaces only
 - [**Credential Encryption**](/docs/how-to/credential-encryption.md) - Secure credential storage and rotation
 - [**Split a Cloud Passport for Business and Infra**](/docs/how-to/split-cloud-passport-for-business-and-infra.md) - Use separate cluster-default and infra passports in the same cluster
+- [**Configure System Certificates**](/docs/how-to/configure-system-certificates.md) - Add CA certificates so EnvGene trusts internal registries and TLS services
 
 ### Migrations
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@
 - [**Filter Namespaces in Template Descriptor**](/docs/how-to/filter-ns-in-template-descriptor.md) - Generate Environments with selected namespaces only
 - [**Credential Encryption**](/docs/how-to/credential-encryption.md) - Secure credential storage and rotation
 - [**Split a Cloud Passport for Business and Infra**](/docs/how-to/split-cloud-passport-for-business-and-infra.md) - Use separate cluster-default and infra passports in the same cluster
+- [**Configure System Certificates**](/docs/how-to/configure-system-certificates.md) - Add CA certificates so EnvGene trusts internal registries and TLS services
 
 ## Migrations
 

--- a/docs/features/system-certificate.md
+++ b/docs/features/system-certificate.md
@@ -1,300 +1,84 @@
-# System Certificate Configuration
+# System certificate configuration
 
-- [System Certificate Configuration](#system-certificate-configuration)
-  - [Problem Statement](#problem-statement)
+- [System certificate configuration](#system-certificate-configuration)
+  - [Problem statement](#problem-statement)
   - [Approach](#approach)
-    - [Certificate Management Process](#certificate-management-process)
-    - [Supported Certificate Types](#supported-certificate-types)
-    - [Certificate Chain Ordering](#certificate-chain-ordering)
-    - [How to Obtain Required Certificates](#how-to-obtain-required-certificates)
-      - [Using OpenSSL to Retrieve Server Certificates](#using-openssl-to-retrieve-server-certificates)
-      - [Extracting Individual Certificates from Chain](#extracting-individual-certificates-from-chain)
-      - [Using Browser to Export Certificates](#using-browser-to-export-certificates)
-      - [Verifying Certificate Chains](#verifying-certificate-chains)
-  - [Usage Examples](#usage-examples)
-    - [Secure Artifact Repositories](#secure-artifact-repositories)
-    - [Internal Services with Self-Signed Certificates](#internal-services-with-self-signed-certificates)
-  - [Technical Implementation](#technical-implementation)
-  - [Troubleshooting](#troubleshooting)
-    - [Common Issues](#common-issues)
-    - [Debugging Tips](#debugging-tips)
+    - [Certificate management process](#certificate-management-process)
+    - [Supported certificate types](#supported-certificate-types)
+  - [Technical implementation](#technical-implementation)
 
-## Problem Statement
+For step-by-step instructions on placing, obtaining, and verifying certificates, see
+[Configure system certificates](/docs/how-to/configure-system-certificates.md).
+
+## Problem statement
 
 When deploying environments in enterprise settings, teams face several certificate-related challenges:
 
-1. Secure Communication Barriers:
-   1. Internal services use self-signed certificates not trusted by default
-   2. Artifact repositories require client certificate authentication
+1. Secure communication barriers:
+   1. Internal services use self-signed certificates that are not trusted by default.
+   2. Artifact repositories are exposed over TLS with private certificate authorities.
 
-2. Manual Certificate Management:
-   1. Manually installing certificates on build agents is error-prone
-   2. Certificate updates require manual intervention
-   3. Different environments may require different certificates
+2. Manual certificate management:
+   1. Installing certificates on build agents by hand is error-prone.
+   2. Certificate updates require manual intervention.
+   3. Different environments may require different certificates.
 
 Goals:
 
-1. Provide a consistent way to manage certificates across all environments
-2. Automate certificate installation during pipeline execution
-3. Support various certificate types and authentication methods
-4. Eliminate manual certificate management on build agents
+1. Provide a consistent way to manage certificates across all environments.
+2. Automate certificate installation during pipeline execution.
+3. Eliminate manual certificate management on build agents.
 
 ## Approach
 
-EnvGene provides a built-in mechanism for managing system certificates through a dedicated directory in the environment instance repository. Certificates placed in this directory are automatically loaded and configured during pipeline execution.
+EnvGene provides a built-in mechanism for managing system certificates through a dedicated directory in the
+environment instance repository. Certificates placed in this directory are automatically loaded and added to the
+runner trust store during pipeline execution.
 
-### Certificate Management Process
+### Certificate management process
 
-The system certificate configuration feature in EnvGene automatically handles certificates placed in the `configuration/certs/` directory of your environment instance repository. During pipeline execution:
+The feature handles certificates placed in the `configuration/certs/` directory of your environment instance
+repository. During pipeline execution:
 
-1. EnvGene checks for certificate files in the `configuration/certs/` directory
-2. Detected certificates are loaded into the runner environment
-3. CA certificates are added to the system's trusted root certificate store
-4. Environment variables are set to ensure tools and libraries use the certificates
-5. EnvGene uses these certificates for secure communication with external systems
+1. EnvGene checks for certificate files in the `configuration/certs/` directory.
+2. Each certificate is added to the runner operating system trust store.
+3. The system trust store is rebuilt so later pipeline steps use the updated certificates.
 
 ```mermaid
 flowchart TD
     A[Place certificates in configuration/certs/] --> B[Pipeline execution begins]
     B --> C[Certificate detection]
-    C --> D[Certificates loaded into runner environment]
-    D --> E[CA certificates added to trusted root store]
-    E --> F[Environment variables set for secure communication]
-    F --> G[EnvGene uses certificates for secure connections]
+    C --> D[Certificates copied to the OS trust anchors]
+    D --> E[System trust store rebuilt]
+    E --> F[Later pipeline steps use the updated trust store]
 ```
 
-To use this feature:
+> [!NOTE]
+> If `configuration/certs/` is absent or empty, EnvGene applies a default certificate baked into the runner image,
+> when one is present. Otherwise the step is a no-op and no certificate is installed.
 
-1. Create a `certs` directory within the `configuration` folder of your environment instance repository:
+### Supported certificate types
 
-   ```text
-   /configuration
-   /certs
-      your-ca-cert.pem
-      your-client-cert.p12
-   ```
+The trust-store mechanism processes CA certificates in PEM format:
 
-2. Place your certificate files in this directory
-3. Commit and push these changes to your repository
-4. When the pipeline runs, these certificates will be automatically loaded and used
+- **CA certificates** (`.crt`, `.pem`): root or intermediate certificates used to validate server certificates.
 
-### Supported Certificate Types
+A single file may contain a full chain of concatenated PEM certificates. For how to assemble a chain file, see
+[Build a certificate chain file](/docs/how-to/configure-system-certificates.md#build-a-certificate-chain-file).
 
-The system supports various certificate types:
+## Technical implementation
 
-- **CA Certificates** (`.crt`, `.pem`): Root or intermediate certificates used to validate server certificates
-- **Client Certificates** (`.p12`, `.pfx`): Used for client authentication when connecting to external systems
+Under the hood, EnvGene runs a certificate handling script that:
 
-While the system will load all certificates in the directory, following these naming conventions can help with organization:
+1. Detects the operating system of the runner.
+2. Copies each certificate to the OS trust anchor directory:
+   - Debian, Ubuntu, and Alpine: `/usr/local/share/ca-certificates/`
+   - CentOS and Red Hat: `/etc/pki/ca-trust/source/anchors/`
+3. Rebuilds the trust store with the command for the detected OS:
+   - Debian and Ubuntu: `update-ca-certificates --fresh`
+   - Alpine: `update-ca-certificates`
+   - CentOS and Red Hat: `update-ca-trust`
+4. Makes the refreshed trust store available to tools and libraries used by later pipeline steps.
 
-- `ca-*.pem` or `ca-*.crt` for CA certificates
-- `client-*.p12` or `client-*.pfx` for client certificates
-
-### Certificate Chain Ordering
-
-When dealing with certificate chains that include multiple levels (root CA, intermediate CAs, and end-entity certificates), proper ordering is crucial for certificate validation. All certificates in the chain should be combined into a single `.crt` or `.pem` file in the correct order.
-
-**Required Order:**
-
-1. Root CA certificate (first)
-2. Intermediate CA certificates (in hierarchical order)
-3. End-entity certificate (last, if applicable)
-
-**Example Certificate Chain File (`ca-chain.pem`):**
-
-```text
------BEGIN CERTIFICATE-----
-[Root CA Certificate - First]
-MIIDXTCCAkWgAwIBAgIJAKoK/OvvXMdTMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
-BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
-...
------END CERTIFICATE-----
------BEGIN CERTIFICATE-----
-[Intermediate CA Certificate - Second]
-MIIDXTCCAkWgAwIBAgIJAKoK/OvvXMdTMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
-BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
-...
------END CERTIFICATE-----
------BEGIN CERTIFICATE-----
-[End-Entity Certificate - Last (if needed)]
-MIIDXTCCAkWgAwIBAgIJAKoK/OvvXMdTMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
-BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
-...
------END CERTIFICATE-----
-```
-
-**Important Notes:**
-
-- Each certificate must be in PEM format with proper `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` boundaries
-- No empty lines should exist between certificates
-- The order is critical for proper certificate validation
-- If you have multiple certificate chains, create separate files for each chain
-
-**Example Directory Structure with Certificate Chains:**
-
-```text
-/configuration
-  /certs
-    ca-chain-internal.pem       # Complete chain for internal services
-    ca-chain-external.pem       # Complete chain for external services
-    client-artifactory.p12      # Client certificate for Artifactory
-```
-
-### How to Obtain Required Certificates
-
-Before configuring certificate chains, you need to identify and obtain the required certificates from your target services. Here are common methods to retrieve certificates:
-
-#### Using OpenSSL to Retrieve Server Certificates
-
-**For HTTPS services:**
-
-```bash
-# Get the complete certificate chain from a server
-openssl s_client -connect your-site.com:443 -showcerts
-
-# Save the certificate chain to a file
-openssl s_client -connect your-site.com:443 -showcerts < /dev/null 2>/dev/null | openssl x509 -outform PEM > server-cert.pem
-
-# Get certificate chain with SNI (Server Name Indication) support
-openssl s_client -connect your-site.com:443 -servername your-site.com -showcerts
-```
-
-**For non-HTTPS services (custom ports):**
-
-```bash
-# For services running on custom ports
-openssl s_client -connect internal-service.company.com:8443 -showcerts
-
-# For services with custom protocols
-openssl s_client -connect ldap-server.company.com:636 -showcerts
-```
-
-#### Extracting Individual Certificates from Chain
-
-When you run `openssl s_client -showcerts`, you'll see output like:
-
-```text
------BEGIN CERTIFICATE-----
-[Certificate 1 - Usually the server certificate]
------END CERTIFICATE-----
------BEGIN CERTIFICATE-----
-[Certificate 2 - Intermediate CA]
------END CERTIFICATE-----
------BEGIN CERTIFICATE-----
-[Certificate 3 - Root CA]
------END CERTIFICATE-----
-```
-
-**To create a proper certificate chain file:**
-
-1. Copy certificates in reverse order (Root CA first, then intermediates, then server cert if needed)
-2. Save them to a single `.pem` file with proper ordering
-
-#### Using Browser to Export Certificates
-
-**Alternative method for web services:**
-
-1. Open the site in your browser
-2. Click on the lock icon in the address bar
-3. View certificate details
-4. Export the certificate chain
-5. Convert to PEM format if needed
-
-#### Verifying Certificate Chains
-
-**Before using certificates, verify they form a valid chain:**
-
-```bash
-# Verify certificate chain
-openssl verify -CAfile ca-chain.pem target-cert.pem
-
-# Check certificate details
-openssl x509 -in certificate.pem -text -noout
-
-# Test certificate chain against a server
-openssl s_client -connect hostname:port -CAfile ca-chain.pem -verify_return_error
-```
-
-## Usage Examples
-
-### Secure Artifact Repositories
-
-**Scenario**: EnvGene needs to connect to secure artifact repositories that require certificate-based authentication.
-
-**Implementation**:
-
-1. Obtain the client certificate for the artifact repository
-2. Place the files in the `configuration/certs/` directory:
-
-   ```text
-   /configuration
-   /certs
-      ca.pem          # CA certificate
-      client-artifactory.p12    # Client certificate for Artifactory
-   ```
-
-3. The certificate will be automatically used for authentication during pipeline execution
-
-```mermaid
-sequenceDiagram
-    participant EnvGene
-    participant SecureRepo
-
-    EnvGene->>SecureRepo: Request with client certificate
-    SecureRepo->>EnvGene: Authenticate and respond
-```
-
-### Internal Services with Self-Signed Certificates
-
-**Scenario**: EnvGene needs to communicate with internal services that use self-signed certificates.
-
-**Implementation**:
-
-1. Obtain the self-signed certificate used by the internal service
-2. Place the certificate in the `configuration/certs/` directory:
-
-   ```text
-   /configuration
-   /certs
-      ca-internal-service.pem  # Self-signed certificate
-   ```
-
-3. The certificate will be automatically added to the trusted root store during pipeline execution
-
-## Technical Implementation
-
-Under the hood, EnvGene uses a certificate handling script that:
-
-1. Detects the operating system of the runner
-2. Copies certificates to the appropriate system location based on the OS:
-   - Debian/Ubuntu: `/usr/local/share/ca-certificates/`
-   - CentOS/Red Hat: `/etc/pki/ca-trust/source/anchors/`
-   - Alpine: appends to `/etc/ssl/certs/ca-certificates.crt`
-3. Updates the CA trust store using the appropriate command for the OS:
-   - Debian/Ubuntu: `update-ca-certificates --fresh`
-   - CentOS/Red Hat: `update-ca-trust`
-4. Sets environment variables like `REQUESTS_CA_BUNDLE` for Python-based tools
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Certificate not recognized**:
-   - Ensure the certificate is in the correct format
-   - Check that the certificate is placed in the correct directory
-
-2. **Connection failures**:
-   - Verify that the certificate is not expired
-   - Ensure the certificate is trusted by the target system
-
-3. **Pipeline failures**:
-   - Check pipeline logs for certificate loading errors
-   - Verify that the certificate files have the correct permissions
-
-### Debugging Tips
-
-To debug certificate issues:
-
-1. Check the pipeline logs for certificate loading messages
-2. Verify that environment variables like `REQUESTS_CA_BUNDLE` are set correctly
-3. Use tools like `openssl` to validate certificate chains
+Each source file keeps its own base name at the destination, with a `.crt` extension, so multiple certificate
+files do not overwrite each other.

--- a/docs/how-to/configure-system-certificates.md
+++ b/docs/how-to/configure-system-certificates.md
@@ -1,0 +1,218 @@
+# Configure system certificates
+
+This guide shows how to add CA certificates to an environment instance repository so that EnvGene trusts internal
+registries and TLS services during pipeline execution. It also covers how to obtain certificates and how to verify
+them before use.
+
+For background on the mechanism, see [System certificate configuration](/docs/features/system-certificate.md).
+
+- [Configure system certificates](#configure-system-certificates)
+  - [Prerequisites](#prerequisites)
+  - [Steps](#steps)
+  - [Obtain the required certificates](#obtain-the-required-certificates)
+    - [Retrieve server certificates with OpenSSL](#retrieve-server-certificates-with-openssl)
+    - [Extract individual certificates from a chain](#extract-individual-certificates-from-a-chain)
+    - [Export certificates from a browser](#export-certificates-from-a-browser)
+  - [Build a certificate chain file](#build-a-certificate-chain-file)
+  - [Verify a certificate](#verify-a-certificate)
+    - [Check that the file parses](#check-that-the-file-parses)
+    - [Check that the chain validates the host](#check-that-the-chain-validates-the-host)
+    - [Check that a client trusts the host](#check-that-a-client-trusts-the-host)
+  - [Usage examples](#usage-examples)
+    - [Secure artifact repositories](#secure-artifact-repositories)
+    - [Internal services with self-signed certificates](#internal-services-with-self-signed-certificates)
+  - [Troubleshooting](#troubleshooting)
+
+## Prerequisites
+
+- Write access to the environment instance repository.
+- The CA certificate, or full certificate chain, of each target service in PEM format.
+- OpenSSL and curl available locally for the verification steps.
+
+## Steps
+
+1. Create a `certs` directory inside the `configuration` folder of your environment instance repository:
+
+   ```text
+   /configuration
+     /certs
+       your-ca-cert.pem
+       ca-chain-internal.pem
+   ```
+
+2. Place your CA certificate files in this directory. Each file must be PEM-encoded and use a `.crt` or `.pem`
+   extension.
+3. Commit and push the changes to your repository.
+4. Run the pipeline. EnvGene loads the certificates and rebuilds the runner trust store before the other steps run.
+
+## Obtain the required certificates
+
+Before adding certificates, identify and retrieve them from your target services.
+
+### Retrieve server certificates with OpenSSL
+
+For an HTTPS service:
+
+```bash
+# Print the certificate chain presented by a server
+openssl s_client -connect your-site.com:443 -servername your-site.com -showcerts
+
+# Save the server certificate to a file
+openssl s_client -connect your-site.com:443 -servername your-site.com < /dev/null 2>/dev/null \
+  | openssl x509 -outform PEM > server-cert.pem
+```
+
+For a service on a custom port, replace the host and port:
+
+```bash
+openssl s_client -connect internal-service.company.com:8443 -showcerts
+```
+
+### Extract individual certificates from a chain
+
+When you run `openssl s_client -showcerts`, the output lists each certificate in the chain:
+
+```text
+-----BEGIN CERTIFICATE-----
+[Certificate 1 - the server certificate]
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+[Certificate 2 - intermediate CA]
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+[Certificate 3 - root CA]
+-----END CERTIFICATE-----
+```
+
+Copy the CA certificates (intermediate and root) into a single file to use as the chain.
+
+### Export certificates from a browser
+
+For a web service you can also export the chain from a browser:
+
+1. Open the site in your browser.
+2. Select the lock icon in the address bar.
+3. Open the certificate details.
+4. Export the certificate chain.
+5. Convert it to PEM format if the export is in a different encoding.
+
+## Build a certificate chain file
+
+You can combine several PEM certificates into one file. Place the root CA first, then any intermediate CAs:
+
+```text
+-----BEGIN CERTIFICATE-----
+[Root CA certificate]
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+[Intermediate CA certificate]
+-----END CERTIFICATE-----
+```
+
+> [!NOTE]
+> For trust-store installation the order inside the file does not change the result, because each CA is trusted
+> independently. A consistent order keeps the file readable and matches the order a server uses when it serves a
+> chain.
+
+Keep separate chains in separate files, for example `ca-chain-internal.pem` and `ca-chain-external.pem`.
+
+## Verify a certificate
+
+Verify a certificate before you commit it. Set the variables once:
+
+```bash
+CERT=configuration/certs/ca-chain.pem
+HOST=artifactory.company.com
+PORT=443
+```
+
+### Check that the file parses
+
+Confirm the file is a valid PEM certificate and read its subject, issuer, and validity dates:
+
+```bash
+openssl x509 -in "$CERT" -noout -subject -issuer -dates
+```
+
+For a file that holds several certificates, `openssl x509` reads only the first one. To confirm that every block
+parses, list them all:
+
+```bash
+openssl crl2pkcs7 -nocrl -certfile "$CERT" | openssl pkcs7 -print_certs -noout
+```
+
+Any error at this step, for example `Could not find certificate from <file>` or `unable to load certificate`,
+means the file is not a valid PEM certificate.
+
+### Check that the chain validates the host
+
+Confirm that the CA in `$CERT` is enough to validate the TLS connection to the host. Look for
+`Verify return code: 0 (ok)`:
+
+```bash
+echo | openssl s_client -connect "$HOST:$PORT" -servername "$HOST" -CAfile "$CERT" 2>&1 \
+  | grep -E "Verify return code|verify error"
+```
+
+- `0 (ok)`: the chain in `$CERT` is sufficient.
+- `20 (unable to get local issuer certificate)`: a root or intermediate certificate is missing from the file.
+
+### Check that a client trusts the host
+
+Confirm that a real client trusts the host with this CA. The command exits with `curl OK` on success:
+
+```bash
+curl --cacert "$CERT" -sSf "https://$HOST:$PORT" -o /dev/null && echo "curl OK"
+```
+
+> [!NOTE]
+> Verify the chain with the CA certificates, not the server leaf certificate. A client trusts a certificate that
+> is present in the CA file directly, so testing with the leaf hides a missing issuer.
+
+## Usage examples
+
+### Secure artifact repositories
+
+**Scenario**: EnvGene needs to connect to an artifact repository exposed over TLS with a private CA.
+
+**Steps**:
+
+1. Obtain the CA certificate, or chain, of the repository.
+2. Place the file in the `configuration/certs/` directory:
+
+   ```text
+   /configuration
+     /certs
+       ca-artifactory.pem
+   ```
+
+3. Verify the certificate with the steps in [Verify a certificate](#verify-a-certificate).
+4. Commit and push. The next pipeline run trusts the repository.
+
+### Internal services with self-signed certificates
+
+**Scenario**: EnvGene needs to reach an internal service that uses a self-signed certificate.
+
+**Steps**:
+
+1. Obtain the self-signed certificate of the internal service.
+2. Place the certificate in the `configuration/certs/` directory:
+
+   ```text
+   /configuration
+     /certs
+       ca-internal-service.pem
+   ```
+
+3. Commit and push. The next pipeline run adds the certificate to the trust store.
+
+## Troubleshooting
+
+| Symptom                    | Check                                                       |
+|----------------------------|-------------------------------------------------------------|
+| Certificate not recognized | PEM encoding, `.crt` or `.pem` extension, correct directory |
+| Connection failures        | Certificate not expired, chain complete                     |
+| Pipeline failures          | Pipeline logs show certificate loading errors               |
+
+To check expiry and chain completeness, rerun the commands in [Verify a certificate](#verify-a-certificate)
+against the target host from the runner.

--- a/docs/how-to/configure-system-certificates.md
+++ b/docs/how-to/configure-system-certificates.md
@@ -27,7 +27,7 @@ For background on the mechanism, see [System certificate configuration](/docs/fe
 
 - Write access to the environment instance repository.
 - The CA certificate, or full certificate chain, of each target service in PEM format.
-- OpenSSL and curl available locally for the verification steps.
+- OpenSSL and cURL available locally for the verification steps.
 
 ## Steps
 


### PR DESCRIPTION
## Summary

Aligns the system certificate documentation with the actual implementation and splits it into a concept feature
doc and a step-by-step how-to.

The docs were checked against the certificate handling scripts (`scripts/utils/handle_certs.sh`,
`scripts/utils/update_ca_cert.sh`). This corrects several drifts and removes an internal implementation detail
(`REQUESTS_CA_BUNDLE`) that misled users into thinking they could set the variable instead of providing a
certificate file.

## Issue

No tracking issue. Documentation-only accuracy fix following a review of `docs/features/system-certificate.md`
against the implementation.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`docs`

## Implementation Notes

- `docs/features/system-certificate.md`: trimmed to concept only (problem statement, approach, supported types,
  technical implementation). Removed all `REQUESTS_CA_BUNDLE` references. Fixed the Alpine trust-anchor copy
  location (the script copies to `/usr/local/share/ca-certificates/`, it does not append to
  `/etc/ssl/certs/ca-certificates.crt`). Documented the `/default_cert.pem` fallback behavior.
- `docs/how-to/configure-system-certificates.md` (new): placement, obtaining certificates, building a chain,
  verification, usage examples, and troubleshooting.
- `README.md`, `docs/README.md`: added the new how-to to navigation.

Structure follows the existing feature vs how-to split in the repo. Content follows the AGENTS.md style rules
(hyphens, no semicolons, sentence-case headings, native callouts, aligned tables, 120-char wrap).

## Tests / Evidence

The verification commands added to the how-to were run for real in an Alpine container (OpenSSL 3.3, the same OS
family as the EnvGene runner image):

- `openssl x509 -noout -subject -issuer -dates` parses a valid cert and errors on a broken file.
- `openssl crl2pkcs7 -nocrl -certfile ... | openssl pkcs7 -print_certs -noout` lists every block in a chain file.
- `openssl s_client -connect ... -CAfile ...` returns `Verify return code: 0 (ok)` with a correct CA and
  `20 (unable to get local issuer certificate)` with an incomplete one.
- `curl --cacert ... -sSf ...` returns `curl OK` with a correct CA.

Distro copy locations and rebuild commands were cross-checked line by line against `update_ca_cert.sh`.

## Additional Notes

Follow-up (out of scope here): the previous doc claimed client certificate (`.p12`/`.pfx`) support that the
implementation does not provide. The rewrite drops those claims from the feature doc and does not carry them into
the how-to, so the new docs are accurate. A dedicated review of the client-cert story can happen separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)