### PR TITLE
docs: apply Collision Parameters symmetrically to external references

### DIFF
--- a/docs/features/calculator-cli.md
+++ b/docs/features/calculator-cli.md
@@ -444,8 +444,8 @@ For a local-category Environment Instance these files hold literal secret values
 Sensitive parameters specified via a `credRef` Credential Reference and external Credentials are written as
 references (VALS URIs or ESO descriptors), at the same parameter paths, to the per-context `credentials.yaml`
 files. The targets are the deployment, pipeline, per-consumer pipeline, and topology files from the
-[Local Sensitive parameters](#version-20-local-sensitive-parameters) list. The runtime `credentials.yaml`,
-`collision-credentials.yaml`, and `custom-params.yaml` never carry external references.
+[Local Sensitive parameters](#version-20-local-sensitive-parameters) list. The runtime `credentials.yaml` and
+`custom-params.yaml` never carry external references.
 
 An Environment Instance is single-category, so a given `credentials.yaml` holds local secrets or references,
 never both. A `credentials.yaml` that holds only references stays plaintext, because references are not
@@ -665,6 +665,17 @@ These parameters establish a dedicated rendering context exclusively applied dur
 
 This context is formed as a result of merging parameters defined in the `deployParameters` sections of the `Tenant`, `Cloud`, `Namespace`, `Application` Environment Instance objects. Parameters from the Application SBOM and `Resource Profile` objects of the Environment Instance also contribute to the formation of this context.
 
+> [!NOTE]
+> Consumers apply these files as an ordered merge sequence when materializing per-application values (for
+> example, as ordered `-f` files for Helm). The canonical order is:
+>
+> 1. `deploy-descriptor.yaml`
+> 2. `credentials.yaml`
+> 3. `deployment-parameters.yaml`
+> 4. `collision-deployment-parameters.yaml`
+> 5. `collision-credentials.yaml`
+> 6. `per-service-parameters/<service-name|app-chart-name>/deployment-parameters.yaml`
+
 For each namespace (identified by its folder name), the context contains files:
 
 ##### \[Version 2.0][Deployment Parameter Context] `deployment-parameters.yaml`
@@ -824,13 +835,14 @@ Root-level parameters from `deployment-parameters.yaml` or `credentials.yaml` ar
 1. The parameter key matches the name of one of the [services](#version-20-service-inclusion-criteria-and-naming-convention)
 2. The parameter is **not** an [Image parameter derived from `deploy_param`](#version-20-image-parameters-derived-from-deploy_param)
 
-Parameters that resolve to external Credentials (references in `credentials.yaml`) are **not** inputs to this
-logic. They never move to `collision-credentials.yaml` or `collision-deployment-parameters.yaml`.
+The rule applies to every sensitive value in `credentials.yaml`, whether the value is a literal secret
+(local-category Environment Instance) or a VALS or ESO reference (external-category Environment Instance).
+The `collision-credentials.yaml` inherits the category of its source `credentials.yaml`.
 
 **Destination files:**
 
-- `collision-deployment-parameters.yaml` — for non-sensitive parameters
-- `collision-credentials.yaml` — for **local** sensitive parameters (defined via `${creds.get(...)}` only)
+- `collision-deployment-parameters.yaml` - for non-sensitive parameters
+- `collision-credentials.yaml` - for sensitive parameters.
 
 > [!NOTE]
 > Only root-level parameters are processed by this collision logic. If a parameter with a service name as its key is nested under a service section, it is not moved to the collision files and remains in its original location.


### PR DESCRIPTION
## Summary

Rework §Collision Parameters in `calculator-cli.md` so the rule applies to every sensitive value in `credentials.yaml`, whether a literal secret (local-category Environment Instance) or a VALS/ESO reference (external-category Environment Instance). The `collision-credentials.yaml` inherits the category of its source `credentials.yaml`.

Also add a canonical merge-order note at the top of §Deployment Parameter Context so the consumer contract is explicit.

## Motivation

Doc-side follow-up to #1537 (impl still open). PR #1539 merged the per-context `credentials.yaml` and `external-credentials.yaml` into one file per context but carried over the pre-merge exclusion clause that treated external references as outside the Collision Parameters rule. That sentence stopped matching reality once references started sharing the file with local secrets: the merged `credentials.yaml` is emitted with a per-service section map that shadows any root-level key whose name matches a service name, so a root-level reference at a colliding key needs the same collision handling that literal secrets get, or consumers overlaying the collision files after the main values would never see it at the root scope.

The change:

- Drops the exclusion clause.
- Restates the rule so it applies to both categories.
- Updates the `collision-credentials.yaml` destination line to point out that the file inherits the category of its source `credentials.yaml`.
- Adds a canonical merge-order note so the consumer contract (which files get applied in what order to produce the final values) is documented in one place.

Doc side only. The calculator impl follow-up belongs to the open impl scope of #1537.

## Scope / Project

`docs`

## Tests / Evidence

- Diff is doc-only, 1 file changed, +18/-6.
- Prose lines wrap at 120 chars, no semicolons, no em-dashes (hyphens throughout).
- Anchors validated: `#version-20deployment-parameter-context-deployment-parametersyaml`, `#version-20deployment-parameter-context-credentialsyaml`, `#version-20deployment-parameter-context-collision-parameters` all exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)