### PR TITLE
docs: remove AWS/Azure Secret Store restriction for system credentials

### DIFF
--- a/docs/features/external-creds.md
+++ b/docs/features/external-creds.md
@@ -747,7 +747,27 @@ GCP auth:
 | `type`                           | Secret Store object | `gcp`                                |
 | `GOOGLE_APPLICATION_CREDENTIALS` | CI/CD variable      | Path to the service account key file |
 
-AWS Secrets Manager and Azure Key Vault are not supported as Secret Stores for system credentials.
+AWS auth:
+
+| Parameter               | Source              | Description                          |
+|-------------------------|---------------------|--------------------------------------|
+| `type`                  | Secret Store object | `aws`                                |
+| `AWS_ACCESS_KEY_ID`     | CI/CD variable      | IAM access key ID                    |
+| `AWS_SECRET_ACCESS_KEY` | CI/CD variable      | IAM secret access key                |
+| `AWS_DEFAULT_REGION`    | CI/CD variable      | AWS region (for example `us-east-1`) |
+
+Azure auth:
+
+| Parameter             | Source              | Description                     |
+|-----------------------|---------------------|---------------------------------|
+| `type`                | Secret Store object | `azure`                         |
+| `AZURE_TENANT_ID`     | CI/CD variable      | Azure AD tenant ID              |
+| `AZURE_CLIENT_ID`     | CI/CD variable      | Service principal client ID     |
+| `AZURE_CLIENT_SECRET` | CI/CD variable      | Service principal client secret |
+
+For multi-store setups, each variable can be prefixed with `<store-id>_` so multiple stores of the same type
+can coexist. See
+[Store identifier and CI/CD variables](#store-identifier-and-cicd-variables).
 
 #### `eso_support` attribute
 
@@ -1319,10 +1339,6 @@ Git operations, and others).
    are pre-created by the user in the external Secret Store, so they are not included in the
    [External Credential Context](#external-credential-context) creation entries.
 
-2. **System Credential Secret Store type.** Every system Credential with `type: external` references a
-   [Secret Store](#secret-store) of type `vault` or `gcp`. `aws` and `azure` are not supported as Secret
-   Stores for system credentials.
-
 #### During CMDB import
 
 1. **No external credentials.** The Environment Instance being imported contains no [Credentials](#credential)
@@ -1338,8 +1354,6 @@ Git operations, and others).
 
 1. Support Blue-Green deployment cases
 2. Support template composition
-3. Support AWS Secrets Manager as a Secret Store for system credentials
-4. Support Azure Key Vault as a Secret Store for system credentials
 
 ## Open questions
 


### PR DESCRIPTION
## Summary

The [Secret Store](/docs/features/external-creds.md#secret-store) `type` enum already lists all four backends (`vault`, `azure`, `aws`, `gcp`), and deployment-flow references (VALS, ESO) and the [External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md) already support all four through the `MultiStoreProvider` in the [qubership-pipelines-common-python-library](https://github.com/Netcracker/qubership-pipelines-common-python-library/blob/main/docs/secret_manager_auth.md). The system-credential read side kept a `vault`/`gcp` restriction that is not backed by a technical limit.

## Changes

- `docs/features/external-creds.md` §Authentication to the Secret Store: drop the restriction sentence. Add AWS auth and Azure auth tables symmetric with Vault and GCP. Note the `<store-id>_` variable prefix for multi-store setups.
- `docs/features/external-creds.md` §During system credentials read: drop validation rule 2 (`aws` and `azure` not supported).
- `docs/features/external-creds.md` §To Do: drop items 3 and 4 (support AWS / Azure for system credentials).

## Scope / Project

`docs`. Under umbrella #1380 (External Credentials Management).

## Related

- Impl-side ticket for the corresponding runtime wiring (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` into the system-credential read code path) will be filed as a separate issue under #1380.
- Library reference: <https://github.com/Netcracker/qubership-pipelines-common-python-library/blob/main/docs/secret_manager_auth.md>

## Tests / Evidence

- Doc-only change, 1 file, +21/-7.
- Prose lines within 120 chars, no semicolons, no em-dashes.
- Anchor `#store-identifier-and-cicd-variables` verified as existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)