### PR TITLE
docs: clarify GCP VALS path is independent of Credential id map key

### DIFF
--- a/docs/features/external-creds-provisioning-cli.md
+++ b/docs/features/external-creds-provisioning-cli.md
@@ -109,9 +109,12 @@ credentials:
   <cred-id>:
     # Mandatory
     # VALS reference string that addresses the secret. The string is a path only — no
-    # key segments (no `#` fragment). The CLI infers the store type from the VALS
-    # scheme. The store identifier comes from the `secret_store_id` query parameter,
-    # or defaults to `default_store` when the parameter is absent.
+    # key segments (no `#` fragment). The path is independent of the Credential id map
+    # key: its last segment is the secret name in the store, which the caller may compose
+    # from a remote reference path (for example `shared--envgene--gcp-license-token`). The
+    # CLI infers the store type from the VALS scheme. The store identifier comes from the
+    # `secret_store_id` query parameter, or defaults to `default_store` when the parameter
+    # is absent.
     vals: string
     # Mandatory
     # See the Strategy enum section for the meaning of each value.
@@ -163,7 +166,7 @@ credentials:
     strategy: fail_if_absent
 
   gcp-license-token:
-    vals: "ref+gcpsecrets://example-project/gcp-license-token"
+    vals: "ref+gcpsecrets://example-project/shared--envgene--gcp-license-token"
     strategy: create_if_absent
     data: _generateValue
 


### PR DESCRIPTION
## What

In `docs/features/external-creds-provisioning-cli.md` the GCP example used the same string (`gcp-license-token`) for both the `credentials` map key and the last segment of the `vals` path. This read as if the path segment must equal the Credential id.

In reality the caller composes the path segment from a remote reference path, so it looks like `shared--envgene--gcp-license-token` — visibly different from the map key.

## Change

- Add a note in the schema comment that the `vals` path is independent of the Credential id map key, and that its last segment is the store secret name.
- Update the GCP example to use a composite path segment so the independence is obvious to readers.

Docs-only. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)