### PR TITLE
docs: add artifact resolution doc and fix registry doc gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ After the pipeline finishes, the Environment configuration will be generated and
 - [**Cloud Passport Processing**](/docs/features/cloud-passport-processing.md) - How a [Cloud Passport](/docs/envgene-objects.md#cloud-passport) is resolved and merged into the environment's Cloud object during environment generation
 - [**Effective Set Calculation**](/docs/features/calculator-cli.md) - Calculate the [Effective Set](/docs/features/calculator-cli.md#effective-set-v20)
 - [**Application and Registry Definition**](/docs/features/app-reg-defs.md) - Describe how applications and registries are defined and referenced
+- [**Artifact Resolution**](/docs/features/artifact-resolution.md) - Describe how EnvGene searches registries and resolves versions to download artifacts
 - [**Environment Inventory Generation**](/docs/features/env-inventory-generation.md) - Auto-generate [Environment Inventory](/docs/envgene-configs.md#env_definitionyml)
 - [**Environment Instance Generation**](/docs/features/environment-instance-generation.md) - Generate Environment Instances from templates and inventories
 - [**Credential Rotation**](/docs/features/cred-rotation.md) - Automate [Credential](/docs/envgene-objects.md#credential) rotation

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@
 - [**Effective Set Generation**](/docs/features/effective-set-generation.md) - Generate the [Effective Set](/docs/features/calculator-cli.md#effective-set-v20) for an environment; covers full and [partial](/docs/features/effective-set-generation.md#partial-generation) modes
 - [**Custom Params**](/docs/instance-pipeline-parameters.md#custom_params) for session-scoped overrides
 - [**Application and Registry Definition**](/docs/features/app-reg-defs.md) - Describe how applications and registries are defined and referenced
+- [**Artifact Resolution**](/docs/features/artifact-resolution.md) - Describe how EnvGene searches registries and resolves versions to download artifacts
 - [**Environment Inventory Generation**](/docs/features/env-inventory-generation.md) - Auto-generate [Environment Inventory](/docs/envgene-configs.md#env_definitionyml)
 - [**Environment Instance Generation**](/docs/features/environment-instance-generation.md) - Generate Environment Instances from templates and inventories (including BG support)
 - [**Credential Rotation**](/docs/features/cred-rotation.md) - Automate [Credential](/docs/envgene-objects.md#credential) rotation

--- a/docs/envgene-objects.md
+++ b/docs/envgene-objects.md
@@ -1913,8 +1913,7 @@ registry:
     repositoryDomainName: string
     # Mandatory
     # Snapshot repository name
-    # EnvGene checks repositories in this order: release -> staging -> snapshot
-    # It stops when it finds the artifact
+    # EnvGene searches these repositories concurrently and uses the first that returns the artifact
     targetSnapshot: string
     # Mandatory
     # Staging repository name
@@ -2073,21 +2072,20 @@ registry:
     # Domain name of the registry
     repositoryDomainName: string
     # Optional
-    # Used in case of provider nexus or artifactory only
+    # Used in case of provider nexus, artifactory, or azure only
     # Snapshot repository name
-    # EnvGene checks repositories in this order: release -> staging -> snapshot
-    # It stops when it finds the artifact
+    # EnvGene searches these repositories concurrently and uses the first that returns the artifact
     targetSnapshot: string
     # Optional
-    # Used in case of provider nexus or artifactory only
+    # Used in case of provider nexus, artifactory, or azure only
     # Staging repository name
     targetStaging: string
     # Optional
-    # Used in case of provider nexus or artifactory only
+    # Used in case of provider nexus, artifactory, or azure only
     # Release repository name
     targetRelease: string
     # Optional
-    # Used in case of provider nexus or artifactory only
+    # Used in case of provider nexus, artifactory, or azure only
     # Snapshot Maven repository group name
     snapshotGroup: string
     # Optional
@@ -2142,11 +2140,6 @@ registry:
   mavenConfig:
     authConfig: aws-maven
     repositoryDomainName: "https://codeartifact.eu-west-1.amazonaws.com/maven/app"
-    targetSnapshot: "snapshots"
-    targetStaging: "staging"
-    targetRelease: "releases"
-    snapshotGroup: "snapshot-group"
-    releaseGroup: "release-group"
 ```
 
 **Example with GCP Artifact Registry:**
@@ -2175,12 +2168,7 @@ registry:
       gcpRegSAEmail: "example@example.com"
   mavenConfig:
     authConfig: gcp-maven
-    repositoryDomainName: "https://artifactregistry.googleapis.com"
-    targetSnapshot: "maven-snapshots"
-    targetStaging: "maven-staging"
-    targetRelease: "maven-releases"
-    snapshotGroup: "maven-snapshots-group"
-    releaseGroup: "maven-releases-group"
+    repositoryDomainName: "https://europe-west1-maven.pkg.dev/123456789012/maven-repo"
 ```
 
 **Example with Azure Artifacts:**
@@ -2522,19 +2510,19 @@ mavenConfig:
   # Domain name of the registry
   repositoryDomainName: string
   # Optional
-  # Used in case of authMethod nexus or artifactory only
+  # Used in case of provider nexus, artifactory, or azure only
   # Snapshot Maven repository name
   targetSnapshot: string
   # Optional
-  # Used in case of authMethod nexus or artifactory only
+  # Used in case of provider nexus, artifactory, or azure only
   # Staging Maven repository name
   targetStaging: string
   # Optional
-  # Used in case of authMethod nexus or artifactory only
+  # Used in case of provider nexus, artifactory, or azure only
   # Release Maven repository name
   targetRelease: string
   # Optional
-  # Used in case of authMethod nexus or artifactory only
+  # Used in case of provider nexus, artifactory, or azure only
   # Snapshot Maven repository name
   snapshotGroup: string
   # Optional
@@ -2782,11 +2770,6 @@ authConfig:
 mavenConfig:
   authConfig: aws
   repositoryDomainName: https://codeartifact.eu-west-1.amazonaws.com/maven/app
-  targetSnapshot: snapshots
-  targetStaging: staging
-  targetRelease: releases
-  snapshotGroup: snapshot-group
-  releaseGroup: staging-group
 dockerConfig:
   authConfig: aws
   snapshotUri: 123456789.dkr.ecr.eu-west-1.amazonaws.com:18080

--- a/docs/features/app-reg-defs.md
+++ b/docs/features/app-reg-defs.md
@@ -168,6 +168,9 @@ EnvGene resolves `application:version` references through the definitions in two
 - [Effective Set generation](/docs/features/effective-set-generation.md), which resolves every application referenced
   by the SDs it processes.
 
+For how EnvGene searches the registries and resolves the version to download an artifact, see
+[Artifact Resolution](/docs/features/artifact-resolution.md).
+
 Resolution reads the root-level folders first and falls back to the per-environment folders. The fallback exists for
 backward compatibility only: all consumers must migrate to the root-level folders.
 

--- a/docs/features/artifact-resolution.md
+++ b/docs/features/artifact-resolution.md
@@ -1,0 +1,64 @@
+# Artifact resolution
+
+- [Artifact resolution](#artifact-resolution)
+  - [Version forms](#version-forms)
+  - [Processing](#processing)
+    - [AWS and GCP registries](#aws-and-gcp-registries)
+    - [Version resolution](#version-resolution)
+
+EnvGene resolves and downloads Maven artifacts in two flows:
+
+1. Download an environment template.
+2. Download an application artifact.
+
+Both begin the same way. Each resolves and downloads a Deployment Descriptor (DD), then fetches the payload.
+This document covers the shared DD-resolution logic.
+
+The DD is a JSON artifact addressed by the artifact coordinates (`groupId:artifactId:version`). The
+coordinates come from a definition object that differs by flow:
+
+1. [Artifact Definition](/docs/features/app-reg-defs.md) for the environment template
+2. [Application Definition](/docs/features/app-reg-defs.md) for the application artifact
+
+Both reference a [Registry Definition](/docs/features/app-reg-defs.md), which declares the repositories to
+search.
+
+## Version forms
+
+The `version` in the coordinates takes one of two forms:
+
+- **Snapshot version.** Ends with `-SNAPSHOT`. It denotes the latest non-released build, not a specific one.
+
+  For example: `1.0.0-SNAPSHOT` or `20260720.122600-SNAPSHOT`.
+
+- **Fixed version.** Has no `-SNAPSHOT` suffix. It names one exact artifact, which can be a release or a
+  pinned snapshot build.
+
+  For example: `1.0.0` or `1.0.0-20260720.122600-1`.
+
+Maven publishes each snapshot build under a unique timestamped version, for example `1.0.0-20260720.122600-1`,
+inside the `1.0.0-SNAPSHOT/` folder. The version-level `maven-metadata.xml` maps `1.0.0-SNAPSHOT` to the
+latest build. A pinned snapshot build is a fixed version that names one such build.
+
+## Processing
+
+EnvGene searches the candidate repositories concurrently, and the first to return the DD wins. If none returns
+the DD, resolution fails. The version form does not affect which repositories are searched.
+
+The candidate repositories come from the Registry Definition `mavenConfig`: `targetSnapshot`, `targetStaging`,
+`targetRelease`, and `snapshotGroup`. The Nexus, Artifactory, and Azure providers and all Registry Definition
+v1 registries use them. AWS and GCP are the exception.
+
+### AWS and GCP registries
+
+For the AWS and GCP providers, `repositoryDomainName` addresses one repository that holds every artifact, so
+`mavenConfig` sets no candidate repositories and EnvGene searches that single repository. The provider is
+declared in Registry Definition v2 `authConfig`.
+
+### Version resolution
+
+Within each searched repository EnvGene builds the URL from the version form:
+
+- **Snapshot version.** EnvGene reads `maven-metadata.xml` to resolve `-SNAPSHOT` to the latest build. The
+  metadata records the latest build per artifact type, so EnvGene picks the one for the DD and requests it.
+- **Fixed version.** EnvGene requests the file directly.


### PR DESCRIPTION
## Summary

Add a feature doc that describes how EnvGene resolves and downloads the Deployment Descriptor and the artifact
payload (environment template or application artifact): version forms, concurrent repository search, and
version resolution. The doc describes the current behavior.

Correct several discrepancies in the registry documentation (`docs/envgene-objects.md`) so it matches the
searcher:

- The search-order comment claimed a sequential `release -> staging -> snapshot`. The searcher queries all
  repositories concurrently and uses the first that returns the artifact.
- The target repository fields were documented as "nexus or artifactory only". The current searcher also uses
  them for the Azure provider.
- Registry Definition v2 said `authMethod nexus or artifactory` for those fields. `nexus`/`artifactory` are
  `provider` values, not `authMethod` values.
- The AWS and GCP examples set `targetSnapshot`/`targetStaging`/`targetRelease`/`snapshotGroup`, which the
  searcher ignores for those providers (they use a single `repositoryDomainName`).
- The GCP example `repositoryDomainName` was a bare host and would not resolve.

Add index entries in both readmes and cross-links between the new doc and Application and Registry Definition.

## Issue

No issue. This is a documentation-alignment change split from a larger effort. Follow-up code changes are
tracked separately (see Additional Notes).

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`docs`

## Implementation Notes

The new doc describes the current searcher behavior only. Three known gaps between the current behavior and the
intended design are deliberately left for follow-up PRs, so this PR does not change any behavior:

- Azure resolving against a single repository like AWS and GCP.
- The searcher using `releaseGroup`.
- Version-form-based repository selection instead of searching all repositories.

## Tests / Evidence

Documentation-only change. `markdownlint` (project config) and `textlint` (terminology) pass on all changed
files.

## Additional Notes

Follow-up PRs will move Azure to the single-repository model and change the snapshot criteria, candidate
repositories, and repository selection to the target design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)