### PR TITLE
docs: publish design-to-cr skill and align creating-cr

### DIFF
--- a/.claude/skills/design-to-cr/SKILL.md
+++ b/.claude/skills/design-to-cr/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: design-to-cr
+description: >-
+  This skill should be used when the user wants to turn a settled design into a change request (CR)
+  issue in Netcracker/qubership-envgene. One pipeline - draft, validate, publish - runs the same no
+  matter where the draft's material comes from. The source only seeds the first draft. Sources: an
+  existing design doc or doc PR (parse it), or the working context - the conversation, code
+  investigation, and memory (synthesize it). Trigger on "file a CR from this PR", "turn this feature
+  doc into an issue", "doc PR to issue", "draft a ticket", "make a CR ticket in stuff/", "create the
+  ticket then publish", or "file a Feature issue" for a settled design. Trigger this whenever the user
+  is heading toward a qubership-envgene implementation CR, even if they do not name the format or say
+  "CR" - filing an implementation issue from a design, a doc PR, or notes shaped from the working
+  context all belong here.
+---
+
+# design-to-cr
+
+Turn a settled design into a change request (CR) issue in `Netcracker/qubership-envgene`. A CR hands
+a finished design to a developer for implementation: it cuts the implementation slice and states how
+the work is verified. This skill produces the issue only. It never pushes branches or opens PRs -
+shipping the design docs is a separate flow, and the CR just links to where that design lives.
+
+The body format is the six-section convention in `docs/dev/creating-cr.md`, which is the single
+source of truth for section order, meaning, and good/bad examples. Do not restate those sections
+here or invent variants - open that file when writing the body. Two sections are optional and only
+appear when the material genuinely exists - see `Optional sections` below.
+
+Target repository is hardcoded `Netcracker/qubership-envgene`. Fail loud on any other repository.
+
+A CR-ready draft is bounded and link-driven: it states the situation and problem in a few sentences,
+points at a settled design with a durable link, cuts a numbered implementation slice where each item
+names what it touches, and gives observable acceptance conditions. If the design is not settled or has
+no addressable reference, the work is not ready for a CR - route the user to an analysis issue rather
+than forcing a body.
+
+## Pick the source
+
+One pipeline - draft, validate, publish - runs the same regardless of source. The source only decides
+how the first draft is seeded. Everything downstream - link rigor, iteration, filing, house rules - is
+shared. Two sources:
+
+- **An existing design doc or doc PR.** The input names a design artifact: a doc PR (URL or number) or
+  a path to a `docs/features/*.md` file. Parse it into the draft. Read `references/from-doc-or-pr.md`
+  for the parse-and-generate mechanics.
+- **The working context.** There is no ready doc, so synthesize the draft from what the session already
+  holds: the conversation, your code investigation, and memory. Read `references/from-context.md` for
+  the synthesize-and-draft mechanics.
+
+The source seeds the draft. It does not change the requirement for a `Design reference`: every CR links
+a committed design doc or PR, even when the draft was synthesized from context rather than parsed from
+that doc. When the source is ambiguous (a design doc exists but the user has not said whether to parse
+it or synthesize), ask before doing work.
+
+## Shared workflow
+
+### Draft as a dry run by default
+
+Creating an issue is outward-facing and hard to reverse, so never file on the first turn. Produce the
+draft first as a local Markdown file in the user's scratch dir, and treat it as provisional until the
+user gives an explicit go-ahead. The draft always carries an H1 title line plus the
+`creating-cr.md` sections. Omit optional sections that are empty rather than filling them with noise.
+
+### Optional sections
+
+Two sections are optional and must never be padded to look complete. Add each only when its material
+genuinely exists, and omit it entirely otherwise - an absent section reads better than an invented one.
+
+- **Out of scope changes.** Include this only when there are real exclusions to name: work a reader
+  might expect that this CR deliberately leaves out. Do not infer or invent exclusions - the boundary
+  is an analyst decision, not something derivable from the design. When nothing is genuinely excluded,
+  drop the section rather than writing "none" or padding it.
+- **Covered cases.** Add this, right after `In scope changes`, only when the change enumerates
+  discrete shapes or scenarios worth pinning as YAML, for example topology cases or credential shapes.
+  When the change has no such enumerable cases, omit it.
+
+### Acceptance notation
+
+Write each acceptance condition in collapsed Gherkin: `Given <fixture>, <observable outcome>.` The Given
+states the prepared on-disk state, committed fixtures, and any run or placement mode. The rest collapses
+Gherkin's When and Then into one observable-outcome clause. This complements, and does not replace, the
+Acceptance principles in `docs/dev/creating-cr.md`, so honor those rather than restating them here.
+
+- Make every outcome externally observable through an existing channel: a job log, a mock registry, an
+  emitted request, or an error message. Prefer "the artifact is requested from registry X" or "the job
+  fails with an error naming the missing definition and both checked locations" over internal state like
+  "resolution uses the root-level copy". Give fixtures distinguishing traits so the outcome is checkable,
+  for example a distinct registry name per copy so the request target reveals which copy won.
+- Keep each bullet self-contained by inlining the observable contract. Do not link to use cases or design
+  sections from inside an acceptance bullet.
+- Enumerate every case that can fail independently, covering the happy path and each failure mode. A
+  condition is redundant only when it cannot fail independently of the others, not when it is logically
+  derivable. Do not fold distinct failures such as a missing folder versus a missing file into one bullet.
+- When a placement or run mode appears in a Given, treat it as on-disk setup only. The rule "do not
+  branch the implementation on the mode" is implementer guidance for Implementation notes, not an
+  acceptance bullet.
+
+Example:
+
+> - Given an AppDef committed only under `configuration/` and none at the instance root, the job fails
+>   with an error naming the missing definition and both checked locations.
+
+### Design reference link rigor
+
+The design-reference link, and each in-scope item's link, must survive the design PR's merge and the
+deletion of its source branch. This rule holds for every source.
+
+- In the `Design reference` section, use a PR reference like `#1198` (GitHub auto-links it and it
+  stays after merge) and/or a commit-SHA permalink to the design doc, for example
+  `https://github.com/Netcracker/qubership-envgene/blob/<sha>/docs/<path>.md`. Get the SHA from the
+  PR head (`mcp__github__pull_request_read` method `get`, field `head.sha`), the merge commit, or
+  `git log -1 --format=%H -- <path>` for a committed local file.
+- Give each `In scope changes` item an inline anchor permalink to the specific design section that
+  motivates it, on the most relevant noun (the modified file, schema field, job, or parameter):
+  `https://github.com/Netcracker/qubership-envgene/blob/<sha>/docs/<path>.md#<anchor>`. Compute the
+  anchor by lowercasing the heading text, replacing spaces with `-`, and stripping every non
+  alphanumeric character except `-`.
+- Never emit branch-pinned URLs (`.../blob/<branch-name>/...`) - they break on branch deletion.
+- If the design doc is not yet committed, do not invent a SHA. Emit `<add permalink after
+  committing>` as a placeholder and warn the user. Repo-relative links like `/docs/...#anchor` are
+  acceptable only for docs guaranteed to land on the default branch.
+- If an in-scope item has no matching design section (a derived change such as a test or refactor),
+  append `<!-- TODO: link to specific design section -->`, link to the file-level permalink, and warn
+  rather than blocking. The user decides whether to add an addressable section or accept the placeholder.
+
+### Iterate to confirmation
+
+Apply the user's edits and re-present the draft until they explicitly signal to file. The draft lives
+in a local file, and the user may edit it by hand between turns, so re-read the file before every edit
+rather than trusting the last write. Do not file until the user says so with words like `create`,
+`file it`, or `publish`, and confirm once more before the write.
+
+### Issue type and title
+
+Match the GitHub issue type to the change's nature and prefix the draft's H1 accordingly, per the
+`Issue type and title` section of `creating-cr.md`: Feature (`[Feat:]`), Bug (`[Bug:]`), or Story
+(`[Story:]`, or `[Docs:]` for a documentation ticket). The H1 carries the prefix, so the filed issue
+title carries it too.
+
+### File the issue
+
+On the go-ahead, re-present the final draft, ask one confirmation question, and on `yes`:
+
+1. Resolve the issue type with `mcp__github__list_issue_types` using **owner only**
+   (`owner: Netcracker`, no `repo`). The repository-level call returns 404 for this org. Match the
+   type to the change's nature (Feature, Bug, or Story; a docs ticket is a Story), and default to
+   `Feature` if unclear.
+2. Call `mcp__github__issue_write` with `method: create`, `owner: Netcracker`,
+   `repo: qubership-envgene`, `type` = the matched type, `title` = the draft H1 (with its `[Feat:]` /
+   `[Bug:]` / `[Story:]` / `[Docs:]` prefix), and `body` = the draft **without** the H1 line, so the
+   body starts at `## Context`. Do not set labels.
+3. Return the resulting issue URL.
+
+### AGENTS.md compliance
+
+Keep the body publish-ready under the repository house rules in `AGENTS.md`, even though the draft file
+lives outside the repository: plain hyphen-minus for dashes (no em or en dash), no semicolons in
+prose, wrap prose at 120 characters, vertically aligned table pipes, sentence-case headings, and
+GitHub native callouts. Chat may be Russian, but the artifact ships in English. Before filing, verify the
+body: grep for em or en dashes and semicolons, and check prose line length against 120.
+
+## Guardrails
+
+- Confirm once before creating the issue. Never create without an explicit go-ahead.
+- Issue types for this org are org-level. Always query `list_issue_types` with owner only.
+- The issue title is the draft H1. The issue body is everything after the H1.
+- Use the GitHub MCP tools, not the `gh` CLI, for reads and writes.
+
+## Failure modes
+
+- **No design reference.** The work is not ready for a CR. Say so and stop - a link-less CR cannot be
+  scoped or reviewed.
+- **Repository other than `Netcracker/qubership-envgene`.** Fail loud. The skill is hardcoded for this
+  repository.
+- Source-specific failure modes (a doc PR with no feature doc, multiple feature docs, a missing
+  Acceptance section, an ambiguous draft path) live in the source references.
+
+## Non-goals
+
+- Do not push branches or open PRs. Doc shipping is a separate flow. The CR only links to it.
+- Do not work cross-repo. Fork or adapt the skill for other repos.
+- Do not auto-edit `docs/dev/creating-cr.md` or this `SKILL.md` from learnings. Learnings are
+  advisory. The user applies them.
+
+## Reference files
+
+- Read `references/from-doc-or-pr.md` when the source is an existing design doc or PR (a doc PR or a
+  `docs/features/*.md` path) - source resolution, the heading-to-section mapping, title derivation,
+  per-item anchor matching, the flat/grouped list rule, and its failure modes.
+- Read `references/from-context.md` when the source is the working context and no ready doc exists -
+  input gathering, the `stuff/` draft path, section assembly, the re-read-every-turn rule, and the
+  translate-to-English-before-filing rule.

--- a/.claude/skills/design-to-cr/references/from-context.md
+++ b/.claude/skills/design-to-cr/references/from-context.md
@@ -1,0 +1,60 @@
+# Source: the working context
+
+Synthesize the CR draft from the working context - the conversation, your code investigation, and
+memory - as a local Markdown file the user edits by hand across turns, then file it. Use this when
+there is no ready feature doc to parse. The pipeline (dry-run default, link rigor, filing, AGENTS
+compliance) lives in `SKILL.md`. This file covers only the synthesize-and-draft mechanics.
+
+## Phase 1 - draft the local Markdown
+
+Gather the inputs, asking only for what is missing:
+
+- The change in one or two sentences (Context - the situation and the problem, not the action).
+- The design reference. Apply the shared link-rigor rules. If no design reference exists, the work is
+  not ready for a CR - say so and stop.
+- The in-scope changes, numbered, each naming what it changes in the design's own terms (a documented
+  object, schema field, job, or parameter, not a private function or file path), each with its anchor
+  permalink.
+- Optional: covered cases (enumerable shapes as YAML), acceptance conditions, implementation notes,
+  and out-of-scope items (only if the user states them - never infer the boundary).
+
+Pick the draft path. Default to the user's scratch area beside the cloned repository,
+`<repo-parent>/stuff/<slug>-ticket.md`, where the slug is the kebab-case feature name. This directory
+is outside the repository and is never committed. Confirm the path if it is ambiguous.
+
+Write the file:
+
+- Start with `# [<Type>:] <Title>` as the H1 - the issue title with its type prefix per
+  `creating-cr.md` (backticks allowed for code).
+- Follow with the `creating-cr.md` sections in order. Omit optional sections that are empty rather
+  than leaving hollow placeholders.
+- Keep items terse and link-driven.
+- Apply the `AGENTS.md` house rules from the start so the body is publish-ready.
+
+Print the path. Tell the user to edit it by hand and to say `file it` when ready.
+
+## Phase 2 - manual iteration
+
+The local Markdown is the living source of truth, and the user edits it directly between turns.
+
+- **Re-read the file at the start of every turn, before any edit.** It may have changed since the
+  last write, and acting on a stale in-memory copy would silently discard the user's hand edits. Do
+  not assume the last write is still current.
+- Apply the requested edits, keep the file AGENTS-compliant, and re-lint on request.
+- Do not file the issue until the user explicitly asks.
+
+## Phase 3 - file the issue
+
+Trigger words: `file it`, `create the ticket`, `publish`. Before filing:
+
+- **Translate any non-English prose to English.** Chat may be Russian, but the ticket ships in
+  English. Do this on the draft as the last editing step, so the filed body is fully English.
+- Follow the shared filing procedure in `SKILL.md`: confirm once, resolve the type owner-only, create
+  with the matched issue type, title = the H1 text (with its type prefix), body = the draft minus the
+  H1 line. Return the issue URL.
+
+## Failure modes (this source)
+
+- **Ambiguous draft path.** Confirm the `stuff/` location before writing rather than guessing where
+  the user keeps scratch files.
+- **Non-English prose still present at filing.** Translate before the `issue_write` call, not after.

--- a/.claude/skills/design-to-cr/references/from-doc-or-pr.md
+++ b/.claude/skills/design-to-cr/references/from-doc-or-pr.md
@@ -1,0 +1,84 @@
+# Source: an existing design doc or PR
+
+Parse an existing design artifact and generate the CR body. Use this when the input names a doc PR
+(URL or number) or a path to a `docs/features/*.md` file. The pipeline (dry-run default, link rigor,
+filing, AGENTS compliance) lives in `SKILL.md`. This file covers only the parse-and-generate
+mechanics.
+
+## 1. Resolve the source
+
+Take one of two inputs. If the user provides neither, ask which.
+
+- **`pr <number-or-url>`.** Call `mcp__github__pull_request_read` with `method: get` to confirm the
+  PR exists and to capture `head.sha` for later permalinks. Then call `method: get_files` and filter
+  the changed paths to `docs/features/*.md`. If several feature docs are touched, list them and ask
+  which one to use. Run the flow once per chosen file if the user wants multiple issues.
+- **`file <path>`.** Read the file. Verify it lives under `docs/features/`. If it does not, fail loud
+  rather than parsing an arbitrary Markdown file as a feature doc.
+
+Capture the SHA the body will pin to: `head.sha` for a PR, or `git log -1 --format=%H -- <path>` for
+a committed local file. If a local file is uncommitted, follow the placeholder rule in the shared
+link-rigor section.
+
+## 2. Parse the feature doc into sections
+
+Map the doc's structure onto the `creating-cr.md` sections best-effort, by heading text. Feature docs
+vary, so match on any of these cues:
+
+- **Issue title** - the H1. See title derivation below.
+- **Context** - the first non-heading paragraph, or `## Description` / `## Overview` / `## Problem`.
+  State the situation, not the action.
+- **In scope changes** - `## Changes` / `## Components where behavior changes` / `## Requirements` /
+  top-level numbered lists. Structure per the flat/grouped rule.
+- **Acceptance** - `## Acceptance` / `## Acceptance criteria` / `## Results` / observable behavioral
+  statements. Observable and testable.
+- **Implementation notes** - mentions of "PoC", "for now", "out of scope", named libraries, `@user`
+  contacts, "use the X pattern". Emit only if such hints exist.
+
+Do not derive `Out of scope changes` - that boundary is an analyst decision. Leave it for the user.
+
+When a structural element is missing, generate the section with a `<!-- TODO: ... -->` placeholder
+and explain the gap in the dry-run output rather than inventing content.
+
+## 3. Derive the title
+
+Take the doc's H1, tighten it (optionally with a phrase from Context), and keep it under about 70
+characters. Prefix it with the issue-type tag per `creating-cr.md` (`[Feat:]`, `[Bug:]`, `[Story:]`,
+or `[Docs:]`).
+
+## 4. Per-item anchor permalinks
+
+Each `In scope changes` item needs an inline anchor permalink to the design section that motivates
+it. Compute the anchor and pin the SHA per the shared link-rigor rules. The source-specific part is
+how to find the right section:
+
+1. Identify the motivating design section by heading match, structural correspondence, or keyword
+   match in the design text.
+2. Attach the link to the most relevant noun in the item - the modified component, file, or schema
+   field.
+3. If no section matches, emit the item, append `<!-- TODO: link to specific design section -->`,
+   and warn the user that the item is either a derived change (link to the file-level permalink and
+   drop the TODO) or needs an addressable section added to the design. Do not block the dry run.
+
+## 5. Flat or grouped in-scope list
+
+Mirror the design's own structure. Do not impose a shape it does not have.
+
+- If the design clusters changes under thematic headings (for example a `## Validation` section with
+  several sub-rules), emit a grouped list: a top-level umbrella with sub-items.
+- If the design is flat (each change is its own top-level concern), emit a flat list.
+- Never nest more than one level deep.
+- If a group would have a single sub-item, flatten it to a top-level item - a one-child group carries
+  no signal.
+- Every item and sub-item carries its own anchor link.
+
+## Failure modes (this source)
+
+- **Doc PR contains no `docs/features/*.md`.** Refuse and explain: the CR convention applies to
+  implementation handoffs derived from feature docs. Suggest an analysis or investigation issue
+  instead. Do not generate a draft.
+- **Multiple feature docs in one PR.** List them and ask which one (or set) to use. Run the flow once
+  per chosen file.
+- **Feature doc lacks an Acceptance-like section.** Generate `## Acceptance` with
+  `<!-- TODO: extract from design -->` and tell the user the section needs manual work.
+- **`file` path is outside `docs/features/`.** Fail loud - it is not a feature doc.

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ build/
 .DS_Store
 pyrightconfig.json
 junit*
+
+# Claude Code local (per-user) files - the shared skill under .claude/skills/ is committed
+.claude/settings.local.json
+.claude/*.lock

--- a/docs/dev/creating-cr.md
+++ b/docs/dev/creating-cr.md
@@ -10,6 +10,7 @@
   - [Acceptance](#acceptance)
   - [Implementation notes](#implementation-notes)
 - [Issue body template](#issue-body-template)
+- [Issue type and title](#issue-type-and-title)
 - [Creating the issue](#creating-the-issue)
 
 ## Description
@@ -93,7 +94,11 @@ If no design reference exists, the work is not ready for a CR.
 ### In scope changes
 
 Required. A numbered list of changes this CR makes. Each item names what is modified or added,
-and at what level (file, schema field, job, parameter).
+and at what level (file, schema field, job, parameter). Name that level in the design's own
+terms, not in implementation internals such as a private function name, a module path, or a source
+file location. The CR hands a settled design to a developer, who locates the code. A
+code-level pointer dates the ticket and locks the solution to one implementation before the
+developer has looked at the code.
 
 Each item must include an inline link to the specific design section that describes it. Use an
 anchor link in the SHA-pinned permalink to the design doc:
@@ -134,6 +139,16 @@ Bad:
 
 The bad example does not let the reader judge whether the scope is sized correctly, and has no
 link to the design section that describes the change.
+
+Also avoid the opposite pitfall - naming implementation internals rather than the design's entities:
+
+Bad (code-level):
+
+> 1. Change the `get_repo_value_pointer_dict` function in `python/.../artifact.py` to branch on the
+>    version.
+
+Name the observable behavior and the entities the design defines, as the Good example above does. A
+code-level pointer pins one implementation and breaks when the code moves.
 
 ### Out of scope changes
 
@@ -262,12 +277,26 @@ same structure. Sections marked optional may be omitted when empty.
 <optional - branch, libraries, contacts, horizon hints>
 ````
 
+## Issue type and title
+
+The GitHub issue type and the title prefix reflect the change's nature:
+
+- **Feature** - a new capability. Title prefix `[Feat:]`.
+- **Bug** - a defect in existing behavior. Title prefix `[Bug:]`.
+- **Story** - a change that is neither a new capability nor a defect, for example a gap in an existing
+  feature. Title prefix `[Story:]`.
+
+A ticket that only creates or updates documentation is a Story with the `[Docs:]` title prefix.
+
+So a title reads `[Feat:] Support Azure single-repository resolution`, and the issue is created with
+the matching type.
+
 ## Creating the issue
 
-Use the local skill `doc-pr-to-issue`. The skill takes a documentation PR URL or a path to a
-feature doc, parses the content, and produces a draft issue body that follows the template
-above. Review the draft, fill out of scope changes and implementation notes where the skill
-cannot derive them, and post.
+Use the skill `design-to-cr`. It turns a settled design into a CR issue that follows the
+template above. The design can come from a doc PR, a feature doc, or the working context. The skill
+drafts the body, you review and fill any sections it cannot derive, and it files the issue on your
+go-ahead.
 
-The skill lives at `~/.claude/skills/doc-pr-to-issue/` for now. Team publication is a separate
-decision.
+The skill lives in the repository at `.claude/skills/design-to-cr/`, so Claude Code picks it up
+automatically when working in this repository.


### PR DESCRIPTION
## Summary

Publish the CR-authoring skill under `.claude/skills/design-to-cr/` so Claude Code picks it up when working in
this repository, and align `docs/dev/creating-cr.md` (the CR convention the skill follows).

The skill turns a settled design into a change-request issue. It was renamed from the local `doc-pr-to-issue`
and reframed as one pipeline (draft, validate, publish) with a pluggable source: an existing design doc or PR
(parse it), or the working context (synthesize it).

`creating-cr.md` changes:

- In scope items name behavior and spec-level entities (documented objects, schema fields, jobs, parameters),
  not implementation internals such as private functions or file paths.
- Add the issue type and title-prefix convention: Feature (`[Feat:]`), Bug (`[Bug:]`), Story (`[Story:]`), and
  a documentation ticket as a Story with `[Docs:]`.
- Point the skill reference at the published in-repo location.

`.gitignore` ignores per-user Claude Code local files (`settings.local.json`, `*.lock`) so only the shared
skill is committed under `.claude/`.

## Issue

No issue. Tooling and documentation-convention change.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`docs`, `.claude`

## Implementation Notes

The skill is markdown-only, self-contained, and portable (no absolute user paths). Its personal learnings log
is kept local and not published. Both `markdownlint` (project config) and `textlint` (terminology) pass on the
skill files and `creating-cr.md`.

## Tests / Evidence

Documentation and tooling change. `markdownlint` and `textlint` pass on all changed markdown.

## Additional Notes

The skill is opt-in: it runs when invoked (for example `/design-to-cr`) and never pushes branches or opens PRs
on its own. It only files issues, on an explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)