### PR TITLE
docs: Shared Template Variable files live in configurations/ folders

### DIFF
--- a/docs/features/env-inventory-generation.md
+++ b/docs/features/env-inventory-generation.md
@@ -123,7 +123,7 @@ The exact target folder depends on the object type and the `place` value.
 | Parameter Set file | `/environments/<cluster-name>/<env-name>/Inventory/parameters/<paramset-name>.yml` | `/environments/<cluster-name>/parameters/<paramset-name>.yml` | `/environments/parameters/<paramset-name>.yml` |
 | Shared Credentials file | `/environments/<cluster-name>/<env-name>/Inventory/credentials/<credentials-file-name>.yml` | `/environments/<cluster-name>/credentials/<credentials-file-name>.yml` | `/environments/credentials/<credentials-file-name>.yml` |
 | Resource Profile Override file | `/environments/<cluster-name>/<env-name>/Inventory/resource_profiles/<override-name>.yml` | `/environments/<cluster-name>/resource_profiles/<override-name>.yml` | `/environments/resource_profiles/<override-name>.yml` |
-| Shared Template Variable File | `/environments/<cluster-name>/<env-name>/shared-template-variables/<file-name>.yml` | `/environments/<cluster-name>/shared-template-variables/<file-name>.yml` | `/environments/shared-template-variables/<file-name>.yml` |
+| Shared Template Variable File | `/environments/<cluster-name>/<env-name>/Inventory/configurations/<file-name>.yml` | `/environments/<cluster-name>/configurations/<file-name>.yml` | `/environments/configurations/<file-name>.yml` |
 
 ##### Processing Model
 
@@ -499,7 +499,7 @@ applications:
 **Result**: a Shared Template Variable File is generated from sharedTemplateVariables[].content and stored based on sharedTemplateVariables[].place.
 
 ```yaml
-# /environments/shared-template-variables/prod-template-variables.yml
+# /environments/configurations/prod-template-variables.yml
 
 TEMPLATE_VAR_1: "prod-value-1"
 TEMPLATE_VAR_2: "prod-value-2"
@@ -509,7 +509,7 @@ nested:
 ```
 
 ```yaml
-# /environments/<cluster-name>/shared-template-variables/sample-cloud-template-variables.yml
+# /environments/<cluster-name>/configurations/sample-cloud-template-variables.yml
 
 CLOUD_VAR_1: "cloud-value-1"
 CLOUD_VAR_2: "cloud-value-2"

--- a/docs/use-cases/environment-inventory-generation.md
+++ b/docs/use-cases/environment-inventory-generation.md
@@ -169,7 +169,7 @@ Instance pipeline (GitLab or GitHub) is started with:
    - `/environments/<cluster-name>/<env-name>/Inventory/parameters/*`
    - `/environments/<cluster-name>/<env-name>/Inventory/credentials/*`
    - `/environments/<cluster-name>/<env-name>/Inventory/resource_profiles/*`
-   - `/environments/<cluster-name>/<env-name>/shared-template-variables/*`
+   - `/environments/<cluster-name>/<env-name>/Inventory/configurations/*`
 4. Changes are committed.
 
 ---
@@ -604,9 +604,9 @@ Instance pipeline (GitLab or GitHub) is started with:
 **Pre-requisites:**
 
 1. The target Shared Template Variable file does not exist (for the resolved `place` and `name`):
-   - `place=env` → `/environments/<cluster-name>/<env-name>/shared-template-variables/<name>.yml`
-   - `place=cluster` → `/environments/<cluster-name>/shared-template-variables/<name>.yml`
-   - `place=site` → `/environments/shared-template-variables/<name>.yml`
+   - `place=env` → `/environments/<cluster-name>/<env-name>/Inventory/configurations/<name>.yml`
+   - `place=cluster` → `/environments/<cluster-name>/configurations/<name>.yml`
+   - `place=site` → `/environments/configurations/<name>.yml`
 
 **Trigger:**
 
@@ -634,10 +634,10 @@ Instance pipeline (GitLab or GitHub) is started with:
       - `name` is present
       - `content` is present
    3. Resolves target path by `place`:
-      - `place=env` → `/environments/<cluster-name>/<env-name>/shared-template-variables/<name>.yml`
-      - `place=cluster` → `/environments/<cluster-name>/shared-template-variables/<name>.yml`
-      - `place=site` → `/environments/shared-template-variables/<name>.yml`
-   4. Creates `shared-template-variables/` directory if missing.
+      - `place=env` → `/environments/<cluster-name>/<env-name>/Inventory/configurations/<name>.yml`
+      - `place=cluster` → `/environments/<cluster-name>/configurations/<name>.yml`
+      - `place=site` → `/environments/configurations/<name>.yml`
+   4. Creates the `configurations/` directory if missing.
    5. Creates the Shared Template Variable file using `content` (create-or-replace semantics; in this UC the file is expected to be missing).
 
 2. The `git_commit` job runs:
@@ -657,9 +657,9 @@ Instance pipeline (GitLab or GitHub) is started with:
 **Pre-requisites:**
 
 1. The target Shared Template Variable file exists (for the resolved `place` and `name`):
-   - `place=env` → `/environments/<cluster-name>/<env-name>/shared-template-variables/<name>.yml`
-   - `place=cluster` → `/environments/<cluster-name>/shared-template-variables/<name>.yml`
-   - `place=site` → `/environments/shared-template-variables/<name>.yml`
+   - `place=env` → `/environments/<cluster-name>/<env-name>/Inventory/configurations/<name>.yml`
+   - `place=cluster` → `/environments/<cluster-name>/configurations/<name>.yml`
+   - `place=site` → `/environments/configurations/<name>.yml`
 
 **Trigger:**
 
@@ -705,9 +705,9 @@ Instance pipeline (GitLab or GitHub) is started with:
 **Pre-requisites:**
 
 1. The target Shared Template Variable file exists (for the resolved `place` and `name`):
-   - `place=env` → `/environments/<cluster-name>/<env-name>/shared-template-variables/<name>.yml`
-   - `place=cluster` → `/environments/<cluster-name>/shared-template-variables/<name>.yml`
-   - `place=site` → `/environments/shared-template-variables/<name>.yml`
+   - `place=env` → `/environments/<cluster-name>/<env-name>/Inventory/configurations/<name>.yml`
+   - `place=cluster` → `/environments/<cluster-name>/configurations/<name>.yml`
+   - `place=site` → `/environments/configurations/<name>.yml`
 
 **Trigger:**
 
@@ -732,9 +732,9 @@ Instance pipeline (GitLab or GitHub) is started with:
       - `place ∈ { env, cluster, site }`
       - `name` is present
    3. Resolves target path by `place`:
-      - `place=env` → `/environments/<cluster-name>/<env-name>/shared-template-variables/<name>.yml`
-      - `place=cluster` → `/environments/<cluster-name>/shared-template-variables/<name>.yml`
-      - `place=site` → `/environments/shared-template-variables/<name>.yml`
+      - `place=env` → `/environments/<cluster-name>/<env-name>/Inventory/configurations/<name>.yml`
+      - `place=cluster` → `/environments/<cluster-name>/configurations/<name>.yml`
+      - `place=site` → `/environments/configurations/<name>.yml`
    4. Deletes the target Shared Template Variable file if it exists.
       - Directories are not removed.
 


### PR DESCRIPTION
## Summary

Target-state documentation for the Shared Template Variable location CR: files created via
`ENV_INVENTORY_CONTENT` live in the `configurations/` folder of the requested `place`
(`env` - `/environments/<cluster>/<env>/Inventory/configurations/`, `cluster` -
`/environments/<cluster>/configurations/`, `site` - `/environments/configurations/`), where template
rendering already looks them up.

> [!IMPORTANT]
> Draft on purpose. Merge together with the implementation of #1607, not before - the current code
> writes these files to a `shared_template_variables/` folder that rendering does not read.

## Issue

Documentation half of #1607. Findings come from the test review of PR #1570.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

docs

## Tests / Evidence

Target paths match the lookup list of the rendering step (`configuration(s)/` under the environment
Inventory, the cluster folder and the instances root).

## Additional Notes

Docs-only half of the CR. The code change and the BDD test-data move ship in the implementation PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)