### PR TITLE
docs: TEMPORARY template version mode applies the version to the run only

### DIFF
--- a/docs/envgene-pipelines.md
+++ b/docs/envgene-pipelines.md
@@ -30,7 +30,8 @@ flowchart TB
     subgraph per_env["Per-environment jobs"]
         C[credential_rotation] --> D[bg_manage]
         D --> E[env_inventory_generation]
-        E --> F[app_reg_def_process]
+        E --> E2[set_template_version]
+        E2 --> F[app_reg_def_process]
         F --> G[process_sd]
         G --> H[env_build]
         H --> I[generate_effective_set]
@@ -64,7 +65,17 @@ flowchart TB
      - [`ENV_TEMPLATE_NAME`](/docs/instance-pipeline-parameters.md#env_template_name) is set (non-empty)
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
-6. **app_reg_def_process**:
+6. **set_template_version**:
+   - **What happens in this job**: Applies
+     [`ENV_TEMPLATE_VERSION`](/docs/instance-pipeline-parameters.md#env_template_version) to the Environment
+     according to
+     [`ENV_TEMPLATE_VERSION_UPDATE_MODE`](/docs/instance-pipeline-parameters.md#env_template_version_update_mode):
+     updates `env_definition.yml` in `PERSISTENT` mode, applies the version to the current run only in
+     `TEMPORARY` mode. See [Template Version Update](/docs/use-cases/template-version-update.md).
+   - **Condition**: Runs if [`ENV_TEMPLATE_VERSION`](/docs/instance-pipeline-parameters.md#env_template_version) is provided.
+   - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
+
+7. **app_reg_def_process**:
    - **What happens in this job**:
        1. Handles certificate updates from the configuration directory.
        2. Renders [Application Definitions](/docs/envgene-objects.md#application-definition) and [Registry Definitions](/docs/envgene-objects.md#registry-definition) from:
@@ -74,34 +85,33 @@ flowchart TB
    - **Condition**: Runs if [`ENV_BUILD: true`](/docs/instance-pipeline-parameters.md#env_builder)
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
-7. **process_sd**:
+8. **process_sd**:
    - **Condition**: Runs if ( [`SD_SOURCE_TYPE: json`](/docs/instance-pipeline-parameters.md#sd_source_type) AND [`SD_DATA`](/docs/instance-pipeline-parameters.md#sd_data) is provided ) OR ( [`SD_SOURCE_TYPE: artifact`](/docs/instance-pipeline-parameters.md#sd_source_type) AND [`SD_VERSION`](/docs/instance-pipeline-parameters.md#sd_version) is provided )
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
-8. **env_build**:
+9. **env_build**:
    - **What happens in this job**:
        1. Handles certificate updates from the configuration directory.
-       2. Updates the Environment Template version if [`ENV_TEMPLATE_VERSION`](/docs/instance-pipeline-parameters.md#env_template_version) is provided.
-       3. Renders the environment using Jinja2 templates (renders Namespaces, Clouds, and other environment components, but not Application and Registry Definitions).
-       4. Handles template overrides
-       5. Handles template Parameter Set and Resource profiles.
-       6. Handles environment-specific Parameter Set and Resource profiles.
-       7. Creates Credentials including shared Credentials
+       2. Renders the environment using Jinja2 templates (renders Namespaces, Clouds, and other environment components, but not Application and Registry Definitions).
+       3. Handles template overrides
+       4. Handles template Parameter Set and Resource profiles.
+       5. Handles environment-specific Parameter Set and Resource profiles.
+       6. Creates Credentials including shared Credentials
    - **Condition**: Runs if [`ENV_BUILD: true`](/docs/instance-pipeline-parameters.md#env_builder).
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
-9. **generate_effective_set**:
-   - **What happens in this job**:
-       1. Generates the Effective Set
-       2. Invokes the [External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md) to materialize each external Credential in its target Secret Store. Skipped when the Environment Instance contains no external Credentials. See [Credential provisioning](/docs/features/external-creds.md#credential-provisioning) for the CI/CD variable contract and failure semantics.
-   - **Condition**: Runs if [`GENERATE_EFFECTIVE_SET: true`](/docs/instance-pipeline-parameters.md#generate_effective_set)
-   - **Docker image**: [`qubership-effective-set-generator`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-effective-set-generator)
+10. **generate_effective_set**:
+    - **What happens in this job**:
+        1. Generates the Effective Set
+        2. Invokes the [External Credentials provisioning CLI](/docs/features/external-creds-provisioning-cli.md) to materialize each external Credential in its target Secret Store. Skipped when the Environment Instance contains no external Credentials. See [Credential provisioning](/docs/features/external-creds.md#credential-provisioning) for the CI/CD variable contract and failure semantics.
+    - **Condition**: Runs if [`GENERATE_EFFECTIVE_SET: true`](/docs/instance-pipeline-parameters.md#generate_effective_set)
+    - **Docker image**: [`qubership-effective-set-generator`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-effective-set-generator)
 
-10. **git_commit**:
+11. **git_commit**:
     - **Condition**: Runs if there are jobs requiring changes to the repository AND [`ENV_TEMPLATE_TEST: false`](/docs/envgene-repository-variables.md#env_template_test)
     - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
-11. **cmdb_import**:
+12. **cmdb_import**:
     - **Condition**: Runs if [`CMDB_IMPORT: true`](/docs/instance-pipeline-parameters.md#cmdb_import)
 
     > [!NOTE]

--- a/docs/features/env-inventory-generation.md
+++ b/docs/features/env-inventory-generation.md
@@ -65,7 +65,8 @@ The generated Environment Inventory must be reused by other jobs in the same pip
 `ENV_INVENTORY_CONTENT` is the primary way to manage Inventory via pipeline. It allows external systems to create, fully replace and delete `env_definition.yml` and related Inventory objects. The parameter also supports creating files on different levels (`site`, `cluster`, `env`) via the `place` field.
 
 > **Note**
-> If `ENV_TEMPLATE_VERSION` is provided in the instance pipeline, it has higher priority than the template version specified in `env_definition.yml`
+> Applying `ENV_TEMPLATE_VERSION` is a separate pipeline step that runs after Inventory generation. See
+> [Template Version Update](/docs/use-cases/template-version-update.md)
 
 `ENV_SPECIFIC_PARAMS` and `ENV_INVENTORY_INIT` are legacy parameters and are deprecated. They do not cover the full set of Inventory management scenarios, therefore new integrations should use `ENV_INVENTORY_CONTENT`.
 

--- a/docs/use-cases/environment-inventory-generation.md
+++ b/docs/use-cases/environment-inventory-generation.md
@@ -33,8 +33,10 @@
 
 This document describes use cases for **Environment Inventory Generation** — creating or replacing `env_definition.yml`, `paramsets`, `resource_profiles`, and `credentials` using `ENV_INVENTORY_CONTENT`.
 
-> **Note (template version priority):**  
-> If `ENV_TEMPLATE_VERSION` is passed to the Instance pipeline, it has **higher priority** than the template version specified in `env_definition.yml` (`envDefinition.content.envTemplate.*`). See [Template Version Update](/docs/use-cases/template-version-update.md).
+> **Note:**  
+> Applying `ENV_TEMPLATE_VERSION` is a separate pipeline step that runs after Inventory generation and
+> therefore overrides the version from `envDefinition.content.envTemplate.*`. See
+> [Template Version Update](/docs/use-cases/template-version-update.md).
 
 ---
 
@@ -54,7 +56,6 @@ Instance pipeline (GitLab or GitHub) is started with:
 - `ENV_NAMES: <cluster-name>/<env-name>`
 - `ENV_INVENTORY_CONTENT: <payload>`
   - Examples: [`/docs/features/env-inventory-generation.md`](/docs/features/env-inventory-generation.md)
-- `ENV_TEMPLATE_VERSION: <template-artifact>` (optional; if provided, it has higher priority than the version from `envDefinition.content.envTemplate.*`)
 
 **Steps:**
 
@@ -70,7 +71,6 @@ Instance pipeline (GitLab or GitHub) is started with:
       - `/environments/<cluster-name>/<env-name>/Inventory/env_definition.yml`
    5. Creates `Inventory/` directory if missing.
    6. Creates `env_definition.yml` using `envDefinition.content`.
-   7. If `ENV_TEMPLATE_VERSION` is provided, applies it as the template version (higher priority).
 2. The `git_commit` job runs:
    1. Commits created files into the Instance repository.
 
@@ -78,8 +78,7 @@ Instance pipeline (GitLab or GitHub) is started with:
 
 1. The file is created:
    - `/environments/<cluster-name>/<env-name>/Inventory/env_definition.yml`
-2. If `ENV_TEMPLATE_VERSION` is provided, it overrides the version from `envDefinition.content.envTemplate.*`.
-3. Changes are committed.
+2. Changes are committed.
 
 ---
 
@@ -97,7 +96,6 @@ Instance pipeline (GitLab or GitHub) is started with:
 - `ENV_NAMES: <cluster-name>/<env-name>`
 - `ENV_INVENTORY_CONTENT: <payload>`
   - Examples: [`/docs/features/env-inventory-generation.md`](/docs/features/env-inventory-generation.md)
-- `ENV_TEMPLATE_VERSION: <template-artifact>` (optional; if provided, it has higher priority than the version from `envDefinition.content.envTemplate.*`)
 
 **Steps:**
 
@@ -112,7 +110,6 @@ Instance pipeline (GitLab or GitHub) is started with:
    4. Resolves target path:
       - `/environments/<cluster-name>/<env-name>/Inventory/env_definition.yml`
    5. Replaces `env_definition.yml` using `envDefinition.content` (fully overwrites the file).
-   6. If `ENV_TEMPLATE_VERSION` is provided, applies it as the template version (higher priority).
 2. The `git_commit` job runs:
    1. Commits updated files into the Instance repository.
 
@@ -120,8 +117,7 @@ Instance pipeline (GitLab or GitHub) is started with:
 
 1. The file is replaced (fully overwritten):
    - `/environments/<cluster-name>/<env-name>/Inventory/env_definition.yml`
-2. If `ENV_TEMPLATE_VERSION` is provided, it overrides the version from `envDefinition.content.envTemplate.*`.
-3. Changes are committed.
+2. Changes are committed.
 
 ---
 

--- a/docs/use-cases/template-version-update.md
+++ b/docs/use-cases/template-version-update.md
@@ -6,33 +6,34 @@
   - [Table of Contents](#table-of-contents)
   - [Overview](#overview)
   - [Template Version Update](#template-version-update)
-    - [UC-TV-1: Apply `ENV_TEMPLATE_VERSION` (`PERSISTENT` vs `TEMPORARY`)](#uc-tv-1-apply-env_template_version-persistent-vs-temporary)
+    - [UC-TV-1: Apply `ENV_TEMPLATE_VERSION` in `PERSISTENT` mode](#uc-tv-1-apply-env_template_version-in-persistent-mode)
+    - [UC-TV-2: Apply `ENV_TEMPLATE_VERSION` in `TEMPORARY` mode](#uc-tv-2-apply-env_template_version-in-temporary-mode)
 
 ---
 
 ## Overview
 
 This document describes use cases for **Template Version Update** - applying
-[`ENV_TEMPLATE_VERSION`](/docs/instance-pipeline-parameters.md#env_template_version) to an Environment. The
-mode is selected with
+[`ENV_TEMPLATE_VERSION`](/docs/instance-pipeline-parameters.md#env_template_version) to an Environment with
+the `set_template_version` pipeline step. The mode is selected with
 [`ENV_TEMPLATE_VERSION_UPDATE_MODE`](/docs/instance-pipeline-parameters.md#env_template_version_update_mode)
 (default: `PERSISTENT`).
 
-> **Note (template version priority):**  
-> If `ENV_TEMPLATE_VERSION` is passed to the Instance pipeline, it has **higher priority** than the template
-> version specified in `env_definition.yml` (`envDefinition.content.envTemplate.*`).
+The job runs after Environment Inventory generation. Because of that order, the version passed in
+`ENV_TEMPLATE_VERSION` overrides the template version arriving in `envDefinition.content.envTemplate.*` of
+[`ENV_INVENTORY_CONTENT`](/docs/features/env-inventory-generation.md#env_inventory_content).
 
 ---
 
 ## Template Version Update
 
-Applying `ENV_TEMPLATE_VERSION` to an Environment in `PERSISTENT` or `TEMPORARY` mode.
+Applying `ENV_TEMPLATE_VERSION` to an Environment in one of the two update modes.
 
-### UC-TV-1: Apply `ENV_TEMPLATE_VERSION` (`PERSISTENT` vs `TEMPORARY`)
+### UC-TV-1: Apply `ENV_TEMPLATE_VERSION` in `PERSISTENT` mode
 
 **Pre-requisites:**
 
-1. Environment Inventory exists:
+1. The Environment Inventory exists, or is generated earlier in the same pipeline run:
    - `/environments/<cluster-name>/<env-name>/Inventory/env_definition.yml`
 
 **Trigger:**
@@ -41,24 +42,49 @@ Instance pipeline (GitLab or GitHub) is started with:
 
 - `ENV_NAMES: <cluster-name>/<env-name>`
 - `ENV_TEMPLATE_VERSION: <template-artifact>`
-- `ENV_TEMPLATE_VERSION_UPDATE_MODE: PERSISTENT | TEMPORARY` (optional; default: `PERSISTENT`)
+- `ENV_TEMPLATE_VERSION_UPDATE_MODE: PERSISTENT` (optional, default)
 
 **Steps:**
 
-1. The `env_inventory_generation` job runs:
-   1. Reads `ENV_TEMPLATE_VERSION_UPDATE_MODE` (default: `PERSISTENT`).
-   2. Applies `ENV_TEMPLATE_VERSION`:
-      - **PERSISTENT**:
-        - Updates template version in `env_definition.yml`
-          (`envTemplate.artifact` or `envTemplate.templateArtifact.artifact.version`).
-      - **TEMPORARY**:
-        - Does not change `envTemplate.*` in `env_definition.yml`.
-        - Writes the applied version into:
-          - `generatedVersions.generateEnvironmentLatestVersion: "<ENV_TEMPLATE_VERSION>"`
+1. The `set_template_version` job runs:
+   1. Updates the template version in `env_definition.yml`
+      (`envTemplate.artifact` or `envTemplate.templateArtifact.artifact.version`).
 2. The `git_commit` job runs:
    1. Commits updated `env_definition.yml` into the Instance repository.
 
 **Results:**
 
-1. **PERSISTENT**: template version in `env_definition.yml` is updated and committed.
-2. **TEMPORARY**: `generatedVersions.generateEnvironmentLatestVersion` is updated and committed. `envTemplate.*` remains unchanged.
+1. The template version in `env_definition.yml` is updated and committed.
+
+---
+
+### UC-TV-2: Apply `ENV_TEMPLATE_VERSION` in `TEMPORARY` mode
+
+**Pre-requisites:**
+
+1. The Environment Inventory exists, or is generated earlier in the same pipeline run:
+   - `/environments/<cluster-name>/<env-name>/Inventory/env_definition.yml`
+
+**Trigger:**
+
+Instance pipeline (GitLab or GitHub) is started with:
+
+- `ENV_NAMES: <cluster-name>/<env-name>`
+- `ENV_TEMPLATE_VERSION: <template-artifact>`
+- `ENV_TEMPLATE_VERSION_UPDATE_MODE: TEMPORARY`
+
+**Steps:**
+
+1. The `set_template_version` job runs:
+   1. Does not change `env_definition.yml`. The version is applied to the current pipeline run only.
+2. If the environment is rendered in the same run (`env_build`),
+   `generatedVersions.generateEnvironmentLatestVersion` in `env_definition.yml` is updated with the
+   template version actually used.
+3. The `git_commit` job runs:
+   1. Commits updated files, if any, into the Instance repository.
+
+**Results:**
+
+1. `envTemplate.*` remains unchanged.
+2. When the environment is rendered in the same run, `generatedVersions.generateEnvironmentLatestVersion`
+   reflects the applied version and is committed.


### PR DESCRIPTION
## Summary

Target-state documentation for the `ENV_TEMPLATE_VERSION_UPDATE_MODE=TEMPORARY` CR, on top of the use-case
split done in #1616:

- `docs/use-cases/template-version-update.md` is rewritten to the target semantics: the version is applied
  by the `set_template_version` job, split into `UC-TV-1` (`PERSISTENT`) and `UC-TV-2` (`TEMPORARY`).
  `TEMPORARY` does not modify `env_definition.yml` and applies the version to the current run only.
  `generatedVersions.generateEnvironmentLatestVersion` is described as a run trace written by the rendering
  step, and only when the environment is actually rendered. Priority is explained by step order: the job
  runs after Inventory generation, so the parameter overrides the version from `envDefinition.content`.
- The inventory generation docs are decoupled from the parameter: the `ENV_TEMPLATE_VERSION` mentions leave
  `UC-EINV-ED-1`/`UC-EINV-ED-2` and both priority notes become cross-links.
- `envgene-pipelines.md` lists `set_template_version` as its own step and no longer attributes the version
  update to `env_build`.

> [!IMPORTANT]
> Draft on purpose. Merge together with the implementation of #1608, not before - today the
> template version resolution does not read `ENV_TEMPLATE_VERSION`, so in `TEMPORARY` mode the parameter is
> silently ignored.

## Issue

Documentation half of #1608. Findings come from the test review of PR #1570.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

docs

## Tests / Evidence

Statements verified against the implementation: `update_version` skips the file in `TEMPORARY` mode, the
rendering step writes `generatedVersions` with the version actually used, template version resolution reads
only `envTemplate.artifact`.

## Additional Notes

Docs-only half of the CR. The code change (version resolution preferring `ENV_TEMPLATE_VERSION`, single
writer) ships in the implementation PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)