### PR TITLE
fix: require name for delete items in ENV_INVENTORY_CONTENT schema

### DIFF
--- a/schemas/env-inventory-content.schema.json
+++ b/schemas/env-inventory-content.schema.json
@@ -78,7 +78,15 @@
           "required": ["content"]
         },
         "else": {
-          "required": ["name"]
+          "anyOf": [
+            { "required": ["name"] },
+            {
+              "required": ["content"],
+              "properties": {
+                "content": { "required": ["name"] }
+              }
+            }
+          ]
         }
       }
     },
@@ -172,7 +180,15 @@
           "required": ["content"]
         },
         "else": {
-          "required": ["name"]
+          "anyOf": [
+            { "required": ["name"] },
+            {
+              "required": ["content"],
+              "properties": {
+                "content": { "required": ["name"] }
+              }
+            }
+          ]
         }
       }
     },

--- a/schemas/env-inventory-content.schema.json
+++ b/schemas/env-inventory-content.schema.json
@@ -76,6 +76,9 @@
         },
         "then": {
           "required": ["content"]
+        },
+        "else": {
+          "required": ["name"]
         }
       }
     },
@@ -120,6 +123,9 @@
         },
         "then": {
           "required": ["content"]
+        },
+        "else": {
+          "required": ["name"]
         }
       }
     },
@@ -164,6 +170,9 @@
         },
         "then": {
           "required": ["content"]
+        },
+        "else": {
+          "required": ["name"]
         }
       }
     },


### PR DESCRIPTION
## Summary

A delete item in `ENV_INVENTORY_CONTENT` must now carry the target name. Until this change the requirement
existed only in the field description text, so a delete item without any name passed JSON schema validation
and the job crashed later with an unhandled `KeyError`. Now such a payload fails at validation with a
readable message before any file is modified.

The name has two documented carriers, and the schema accepts either:

- `paramSets` and `resourceProfiles`: the top-level `name` field or `content.name` (the form used by the
  existing unit tests and supported by the code).
- `credentials`: the top-level `name` field (the content is a credentials map and carries no file name).

`sharedTemplateVariables` already requires `name` unconditionally, and `envDefinition` needs no name, so
both are untouched.

## Issue

Fixes #1610. Findings come from the test review of PR #1570.

## Breaking Change?

- [ ] Yes
- [x] No

Payloads rejected by the stricter schema crashed the job before this change.

## Scope / Project

schemas

## Tests / Evidence

Verified with `jsonschema` against the updated schema per family: delete with a top-level `name` validates,
delete with `content.name` validates for `paramSets`/`resourceProfiles`, delete without any name (bare or
with a nameless `content`) is rejected, and `create_or_replace` items are unaffected. The checked shapes
include the exact payloads of the BDD suite (top-level `name`) and of the unit test
`test_gen_env_create_delete` (`content.name`).

## Additional Notes

Targets `feature/integration-tests`: the top-level `name` mechanism for delete items (schema property and
the `obj.get("content")` code path) lives on this branch. If the `specificTemplateVersions` and
`templateVariables` blocks stay in the branch schema, they need the same conditional requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)