### PR TITLE
fix: require a delete target name in ENV_INVENTORY_CONTENT schema

### DIFF
--- a/schemas/env-inventory-content.schema.json
+++ b/schemas/env-inventory-content.schema.json
@@ -43,6 +43,11 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Name of the Parameter Set file (without extension). Required for delete action. The file will be saved as <name>.yml"
+          },
           "action": {
             "type": "string",
             "enum": ["create_or_replace", "delete"],
@@ -71,6 +76,17 @@
         },
         "then": {
           "required": ["content"]
+        },
+        "else": {
+          "anyOf": [
+            { "required": ["name"] },
+            {
+              "required": ["content"],
+              "properties": {
+                "content": { "required": ["name"] }
+              }
+            }
+          ]
         }
       }
     },
@@ -115,6 +131,9 @@
         },
         "then": {
           "required": ["content"]
+        },
+        "else": {
+          "required": ["name"]
         }
       }
     },
@@ -126,6 +145,11 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Name of the Resource Profile Override file (without extension). Required for delete action."
+          },
           "action": {
             "type": "string",
             "enum": ["create_or_replace", "delete"],
@@ -154,6 +178,17 @@
         },
         "then": {
           "required": ["content"]
+        },
+        "else": {
+          "anyOf": [
+            { "required": ["name"] },
+            {
+              "required": ["content"],
+              "properties": {
+                "content": { "required": ["name"] }
+              }
+            }
+          ]
         }
       }
     },

--- a/scripts/build_env/env_inventory_generation.py
+++ b/scripts/build_env/env_inventory_generation.py
@@ -180,9 +180,9 @@ def handle_objects(env_dir, objects, subdir, inventory="", encrypt=False):
     for obj in objects:
         place = Place(obj["place"])
         action = Action(obj["action"])
-        content = obj["content"]
+        content = obj.get("content")
 
-        name = content["name"] if content.get("name") else obj["name"]
+        name = content["name"] if content and content.get("name") else obj["name"]
         obj_path = resolve_path(env_dir, place, subdir, name, inventory)
 
         logger.info(f"Processing {subdir}, action={action.value}, place={place.value}. Target path: {obj_path}")


### PR DESCRIPTION
## Summary

A delete item in `ENV_INVENTORY_CONTENT` must carry the target name. Until now the requirement existed only
in the field description text, so a delete item without any name passed JSON schema validation and the job
crashed later with an unhandled `KeyError`. Now such a payload fails at validation with a readable message
before any file is modified.

The name has two documented carriers, and the schema accepts either:

- `paramSets` and `resourceProfiles`: the top-level `name` field (now declared in the schema) or
  `content.name` (the form used by the existing unit tests).
- `credentials`: the top-level `name` field (the content is a credentials map and carries no file name).

`sharedTemplateVariables` already requires `name` unconditionally, and `envDefinition` needs no name, so
both are untouched. A two-line code change stops reading `content` unconditionally, so a delete item with a
top-level name only is handled instead of crashing on the missing `content` key.

## Issue

Fixes #1610. Findings come from the test review of PR #1570.

## Breaking Change?

- [ ] Yes
- [x] No

Payloads rejected by the stricter schema crashed the job before this change.

## Scope / Project

schemas

## Tests / Evidence

Verified with `jsonschema` against the updated schema per family: delete with a top-level `name` validates,
delete with `content.name` validates for `paramSets`/`resourceProfiles`, delete without any name (bare or
with a nameless `content`) is rejected, and `create_or_replace` items are unaffected. The checked shapes
include the exact payloads of the unit test `test_gen_env_create_delete`.

## Additional Notes

Replaces #1611, which targeted `feature/integration-tests` - the fix belongs on `main`. The integration
branch picks it up on its next merge from `main` (its schema already declares the `name` properties and its
code already reads `content` optionally, so the merge is small).

🤖 Generated with [Claude Code](https://claude.com/claude-code)