### PR TITLE
docs: move the template version update use case into its own document

### DIFF
--- a/docs/use-cases/environment-inventory-generation.md
+++ b/docs/use-cases/environment-inventory-generation.md
@@ -26,17 +26,15 @@
     - [UC-EINV-STV-2: Replace Shared Template Variable file (create\_or\_replace, file exists)](#uc-einv-stv-2-replace-shared-template-variable-file-create_or_replace-file-exists)
     - [UC-EINV-STV-3: Delete Shared Template Variable file](#uc-einv-stv-3-delete-shared-template-variable-file)
     - [UC-EINV-AT-ALL-1: Fail without committing changes if any operation fails (negative)](#uc-einv-at-all-1-fail-without-committing-changes-if-any-operation-fails-negative)
-  - [Template Version Update](#template-version-update)
-    - [UC-EINV-TV-1: Apply `ENV_TEMPLATE_VERSION` (`PERSISTENT` vs `TEMPORARY`)](#uc-einv-tv-1-apply-env_template_version-persistent-vs-temporary)
 
 ---
 
 ## Overview
 
-This document describes use cases for **Environment Inventory Generation** — creating or replacing `env_definition.yml`, `paramsets`, `resource_profiles`, and `credentials` using `ENV_INVENTORY_CONTENT`, as well as template version update in `PERSISTENT` and `TEMPORARY` modes.
+This document describes use cases for **Environment Inventory Generation** — creating or replacing `env_definition.yml`, `paramsets`, `resource_profiles`, and `credentials` using `ENV_INVENTORY_CONTENT`.
 
 > **Note (template version priority):**  
-> If `ENV_TEMPLATE_VERSION` is passed to the Instance pipeline, it has **higher priority** than the template version specified in `env_definition.yml` (`envDefinition.content.envTemplate.*`).
+> If `ENV_TEMPLATE_VERSION` is passed to the Instance pipeline, it has **higher priority** than the template version specified in `env_definition.yml` (`envDefinition.content.envTemplate.*`). See [Template Version Update](/docs/use-cases/template-version-update.md).
 
 ---
 
@@ -795,41 +793,3 @@ During processing of `ENV_INVENTORY_CONTENT`, at least one operation fails .
 1. No changes are committed to the Instance repository.
 2. Pipeline logs contain a readable error message explaining the failure reason.
 
----
-
-## Template Version Update
-
-### UC-EINV-TV-1: Apply `ENV_TEMPLATE_VERSION` (`PERSISTENT` vs `TEMPORARY`)
-
-**Pre-requisites:**
-
-1. Environment Inventory exists:
-   - `/environments/<cluster-name>/<env-name>/Inventory/env_definition.yml`
-
-**Trigger:**
-
-Instance pipeline (GitLab or GitHub) is started with:
-
-- `ENV_NAMES: <cluster-name>/<env-name>`
-- `ENV_TEMPLATE_VERSION: <template-artifact>`
-- `ENV_TEMPLATE_VERSION_UPDATE_MODE: PERSISTENT | TEMPORARY` (optional; default: `PERSISTENT`)
-
-**Steps:**
-
-1. The `env_inventory_generation` job runs:
-   1. Reads `ENV_TEMPLATE_VERSION_UPDATE_MODE` (default: `PERSISTENT`).
-   2. Applies `ENV_TEMPLATE_VERSION`:
-      - **PERSISTENT**:
-        - Updates template version in `env_definition.yml`
-          (`envTemplate.artifact` or `envTemplate.templateArtifact.artifact.version`).
-      - **TEMPORARY**:
-        - Does not change `envTemplate.*` in `env_definition.yml`.
-        - Writes the applied version into:
-          - `generatedVersions.generateEnvironmentLatestVersion: "<ENV_TEMPLATE_VERSION>"`
-2. The `git_commit` job runs:
-   1. Commits updated `env_definition.yml` into the Instance repository.
-
-**Results:**
-
-1. **PERSISTENT**: template version in `env_definition.yml` is updated and committed.
-2. **TEMPORARY**: `generatedVersions.generateEnvironmentLatestVersion` is updated and committed; `envTemplate.*` remains unchanged.

--- a/docs/use-cases/template-version-update.md
+++ b/docs/use-cases/template-version-update.md
@@ -1,0 +1,64 @@
+# Template Version Update Use Cases
+
+## Table of Contents
+
+- [Template Version Update Use Cases](#template-version-update-use-cases)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+  - [Template Version Update](#template-version-update)
+    - [UC-TV-1: Apply `ENV_TEMPLATE_VERSION` (`PERSISTENT` vs `TEMPORARY`)](#uc-tv-1-apply-env_template_version-persistent-vs-temporary)
+
+---
+
+## Overview
+
+This document describes use cases for **Template Version Update** - applying
+[`ENV_TEMPLATE_VERSION`](/docs/instance-pipeline-parameters.md#env_template_version) to an Environment. The
+mode is selected with
+[`ENV_TEMPLATE_VERSION_UPDATE_MODE`](/docs/instance-pipeline-parameters.md#env_template_version_update_mode)
+(default: `PERSISTENT`).
+
+> **Note (template version priority):**  
+> If `ENV_TEMPLATE_VERSION` is passed to the Instance pipeline, it has **higher priority** than the template
+> version specified in `env_definition.yml` (`envDefinition.content.envTemplate.*`).
+
+---
+
+## Template Version Update
+
+Applying `ENV_TEMPLATE_VERSION` to an Environment in `PERSISTENT` or `TEMPORARY` mode.
+
+### UC-TV-1: Apply `ENV_TEMPLATE_VERSION` (`PERSISTENT` vs `TEMPORARY`)
+
+**Pre-requisites:**
+
+1. Environment Inventory exists:
+   - `/environments/<cluster-name>/<env-name>/Inventory/env_definition.yml`
+
+**Trigger:**
+
+Instance pipeline (GitLab or GitHub) is started with:
+
+- `ENV_NAMES: <cluster-name>/<env-name>`
+- `ENV_TEMPLATE_VERSION: <template-artifact>`
+- `ENV_TEMPLATE_VERSION_UPDATE_MODE: PERSISTENT | TEMPORARY` (optional; default: `PERSISTENT`)
+
+**Steps:**
+
+1. The `env_inventory_generation` job runs:
+   1. Reads `ENV_TEMPLATE_VERSION_UPDATE_MODE` (default: `PERSISTENT`).
+   2. Applies `ENV_TEMPLATE_VERSION`:
+      - **PERSISTENT**:
+        - Updates template version in `env_definition.yml`
+          (`envTemplate.artifact` or `envTemplate.templateArtifact.artifact.version`).
+      - **TEMPORARY**:
+        - Does not change `envTemplate.*` in `env_definition.yml`.
+        - Writes the applied version into:
+          - `generatedVersions.generateEnvironmentLatestVersion: "<ENV_TEMPLATE_VERSION>"`
+2. The `git_commit` job runs:
+   1. Commits updated `env_definition.yml` into the Instance repository.
+
+**Results:**
+
+1. **PERSISTENT**: template version in `env_definition.yml` is updated and committed.
+2. **TEMPORARY**: `generatedVersions.generateEnvironmentLatestVersion` is updated and committed. `envTemplate.*` remains unchanged.


### PR DESCRIPTION
## Summary

Pure reorganization of current documentation: the template version update use case moves verbatim out of
the environment inventory generation use cases into its own document,
`docs/use-cases/template-version-update.md`, renamed from `UC-EINV-TV-1` to `UC-TV-1`. The inventory doc
keeps the priority note with a cross-link to the new document. No behavior statements are changed, so no
doc-vs-code gap is created.

## Issue

No issue: docs-only reorganization with no implementation change. Separating the two features was decided
during the test review of PR #1570.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

docs

## Tests / Evidence

The moved section is byte-identical to the source except the UC id, the document framing (title, TOC,
Overview) and one semicolon split into two sentences.

## Additional Notes

The draft PR #1605 (target-state docs for #1608) will be rebased on top of this split: its diff then
shrinks to the semantic changes only (step attribution, TEMPORARY semantics, pipeline doc entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)