### PR TITLE
docs: add the bdd-test-review skill

### DIFF
--- a/.claude/skills/bdd-test-review/SKILL.md
+++ b/.claude/skills/bdd-test-review/SKILL.md
@@ -75,7 +75,7 @@ a new test there forces the divergence to be resolved.
    the run are void, and comparing output against the very payload that produced it is an echo, not an
    oracle. This is informal mutation testing: imagine the smallest realistic break and check the test
    would catch it.
-3. Oracle independence - the scenario must not be confirmed by product code changed in the same PR
+3. Oracle independence - the scenario must not be confirmed by the product code changed in the same PR
    (self-blessing). Goldens produced by UPDATE_GOLDEN-style runs are code-blessed: verify their content is
    independently derivable from the documented contract. Carry the result inside the verdict reason cell
    ("strict golden"), never as a standalone published note - standalone notes of that kind were rejected
@@ -114,7 +114,7 @@ undocumented / defer to the product owner.
 Actions per verdict:
 
 - code wrong - CR issue (use the design-to-cr skill when available, body format: `docs/dev/creating-cr.md`).
-- doc wrong, mechanical fix (names, paths, copy-paste) - direct docs PR.
+- doc wrong, mechanical fix (names, paths, copypaste) - direct docs PR.
 - doc wrong, semantic (contract rewrite, removal of a promised feature) - issue first.
 - defer - issue carrying the question.
 
@@ -142,7 +142,7 @@ The fate of a test follows the fate of the behavior:
 - behavior fixed by an issue - the test stays, marked @xfail(strict) with the issue link until the fix.
 - behavior owned by another module - the scenario moves out of this suite (`not needed`), proposed ones
   vanish.
-- optional nice-to-have negatives (schema pattern guards already covered by a generic schema negative) are
+- optional nice to have negatives (schema pattern guards already covered by a generic schema negative) are
   not proposed. When the schema itself is lax, fix the schema (issue + PR) instead of pinning the laxness
   with a test.
 
@@ -154,7 +154,7 @@ The report format - sections, verdict scale, legends, table rules, worked exampl
 Self-checks before showing the report:
 
 - the rows for existing scenarios (every verdict except `missing`) must equal the scenario count in the
-  feature file, one to one by UC id (a row was silently lost once - counting the whole table would mask
+  feature file, one to one by UC ID (a row was silently lost once - counting the whole table would mask
   exactly that loss whenever missing rows are present).
 - bidirectional check: every `missing` row has a Gherkin draft or is named in a pattern comment, and every
   draft has a row.
@@ -164,7 +164,7 @@ Publication, only on the user's explicit command:
 
 1. Translate to English (chat iterations may be Russian, the published artifact ships in English).
 2. Critic-author loop: a FRESH-context agent checks translation fidelity against the source, internal
-   consistency, 3-4 repo spot-facts, and house style (no semicolons, no em or en dashes, aligned table
+   consistency, 3-4 repository spot-facts, and house style (no semicolons, no em or en dashes, aligned table
    pipes, prose at 120 chars). Fix and re-run until a clean round. If the user capped the iterations and
    complaints remain at the cap, stop and surface them instead of publishing.
 3. Post as a PR comment. Never publish, commit or push anything without an explicit go-ahead.
@@ -174,7 +174,7 @@ Publication, only on the user's explicit command:
 The report is a living artifact the user challenges row by row. While it is chat-borne, re-emit the FULL
 report after every accepted change. Once the user asks to keep it as a file (default location:
 `<repo-parent>/stuff/pr-<N>-test-review.md` - the scratch directory beside the repository clone,
-outside the repo and never committed), update the
+outside the repository and never committed), update the
 file after every accepted change and report the delta in chat. Debate challenges rather than
 auto-accepting - recommend, then wait. When a challenge changes the format itself, propose an edit to
 this skill's files (SKILL.md or the reference) and apply it on the user's approval - the skill does

--- a/.claude/skills/bdd-test-review/SKILL.md
+++ b/.claude/skills/bdd-test-review/SKILL.md
@@ -2,9 +2,10 @@
 name: bdd-test-review
 description: >
   Review a qubership-envgene PR that adds or changes BDD (pytest-bdd / Gherkin) scenarios and their test
-  data. Use when the user asks to review or validate the test scenarios and test data of a PR - "поресьюим
-  PR с тестами", "провалидируй сценарии и тест-дату", "review the BDD tests in PR #N", or a PR link plus a
-  request to validate its scenarios or test data. Validates scenario completeness and validity plus
+  data. Use when the user asks to review or validate the test scenarios and test data of a PR - "поревьюим
+  (поресьюим) PR с тестами", "сделай ревью тестов", "отревьюй сценарии", "проверь/провалидируй сценарии и
+  тест-дату", "review the BDD tests in PR #N", "validate the scenarios and test data" - or a PR link plus
+  a request to validate its scenarios or test data. Validates scenario completeness and validity plus
   test-data completeness and validity against both docs and code, drives doc-vs-code divergence resolution
   with the user, and produces the canonical verdict report published as a PR comment.
 ---

--- a/.claude/skills/bdd-test-review/SKILL.md
+++ b/.claude/skills/bdd-test-review/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: bdd-test-review
+description: >
+  Review a qubership-envgene PR that adds or changes BDD (pytest-bdd / Gherkin) scenarios and their test
+  data. Use when the user asks to review or validate the test scenarios and test data of a PR - "поресьюим
+  PR с тестами", "провалидируй сценарии и тест-дату", "review the BDD tests in PR #N", or a PR link plus a
+  request to validate its scenarios or test data. Validates scenario completeness and validity plus
+  test-data completeness and validity against both docs and code, drives doc-vs-code divergence resolution
+  with the user, and produces the canonical verdict report published as a PR comment.
+---
+
+# bdd-test-review
+
+Review AI-generated (or human-written) BDD scenarios and their test data as the domain expert's proxy.
+The core threat model: a generated test can be plausible and green while verifying nothing - the review
+exists to catch empty oracles, self-blessing and non-discriminating data before humans start trusting the
+suite. The four axes below and the report format are settled defaults - do not re-ask for them,
+re-open only if the user explicitly signals a different scope.
+
+## Scope contract
+
+The review validates exactly four axes - nothing else:
+
+1. Scenario completeness - against docs AND code (doc-vs-code mismatches go to the divergence list, never
+   auto-counted as coverage gaps).
+2. Scenario validity - four questions per scenario (Phase 3).
+3. Test-data completeness - every referenced datum exists and is reachable.
+4. Test-data validity - schema-valid AND discriminating.
+
+Explicitly out of scope (do not report, do not propose cases for):
+
+- Framework and runner quality, CI wiring, lint, PR hygiene - other reviews own these.
+- Product code brought in by the test PR itself. Its fate is the code reviewer's call. Never treat
+  smuggled code as a coverage target. Exception: test-data findings stay in scope even when product code
+  was bent around them (a schema loosened to admit a defective fixture - report the fixture).
+- Suite-level limitations ("a hermetic run cannot verify the commit step"). They get no verdict rows.
+  Where testable, absorb into a proposed scenario, otherwise drop.
+
+## Phase 1 - fix the references
+
+Work on the CURRENT PR head in a worktree (`git fetch origin pull/<N>/head:<branch>`, then
+`git worktree add`). Identify and read:
+
+- the feature file(s), step definitions, test data and goldens.
+- the doc pair: use-case doc (`docs/use-cases/`) and feature doc (`docs/features/`).
+- the JSON schemas the payloads are validated against.
+- the implementation entry points the scenarios exercise.
+
+Build the self-blessing map: diff the PR against ITS OWN base branch (not main) and list every product
+file, schema and doc the PR itself changed. A scenario verifying behavior introduced by the same PR is
+flagged under oracle independence.
+
+Verification rules - each of these cost a wrong claim once:
+
+- Re-verify every fact on the current head. Directories move mid-branch (a python/ to modules/ move made
+  earlier greps silently blind and produced a false "not implemented" claim).
+- Before declaring behavior unimplemented, search the orchestrator for a SEPARATE step implementing it.
+- A claim about a written artifact needs BOTH its writer and its reader located. A writer whose output no
+  reader consumes is a different and worse finding than a naming mismatch.
+- Verify where a payload actually fails and where data actually differs - never trust names and comments.
+
+## Phase 2 - completeness matrix
+
+Enumerate the documented variations (use case x action x place x mode ...) and map them to scenarios.
+Uncovered documented variations become `missing` rows. Code branches absent from the docs go to the
+divergence list for maintainer triage - they are not automatically test gaps. Cross-check where the
+uncovered zone overlaps the doc-vs-code disagreement zone: that overlap is the highest-value gap, because
+a new test there forces the divergence to be resolved.
+
+## Phase 3 - scenario validity, four questions each
+
+1. Doc conformance - Given/When/Then does not contradict the documented behavior.
+2. Oracle strength - what state transition does the assertion distinguish? Ask: would the test pass if the
+   code did nothing? If it produced a wrong result? Existence-only asserts on a file that existed before
+   the run are void, and comparing output against the very payload that produced it is an echo, not an
+   oracle. This is informal mutation testing: imagine the smallest realistic break and check the test
+   would catch it.
+3. Oracle independence - the scenario must not be confirmed by product code changed in the same PR
+   (self-blessing). Goldens produced by UPDATE_GOLDEN-style runs are code-blessed: verify their content is
+   independently derivable from the documented contract. Carry the result inside the verdict reason cell
+   ("strict golden"), never as a standalone published note - standalone notes of that kind were rejected
+   in review.
+4. Determinism - no network, wall clock, ordering or environment dependence. Encryption with random IVs
+   makes byte-goldens impossible - a fixed test key enables decrypt-then-compare instead.
+
+Negative scenarios get one extra check - the failure POINT: the payload must reach the failure stage the
+title claims. A "rollback on mid-processing failure" test whose payload dies at upfront schema validation
+proves nothing about rollback and silently duplicates the plain schema negative. Check WHERE it fails, not
+just THAT it fails.
+
+## Phase 4 - test data, per scenario
+
+Judge payload, initial state and golden separately for each scenario:
+
+- liveness - reachable from a live step. Data referenced only by dead steps is dead data: list it in
+  Notes for deletion, together with the dead steps.
+- schema validity - passes the product schemas. Placeholder stubs (`name: test / value: placeholder`) are
+  findings.
+- discriminating power - initial state, payload and golden must differ wherever the semantics require.
+  If two scenarios would pass on identical data, or a replace test cannot be told from a no-op, that is
+  the finding. Deletion tests need a surviving sibling file to make over-deletion observable.
+- realism notes (plain-text credentials where real repositories store encrypted ones) - minor, recorded.
+
+Goldens additionally: the comparison must be strict in both directions (missing AND extra files), and the
+golden content must be verifiable against the docs without running the code.
+
+## Phase 5 - divergence resolution
+
+Every doc-vs-code contradiction goes to a numbered divergence list and is resolved WITH the user, never
+silently. Present each one as: what the doc says (quote), what the code does (file:line), how it
+manifests, recommendation. Verdict options: doc wrong / code wrong / both wrong / behavior OK but
+undocumented / defer to the product owner.
+
+Actions per verdict:
+
+- code wrong - CR issue (use the design-to-cr skill when available, body format: `docs/dev/creating-cr.md`).
+- doc wrong, mechanical fix (names, paths, copy-paste) - direct docs PR.
+- doc wrong, semantic (contract rewrite, removal of a promised feature) - issue first.
+- defer - issue carrying the question.
+
+All resulting issues and PRs are proposed to the user as one batch. Nothing is filed, committed or
+pushed without explicit confirmation - a verdict on a divergence authorizes drafting, not publishing.
+Keep the numbered divergence list in the draft report or chat while iterating - it is a working
+artifact and does not survive into the published report (see the reference).
+
+Two binding patterns:
+
+- Current-truth doc fixes may merge immediately (they create no gap). Target-state doc changes ship as
+  DRAFT PRs attached to their CRs ("merge together with the implementation, not before"), so the default
+  branch never documents unimplemented behavior. The CR's in-scope item reads "Merge the prepared
+  documentation PR #N together with the code change".
+- Resolutions feed BACK into verdicts: "code wrong" flips the affected scenarios to doc-side expectations
+  with @xfail(strict) plus the issue link until the fix lands. Record every resolution (issue links in the
+  report, a resolved-mark per divergence while iterating).
+
+## Scenario fate rules
+
+The fate of a test follows the fate of the behavior:
+
+- behavior removed - existing scenario becomes `not needed` (the row is the action item for the author),
+  a proposed one vanishes from the report entirely.
+- behavior fixed by an issue - the test stays, marked @xfail(strict) with the issue link until the fix.
+- behavior owned by another module - the scenario moves out of this suite (`not needed`), proposed ones
+  vanish.
+- optional nice-to-have negatives (schema pattern guards already covered by a generic schema negative) are
+  not proposed. When the schema itself is lax, fix the schema (issue + PR) instead of pinning the laxness
+  with a test.
+
+## Report and publication
+
+The report format - sections, verdict scale, legends, table rules, worked example - lives in
+`references/report-format.md`. Follow it exactly: every rule there was hard-won in review iterations.
+
+Self-checks before showing the report:
+
+- the rows for existing scenarios (every verdict except `missing`) must equal the scenario count in the
+  feature file, one to one by UC id (a row was silently lost once - counting the whole table would mask
+  exactly that loss whenever missing rows are present).
+- bidirectional check: every `missing` row has a Gherkin draft or is named in a pattern comment, and every
+  draft has a row.
+- every legend covers every value actually used in its table.
+
+Publication, only on the user's explicit command:
+
+1. Translate to English (chat iterations may be Russian, the published artifact ships in English).
+2. Critic-author loop: a FRESH-context agent checks translation fidelity against the source, internal
+   consistency, 3-4 repo spot-facts, and house style (no semicolons, no em or en dashes, aligned table
+   pipes, prose at 120 chars). Fix and re-run until a clean round. If the user capped the iterations and
+   complaints remain at the cap, stop and surface them instead of publishing.
+3. Post as a PR comment. Never publish, commit or push anything without an explicit go-ahead.
+
+## Iteration discipline
+
+The report is a living artifact the user challenges row by row. While it is chat-borne, re-emit the FULL
+report after every accepted change. Once the user asks to keep it as a file (default location:
+`<repo-parent>/stuff/pr-<N>-test-review.md` - the scratch directory beside the repository clone,
+outside the repo and never committed), update the
+file after every accepted change and report the delta in chat. Debate challenges rather than
+auto-accepting - recommend, then wait. When a challenge changes the format itself, propose an edit to
+this skill's files (SKILL.md or the reference) and apply it on the user's approval - the skill does
+not silently self-edit.

--- a/.claude/skills/bdd-test-review/SKILL.md
+++ b/.claude/skills/bdd-test-review/SKILL.md
@@ -2,8 +2,7 @@
 name: bdd-test-review
 description: >
   Review a qubership-envgene PR that adds or changes BDD (pytest-bdd / Gherkin) scenarios and their test
-  data. Use when the user asks to review or validate the test scenarios and test data of a PR - "поревьюим
-  (поресьюим) PR с тестами", "сделай ревью тестов", "отревьюй сценарии", "проверь/провалидируй сценарии и
+  data. Use when the user asks to review or validate the test scenarios and test data of a PR - "поревьюим PR с тестами", "сделай ревью тестов", "отревьюй сценарии", "проверь/провалидируй сценарии и
   тест-дату", "review the BDD tests in PR #N", "validate the scenarios and test data" - or a PR link plus
   a request to validate its scenarios or test data. Validates scenario completeness and validity plus
   test-data completeness and validity against both docs and code, drives doc-vs-code divergence resolution

--- a/.claude/skills/bdd-test-review/references/report-format.md
+++ b/.claude/skills/bdd-test-review/references/report-format.md
@@ -1,0 +1,118 @@
+# Report format
+
+Published title: "Test review: scenarios and test data". Five sections, in this order: Per-scenario
+verdicts, Proposed scenarios, Test data per scenario, Notes, Related issues (context only). When the
+draft becomes file-based (SKILL.md owns that mode switch), it lives in the scratch directory beside
+the repository clone (`<repo-parent>/stuff/pr-<N>-test-review.md`, outside the repo, never
+committed). The published comment is the draft's English translation.
+
+House style everywhere: no semicolons in prose, hyphen-minus only (no em or en dashes), prose wrapped at
+120 characters (tables and URLs exempt), all tables with vertically aligned pipes and dash-padded
+separator rows (align programmatically, skip fenced code blocks). Plain language: allowed jargon is
+limited to test-approach terms (golden, snapshot, negative, the verdict values, @xfail) and product
+terminology as spelled in the docs. Everything else - paraphrase (no "oracle", "no-op", "advisory",
+"camelCase" and similar in reasons). After issues are filed, reference them as bare #NNNN (GitHub
+auto-links them). Before filing, use named placeholders plus a pointer in the Related issues
+section, and replace them at filing.
+
+## Per-scenario verdicts
+
+Open with the legend, one plain sentence per value:
+
+- `valid` - the scenario correctly verifies the claimed behavior
+- `weak` - the scenario exists, but its checks cannot tell some wrong outcomes from the right one
+- `invalid` - the scenario passes even when the behavior is broken: the checks do not serve their purpose
+- `missing` - no such scenario, proposed to add (drafts are in "Proposed scenarios")
+- `not needed` - the scenario exists, but per the taken decisions it is removed or moved out of this
+  feature
+
+Table columns: Scenario | Verdict | Reason.
+
+- The Scenario column holds the UC id ONLY. For existing scenarios spell it exactly as in the feature
+  file. `missing` rows carry proposed ids continuing the family numbering (UC-X-PS-4 after PS-1..3) and
+  are interleaved into the table right next to their family, not appended at the bottom. No "(proposed)"
+  markers - the `missing` verdict itself carries that meaning.
+- Verdict values are English even in a Russian draft.
+- Reasons are evidence, not restatements. For `valid` name what proves it ("pre-run content differs from
+  the golden - full overwrite is proven"). For `weak` and `invalid` name the exact blindness and the
+  cure. For `missing` keep identical wording for identical gaps ("place cluster/site are not covered").
+  For `not needed` state the decision and its carrier ("removed together with the legacy X flow
+  (#NNNN)").
+- Verdict-driving analyses stay inside the cell (no footnotes), but trim resolution history to an issue
+  reference. A reason must answer "why is this verdict earned", not only state a fact about the data -
+  "the payload fails at the wrong point: at schema validation, before the first write - there is nothing
+  to roll back" explains `invalid`, "the payload uses an invalid action value" does not.
+- Suite-level limitations and observations about product code smuggled by the PR get NO rows.
+
+## Proposed scenarios
+
+One fenced gherkin block. For every `missing` row either a full draft or an explicit mention in a pattern
+comment that names the UC id, so searching any id finds its draft. Rules:
+
+- Reuse the existing step vocabulary of the suite verbatim - drafts must be paste-ready.
+- Use Scenario Outline plus an Examples table for place or mode variants instead of copy-paste.
+- Every draft starts with a short `# why:` comment stating the gap it closes.
+- Data that does not exist yet appears as "<new payload>"-style placeholders. Paths that already exist in
+  the repo stay real.
+- A draft expected to fail until an issue is fixed carries a comment: "@xfail(strict) with a link to
+  #NNNN until the fix".
+- No meta boilerplate around the block ("ids are tentative", "payloads to be created") - substantive
+  inline comments only.
+
+## Test data per scenario
+
+Open with the legend:
+
+- `✓` - the data exists and does its job (where it matters, the cell says what it proves)
+- `✗` - the data is required but absent - the cell says what the missing piece would catch
+- `n/a by design` - this kind of data is not required for the scenario (a create scenario starts from a
+  clean workspace). Do not reuse the verdict phrase "not needed" here - the collision with
+  the verdict value confuses readers.
+- `-` - not applicable: the scenario leaves the suite
+- a `weak:` note - the data exists but has the described defect
+
+Table columns: Scenario | Payload | Initial state | Golden. Rows are the existing scenarios of the
+Per-scenario verdicts table (`missing` ones have no data yet). Cells are self-explanatory phrases
+that name what differs from what and what that proves - never invented terms or bare tokens.
+"✓ old values differ from the payload" and
+"✓ differs from the pre-run state - proves the replacement", not "✓ discriminating" or "✓ old_param"
+(both fail readers once the surrounding discussion is gone). Every ✗ cell states the cure ("a golden
+of the remaining state would catch extra deletion"). If the data mapping stops being one-to-one per
+scenario (shared goldens across many scenarios), point shared cells at one place instead of duplicating.
+
+## Notes
+
+PR-scoped action items ONLY - everything here is addressed to the author of the reviewed PR. Bullets:
+
+- dead data and the dead steps that reference it (list the files, name what stays alive and why).
+- dead or unused fixture fields.
+
+Nothing tracked in a separate issue belongs here: mixing them made a reader take the filed tickets for
+the review's requested scope once.
+
+## Related issues (context only)
+
+Product-side findings discovered during the review, tracked in their own issues. Open with the lead-in:
+"Product-side findings discovered during the review. Tracked in their own issues - they are not part of
+this PR's scope and do not block it." Bullets:
+
+- one bullet per filed issue: bare #NNNN plus a one-line statement of FACT (what is broken or decided),
+  not of action - the action lives in the issue, the review only points at it.
+- the docs-alignment bullet: which docs PR fixes current truth (mergeable now, creates no gap) and which
+  draft PRs carry target-state docs attached to which issues.
+
+No references to reviewer-local files, patches or paths anywhere in the report - the published comment
+must be self-contained for a GitHub reader. The numbered divergence list from Phase 5 is a working
+artifact (a draft section or chat) and is stripped at publish: every "divergence #N" reference
+collapses to the bare issue number or to self-contained wording.
+
+## Worked example rows
+
+| Scenario  | Verdict | Reason                                                                                                                           |
+|-----------|---------|----------------------------------------------------------------------------------------------------------------------------------|
+| UC-X-ED-2 | valid   | pre-run content differs from the golden - full file overwrite is proven                                                          |
+| UC-X-CR-2 | invalid | the file existed before the run and exists after, the content is never compared - the test is green even if the code did nothing |
+| UC-X-PS-4 | missing | place cluster/site are not covered                                                                                               |
+
+A complete published instance:
+https://github.com/Netcracker/qubership-envgene/pull/1570#issuecomment-5028814660

--- a/.claude/skills/bdd-test-review/references/report-format.md
+++ b/.claude/skills/bdd-test-review/references/report-format.md
@@ -3,7 +3,7 @@
 Published title: "Test review: scenarios and test data". Five sections, in this order: Per-scenario
 verdicts, Proposed scenarios, Test data per scenario, Notes, Related issues (context only). When the
 draft becomes file-based (SKILL.md owns that mode switch), it lives in the scratch directory beside
-the repository clone (`<repo-parent>/stuff/pr-<N>-test-review.md`, outside the repo, never
+the repository clone (`<repo-parent>/stuff/pr-<N>-test-review.md`, outside the repository, never
 committed). The published comment is the draft's English translation.
 
 House style everywhere: no semicolons in prose, hyphen-minus only (no em or en dashes), prose wrapped at
@@ -28,8 +28,8 @@ Open with the legend, one plain sentence per value:
 
 Table columns: Scenario | Verdict | Reason.
 
-- The Scenario column holds the UC id ONLY. For existing scenarios spell it exactly as in the feature
-  file. `missing` rows carry proposed ids continuing the family numbering (UC-X-PS-4 after PS-1..3) and
+- The Scenario column holds the UC ID ONLY. For existing scenarios spell it exactly as in the feature
+  file. `missing` rows carry proposed IDs continuing the family numbering (UC-X-PS-4 after PS-1..3) and
   are interleaved into the table right next to their family, not appended at the bottom. No "(proposed)"
   markers - the `missing` verdict itself carries that meaning.
 - Verdict values are English even in a Russian draft.
@@ -47,16 +47,16 @@ Table columns: Scenario | Verdict | Reason.
 ## Proposed scenarios
 
 One fenced gherkin block. For every `missing` row either a full draft or an explicit mention in a pattern
-comment that names the UC id, so searching any id finds its draft. Rules:
+comment that names the UC ID, so searching any ID finds its draft. Rules:
 
 - Reuse the existing step vocabulary of the suite verbatim - drafts must be paste-ready.
-- Use Scenario Outline plus an Examples table for place or mode variants instead of copy-paste.
+- Use Scenario Outline plus an Examples table for place or mode variants instead of copypaste.
 - Every draft starts with a short `# why:` comment stating the gap it closes.
 - Data that does not exist yet appears as "<new payload>"-style placeholders. Paths that already exist in
-  the repo stay real.
+  the repository stay real.
 - A draft expected to fail until an issue is fixed carries a comment: "@xfail(strict) with a link to
   #NNNN until the fix".
-- No meta boilerplate around the block ("ids are tentative", "payloads to be created") - substantive
+- No meta boilerplate around the block ("IDs are tentative", "payloads to be created") - substantive
   inline comments only.
 
 ## Test data per scenario
@@ -115,4 +115,4 @@ collapses to the bare issue number or to self-contained wording.
 | UC-X-PS-4 | missing | place cluster/site are not covered                                                                                               |
 
 A complete published instance:
-https://github.com/Netcracker/qubership-envgene/pull/1570#issuecomment-5028814660
+<https://github.com/Netcracker/qubership-envgene/pull/1570#issuecomment-5028814660>


### PR DESCRIPTION
## Summary

Adds `.claude/skills/bdd-test-review` - a Claude Code skill that reviews a PR adding or changing BDD
(pytest-bdd / Gherkin) scenarios and their test data. The skill validates scenario completeness and
validity plus test-data completeness and validity against both docs and code, drives doc-vs-code
divergence resolution with the maintainer, and produces the canonical verdict report published as a PR
comment.

The procedure and the report format were extracted from the test review of PR #1570 (the published
instance: https://github.com/Netcracker/qubership-envgene/pull/1570#issuecomment-5028814660). Key encoded
rules: the four review axes and scope exclusions, the self-blessing map (product code changed by the test
PR itself), oracle-strength questions per scenario, the failure-point check for negatives, discriminating
test data, verdict scale `valid` / `weak` / `invalid` / `missing` / `not needed`, and the
divergence-resolution workflow with draft docs PRs attached to CRs.

## Issue

No issue: adds a development-process skill, no product change. Targeted at `feature/modern-toolset`, where
the BDD suite lineage lives.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

docs

## Tests / Evidence

The skill went through three author-critic iterations locally (12 defects fixed) and three more for this
publication (9 defects fixed: scratch-convention self-definition, removal of session-specific references,
AGENTS.md style compliance). Factual repo references verified against the branch.

## Additional Notes

The skill references the design-to-cr skill for filing CR issues with a fallback to
`docs/dev/creating-cr.md` - design-to-cr currently exists on `main` only and arrives here with the next
merge from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)