### PR TITLE
fix: support origin setup for GIT_STRATEGY fetch

### DIFF
--- a/python/envgene/envgenehelper/git_helper.py
+++ b/python/envgene/envgenehelper/git_helper.py
@@ -84,11 +84,12 @@ class GitRepoManager:
                 f"{self.ctx.server_host}/{self.ctx.project_path}.git"
             )
 
-    def _fetch(self, ref: str, checkout: str, checkout_option: list[str], create_remote: bool = False) -> None:
-        if create_remote:
-            self.repo.create_remote("origin", self._resolve_remote_url())
+    def _fetch(self, ref: str, checkout: str, checkout_option: list[str]) -> None:
+        remote = next((r for r in self.repo.remotes if r.name == "origin"), None)
+        if remote:
+            remote.set_url(self._resolve_remote_url(), push=True)
         else:
-            self.repo.remote("origin").set_url(self._resolve_remote_url(), push=True)
+            self.repo.create_remote("origin", self._resolve_remote_url())        
 
         try:
             logger.info(f"git fetch --depth=1 origin {ref}")
@@ -159,7 +160,6 @@ class GitRepoManager:
             ref=self.ctx.commit_sha,
             checkout=self.ctx.commit_sha,
             checkout_option=["--force"],
-            create_remote=True,
         )
 
         logger.info("git sparse-checkout init --cone")


### PR DESCRIPTION
# Pull Request

## Summary
Updated sparse checkout initialization to reuse the existing origin remote when the repository has already been initialized by GitLab Runner. This prevents failures in environments where GIT_STRATEGY=empty is not supported while preserving the existing behavior for supported environments.


## Issue

Envgene is configured to use GIT_STRATEGY=empty for its GitLab CI jobs.
However, old gitlab runners with version below 17.3, does not recognize GIT_STRATEGY=empty. As a result, the runner falls back to the default fetch strategy, causing unexpected checkout behavior.

## Breaking Change?

- [ ] Yes
- [X] No


## Scope / Project

git helper

## Implementation Notes


## Tests / Evidence

Tested via instance pipeline with git_strategy=empty and fetch

## Additional Notes


Leave blank if not applicable.
