### PR TITLE
docs: resolve unique snapshot version as both snapshot and release

### DIFF
--- a/docs/features/artifact-resolution.md
+++ b/docs/features/artifact-resolution.md
@@ -5,7 +5,6 @@
   - [Processing](#processing)
     - [Traditional registries](#traditional-registries)
     - [Public cloud registries](#public-cloud-registries)
-    - [Version resolution](#version-resolution)
 
 EnvGene resolves and downloads Maven artifacts in two flows:
 
@@ -29,14 +28,15 @@ The `version` in the coordinates takes one of three forms:
 - **Non-unique snapshot version.** Ends with `-SNAPSHOT`. It denotes the latest snapshot build, not a specific
   one. For example: `1.0.0-SNAPSHOT`.
 
-- **Unique snapshot version.** A snapshot build published under its timestamped name
-  `<base>-<timestamp>-<buildNumber>`, matching `^(.*)-\d{8}\.\d{6}-\d+$`. It names one exact snapshot build.
-  For example: `1.0.0-20260720.122600-1`.
+- **Unique snapshot version.** A build published under its timestamped name `<base>-<timestamp>-<buildNumber>`,
+  matching `^(.*)-\d{8}\.\d{6}-\d+$`. It names one exact build. For example: `1.0.0-20260720.122600-1`.
 
 - **Release version.** Any version that is neither of the above. It names one exact released artifact. For
   example: `1.0.0`.
 
-Maven publishes each snapshot build under its unique timestamped name inside the `<base>-SNAPSHOT/` folder.
+These forms classify the version string, not the artifact behind it. The unique snapshot form is ambiguous:
+the same string can name a snapshot build or a promoted release that kept the timestamped name. Resolution
+therefore treats it as both.
 
 ## Processing
 
@@ -44,27 +44,33 @@ EnvGene searches the selected repositories concurrently, and the first to return
 the DD, resolution fails.
 
 The registry provider selects the repository model, traditional or public cloud. Registry Definition v2
-declares the provider. Registry Definition v1 has no provider and always uses the traditional model.
+declares the provider. Registry Definition v1 has no provider and always uses the traditional model. The model
+sets where each version form is looked up.
 
 ### Traditional registries
 
 Nexus and Artifactory. `repositoryDomainName` is a base URL, and `mavenConfig` names the candidate
-repositories: `targetSnapshot`, `targetStaging`, `targetRelease`, `snapshotGroup`, and `releaseGroup`. The
-search probes all of them.
+repositories. The snapshot repositories are `targetSnapshot`, `targetStaging`, and `snapshotGroup`. The
+release repositories are `targetRelease` and `releaseGroup`. Each version form sets the folder and the
+repositories to search:
+
+- **Non-unique snapshot version.** The folder is `<version>` (ending in `-SNAPSHOT`). EnvGene reads that
+  folder's `maven-metadata.xml` to resolve `-SNAPSHOT` to the latest build and requests it from the snapshot
+  repositories.
+- **Unique snapshot version.** EnvGene resolves it as both a snapshot and a release. As a snapshot, the folder
+  is `<base>-SNAPSHOT` (the `-<timestamp>-<buildNumber>` suffix replaced with `-SNAPSHOT`), requested directly
+  from the snapshot repositories. As a release, the folder is `<version>`, requested directly from the release
+  repositories.
+- **Release version.** The folder is `<version>`, requested directly from the release repositories.
 
 ### Public cloud registries
 
 AWS, GCP, and Azure. `repositoryDomainName` addresses one repository that holds every artifact, with no
-snapshot, staging, release, or group separation. `mavenConfig` sets no candidate repositories, and EnvGene
-searches that single repository.
+snapshot, staging, release, or group separation. `mavenConfig` names no candidate repositories. Each version
+form sets the folder to request from that single repository:
 
-### Version resolution
-
-The version form sets the storage folder and how EnvGene picks the build within each searched repository:
-
-- **Non-unique snapshot version.** The folder is the version itself. EnvGene reads that folder's
-  `maven-metadata.xml` to resolve `-SNAPSHOT` to the latest build and requests it.
-- **Unique snapshot version.** The folder is `<base>-SNAPSHOT`, derived by replacing the
-  `-<timestamp>-<buildNumber>` suffix with `-SNAPSHOT`. The build is already named, so EnvGene requests it
-  directly without reading metadata.
-- **Release version.** The folder is the version itself, and EnvGene requests the file directly.
+- **Non-unique snapshot version.** The folder is `<version>` (ending in `-SNAPSHOT`). EnvGene reads that
+  folder's `maven-metadata.xml` to resolve `-SNAPSHOT` to the latest build and requests it.
+- **Unique snapshot version.** EnvGene tries both folders, each requested directly: `<base>-SNAPSHOT` (the
+  `-<timestamp>-<buildNumber>` suffix replaced with `-SNAPSHOT`) and `<version>`.
+- **Release version.** The folder is `<version>`, requested directly.


### PR DESCRIPTION
## What

Update the artifact resolution feature doc so a unique snapshot version (timestamped
`<base>-<timestamp>-<buildNumber>`) is resolved as both a snapshot and a release.

## Why

A release promoted without the `-RELEASE` postfix keeps its timestamped name but is published in the release
repository under the raw `<version>/` folder (precedent: PDPLDEVOPS-22916). The version string alone cannot
tell a genuine snapshot from such a release, so resolution must try both.

## Changes

- Note that the version forms classify the version string, not the artifact behind it.
- Fold version resolution into the `Traditional registries` and `Public cloud registries` sections.
- Traditional: snapshot folder in snapshot repos (`targetSnapshot`, `targetStaging`, `snapshotGroup`),
  release folder in release repos (`targetRelease`, `releaseGroup`); a unique snapshot is searched both ways.
- Public cloud: both folders tried in the single repository for a unique snapshot.

This doc is the design reference for the follow-up implementation CR (artifact-searcher dual resolution plus
the `releaseGroup` search gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)