### PR TITLE
docs: add use_committed_sd config for No-SD Mode without incoming SD

### DIFF
--- a/docs/envgene-configs.md
+++ b/docs/envgene-configs.md
@@ -395,6 +395,15 @@ sbom_retention:
 # and [Full Generation](/docs/features/effective-set-generation.md#full-generation)
 # for generation mode behavior
 effective_set_generation_strategy: enum [`full`, `partial`]
+# Optional. Default value - `true`
+# Controls whether the committed Full SD is used when a pipeline run provides no incoming SD
+# `true` - the committed Full SD is used, so Full Generation or Partial Generation runs
+# `false` - the committed Full SD is ignored when no SD is passed, so No-SD Mode runs and only
+# `topology` and `pipeline` contexts are produced
+# Set to `false` to avoid failures when the committed Full SD references application versions that can no
+# longer be downloaded from the registry
+# See [No-SD Mode](/docs/features/effective-set-generation.md#no-sd-mode)
+use_committed_sd: boolean
 ```
 
 ## `integration.yml`

--- a/docs/features/effective-set-generation.md
+++ b/docs/features/effective-set-generation.md
@@ -75,7 +75,8 @@ The generation path is chosen automatically based on the outcome of SD processin
 The entire ES is rebuilt from the current Full SD and environment instance data. All five contexts (`topology`, `pipeline`, `deployment`, `runtime`, `cleanup`) are produced. Applied when:
 
 - `SD_REPO_MERGE_MODE=replace`, or
-- The pipeline runs without an incoming SD and a Full SD already exists in the repository, or
+- The pipeline runs without an incoming SD, a Full SD already exists in the repository, and
+  `use_committed_sd` is `true` (the default), or
 - An incoming SD is supplied with a merge mode but no Full SD exists yet — the incoming SD becomes the Full SD, there is nothing to merge against.
 
 Application and Registry Definitions for every application in the Full SD must be available.
@@ -112,9 +113,21 @@ Under partial generation, the `generate_effective_set` stage follows the Delta S
 
 ### No-SD Mode
 
-Applied when the pipeline runs without an incoming SD and no Full SD exists in the repository. Only `topology` and `pipeline` contexts are produced; `deployment`, `runtime`, and `cleanup` require application data from a Solution Descriptor and cannot be generated without one. SBOMs are not required and are not requested.
+Applied when the pipeline runs without an incoming SD and one of the following holds:
 
-See [Generate Without a Solution Descriptor](/docs/how-to/generate-effective-set.md#generate-without-a-solution-descriptor) in the how-to guide.
+- No Full SD exists in the repository, or
+- A Full SD exists but `use_committed_sd` is `false` in
+  [`config.yml`](/docs/envgene-configs.md#configyml).
+
+Only `topology` and `pipeline` contexts are produced. `deployment`, `runtime`, and `cleanup` require
+application data from a Solution Descriptor and cannot be generated without one. SBOMs are not required
+so are not generated.
+
+By default (`use_committed_sd: true`) a run with no incoming SD uses the committed Full SD and Full
+Generation runs.
+
+See [Generate Without a Solution Descriptor](/docs/how-to/generate-effective-set.md#generate-without-a-solution-descriptor)
+in the how-to guide.
 
 ## Configuration
 

--- a/docs/how-to/generate-effective-set.md
+++ b/docs/how-to/generate-effective-set.md
@@ -165,7 +165,7 @@ The `git_commit` job commits these files to the Instance Repository automaticall
 
 ### Generate Without a Solution Descriptor
 
-When no Solution Descriptor is provided - for example when setting up infrastructure-only namespaces or preparing an environment before any applications are defined - the Effective Set is generated in a partial mode.
+When no Solution Descriptor is provided - for example when setting up infrastructure-only namespaces or preparing an environment before any applications are defined - the Effective Set is generated in No-SD Mode.
 
 Without an SD, EnvGene does not know which applications belong to which namespaces, so the application-specific contexts cannot be produced. The following contexts are generated normally:
 
@@ -178,7 +178,13 @@ The following contexts are **not generated**:
 - `runtime` - requires application definitions from the SD
 - `cleanup` - requires application definitions from the SD
 
-To use this mode, simply omit `SD_VERSION` and `SD_SOURCE_TYPE` from the pipeline variables. If no SD artifact is passed and no `sd.yaml` exists in the repository, EnvGene skips all application-level processing automatically.
+To use this mode, omit `SD_VERSION` and `SD_SOURCE_TYPE` from the pipeline variables. If no SD artifact is
+passed and no `sd.yaml` exists in the repository, EnvGene enters No-SD Mode automatically.
+
+If a `sd.yaml` is committed but you still want No-SD Mode - for example when the committed SD references
+application versions that can no longer be downloaded from the registry - set `use_committed_sd: false` in
+[`config.yml`](/docs/envgene-configs.md#configyml). With `use_committed_sd` set to `false`, a run with no
+incoming SD stays in No-SD Mode instead of using the committed SD.
 
 ---
 


### PR DESCRIPTION
## Summary

Documents a new `config.yml` attribute `use_committed_sd` (boolean, default `true`) that controls whether
the committed Full SD is used when a `generate_effective_set` run provides no incoming SD.

Today, a run with no incoming SD falls back to the committed Full SD and runs Full Generation, which
downloads the artifacts for every application version in the SD. If the committed Full SD references a
version that can no longer be downloaded from the registry, the whole run fails. With `use_committed_sd:
false`, such a run enters No-SD Mode (`topology` and `pipeline` contexts only) instead. The default `true`
preserves current behavior.

Changes:

- `docs/features/effective-set-generation.md` — extend the No-SD Mode entry condition and the Full
  Generation condition with `use_committed_sd`.
- `docs/envgene-configs.md` — document the `use_committed_sd` attribute in the `config.yml` section.
- `docs/how-to/generate-effective-set.md` — operational note plus a No-SD Mode terminology fix.

## Issue

No linked issue yet. This PR ships the design documentation. The implementation change request will be
filed separately and will reference this PR as its design source.

## Breaking Change?

- [ ] Yes
- [x] No

The attribute is optional and defaults to `true`, preserving current behavior.

## Scope / Project

`docs`

## Implementation Notes

Documentation only. The behavior itself is not implemented in this PR. The documented design was
cross-checked against the current No-SD Mode mechanism (`resolve_es_generation_mode` in
`python/envgene/envgenehelper/effective_set_helper.py` and the SBOM gate in `get_sboms`).

## Tests / Evidence

Docs only. Verified locally: no em or en dashes and no semicolons in new prose, prose wrapped at 120,
internal anchors (`#no-sd-mode`, `#configyml`) resolve.

## Additional Notes

- Documents behavior ahead of implementation. Implementation is a follow-up change request.
- Neighbouring feature: #1253 (Partial Effective Set generation) modifies adjacent leaves of the same
  SD-processing-outcome decision tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)