### PR TITLE
docs: search all candidate repositories for every version form

### DIFF
--- a/docs/features/artifact-resolution.md
+++ b/docs/features/artifact-resolution.md
@@ -45,23 +45,19 @@ the DD, resolution fails.
 
 The registry provider selects the repository model, traditional or public cloud. Registry Definition v2
 declares the provider. Registry Definition v1 has no provider and always uses the traditional model. The model
-sets where each version form is looked up.
+sets which repositories are searched.
 
 ### Traditional registries
 
 Nexus and Artifactory. `repositoryDomainName` is a base URL, and `mavenConfig` names the candidate
-repositories. The snapshot repositories are `targetSnapshot`, `targetStaging`, and `snapshotGroup`. The
-release repositories are `targetRelease` and `releaseGroup`. Each version form sets the folder and the
-repositories to search:
+repositories: `targetSnapshot`, `targetStaging`, `targetRelease`, `snapshotGroup`, and `releaseGroup`. Every
+version form is searched across all of them. The version form sets the folder to request:
 
 - **Non-unique snapshot version.** The folder is `<version>` (ending in `-SNAPSHOT`). EnvGene reads that
-  folder's `maven-metadata.xml` to resolve `-SNAPSHOT` to the latest build and requests it from the snapshot
-  repositories.
-- **Unique snapshot version.** EnvGene resolves it as both a snapshot and a release. As a snapshot, the folder
-  is `<base>-SNAPSHOT` (the `-<timestamp>-<buildNumber>` suffix replaced with `-SNAPSHOT`), requested directly
-  from the snapshot repositories. As a release, the folder is `<version>`, requested directly from the release
-  repositories.
-- **Release version.** The folder is `<version>`, requested directly from the release repositories.
+  folder's `maven-metadata.xml` to resolve `-SNAPSHOT` to the latest build and requests it.
+- **Unique snapshot version.** EnvGene tries both folders, each requested directly: `<base>-SNAPSHOT` (the
+  `-<timestamp>-<buildNumber>` suffix replaced with `-SNAPSHOT`) and `<version>`.
+- **Release version.** The folder is `<version>`, requested directly.
 
 ### Public cloud registries
 


### PR DESCRIPTION
## What

Revert the artifact resolution doc from role-scoped repository lookup back to searching all candidate
repositories for every version form, keeping the unique snapshot dual-folder probe.

## Why

Role-scoping (introduced in #1628) contradicts #1600, which keeps probing all candidate repositories with no
routing by version form. The only behaviour EnvGene needs to add over current behaviour is the raw
`<version>` folder candidate for a unique snapshot version.

## Changes

- Traditional registries: search all candidate repositories for every version form. A unique snapshot version
  tries both the `<base>-SNAPSHOT` folder and the raw `<version>` folder, first hit wins.
- Public cloud registries: unchanged (already probes both folders in the single repository).

This doc is the design reference for the implementation CR #1629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)