### PR TITLE
docs: correct the SBOM total-size limit to 600 MB

### DIFF
--- a/docs/envgene-configs.md
+++ b/docs/envgene-configs.md
@@ -375,7 +375,7 @@ app_reg_defs_placement: enum [`dual`, `root`]
 # Runs during Effective Set generation when enabled
 # Applies per-application SBOM retention to subdirectories of `/sboms/` when `keep_versions_per_app` is set
 # A total size limit step keeps only the single most recent file per application subdirectory
-# if the total size of `/sboms/` still exceeds 1200 MB after per-application SBOM retention
+# if the total size of `/sboms/` still exceeds 600 MB after per-application SBOM retention
 sbom_retention:
   # Optional. Default value - `false`
   # Enable/disable SBOM retention cleanup
@@ -385,7 +385,7 @@ sbom_retention:
   # Per-application SBOM retention runs only when this is set to a positive integer.
   # If the field is omitted or set to `0`, this step is skipped and only the total size
   # limit step runs (keeping the most recent file per application subdirectory when /sboms/
-  # exceeds 1200 MB)
+  # exceeds 600 MB)
   keep_versions_per_app: integer
 # Optional. Default value - `partial`
 # Defines the Effective Set generation strategy used by `generate_effective_set`

--- a/docs/features/sbom-retention.md
+++ b/docs/features/sbom-retention.md
@@ -37,7 +37,7 @@ Automatic SBOM retention policy that:
   subdirectory under `/sboms/`, when `keep_versions_per_app` is set
 - Falls back to a [total size limit](#total-size-limit) step that keeps only the single most
   recently modified file in each per-application subdirectory if the total size of `/sboms/`
-  still exceeds 1200 MB after per-application SBOM retention
+  still exceeds 600 MB after per-application SBOM retention
 
 ## When cleanup is triggered
 
@@ -46,7 +46,7 @@ Cleanup runs when both of the following conditions are true:
 1. `GENERATE_EFFECTIVE_SET: true` (retention runs as part of the effective set job)
 2. `sbom_retention.enabled: true` in `/configuration/config.yml`
 
-Cleanup is **not** gated by repository size. The 1200 MB limit is checked only by the
+Cleanup is **not** gated by repository size. The 600 MB limit is checked only by the
 [total size limit](#total-size-limit) step, after per-application SBOM retention has run.
 
 ## Retention strategy
@@ -79,14 +79,14 @@ For each application subdirectory under `/sboms/`:
 
 ### Total size limit
 
-After per-application SBOM retention, the total size of `/sboms/` is compared to the 1200 MB
+After per-application SBOM retention, the total size of `/sboms/` is compared to the 600 MB
 limit:
 
-- If the total size is at or below 1200 MB, no further action is taken
-- If the total size exceeds 1200 MB, retention runs over each per-application subdirectory and
+- If the total size is at or below 600 MB, no further action is taken
+- If the total size exceeds 600 MB, retention runs over each per-application subdirectory and
   keeps only the single most recently modified file. Older files in each subdirectory are deleted
 
-The 1200 MB limit sits below the [job artifacts](/docs/dev/job-artifacts.md) 1500 MB limit on
+The 600 MB limit sits below the [job artifacts](/docs/dev/job-artifacts.md) 1500 MB limit on
 job artifact size, so that retention can keep the cache within bounds before the job artifact
 size becomes a problem.
 
@@ -108,7 +108,7 @@ sbom_retention:
   # Per-application SBOM retention runs only when this is set to a positive integer.
   # If the field is omitted or set to `0`, this step is skipped and only the total size
   # limit step runs (keeping the most recent file per application subdirectory when
-  # /sboms/ exceeds 1200 MB)
+  # /sboms/ exceeds 600 MB)
   keep_versions_per_app: int
 ```
 

--- a/docs/use-cases/sbom-retention.md
+++ b/docs/use-cases/sbom-retention.md
@@ -7,7 +7,7 @@
     - [UC-SBOM-2: All applications within per-application limit - no files deleted](#uc-sbom-2-all-applications-within-per-application-limit---no-files-deleted)
     - [UC-SBOM-3: Per-application retention keeps 10 most recent versions](#uc-sbom-3-per-application-retention-keeps-10-most-recent-versions)
     - [UC-SBOM-4: Per-application retention with custom version count](#uc-sbom-4-per-application-retention-with-custom-version-count)
-    - [UC-SBOM-5: Total /sboms/ size exceeds 1200 MB - keeps newest per application](#uc-sbom-5-total-sboms-size-exceeds-1200-mb---keeps-newest-per-application)
+    - [UC-SBOM-5: Total /sboms/ size exceeds 600 MB - keeps newest per application](#uc-sbom-5-total-sboms-size-exceeds-600-mb---keeps-newest-per-application)
 
 ## Overview
 
@@ -22,7 +22,7 @@ structure.
 The cleanup logic runs during effective set generation and depends only on the
 `sbom_retention.enabled` flag. When enabled, per-application SBOM retention runs only if
 `keep_versions_per_app` is set, then the total size of `/sboms/` is checked against the
-1200 MB limit. These use cases demonstrate the observable behavior in each scenario.
+600 MB limit. These use cases demonstrate the observable behavior in each scenario.
 
 ### UC-SBOM-1: SBOM retention disabled - no cleanup
 
@@ -84,7 +84,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
      keep_versions_per_app: 10
    ```
 
-4. Total size of `/sboms/` is 200 MB (at or below the 1200 MB limit)
+4. Total size of `/sboms/` is 200 MB (at or below the 600 MB limit)
 
 **Trigger:**
 
@@ -100,7 +100,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 3. Any legacy flat SBOM files at the top of `/sboms/` are removed (none in this case).
 4. Per-application SBOM retention runs over each subdirectory. Every subdirectory already
    contains 10 or fewer files, so no files are deleted.
-5. The total size of `/sboms/` is at or below the 1200 MB limit. The total size limit step
+5. The total size of `/sboms/` is at or below the 600 MB limit. The total size limit step
    does not run.
 6. The effective set generation completes.
 
@@ -129,7 +129,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
      keep_versions_per_app: 10
    ```
 
-4. Total size of `/sboms/` is 500 MB (below the 1200 MB limit)
+4. Total size of `/sboms/` is 500 MB (below the 600 MB limit)
 
 **Trigger:**
 
@@ -145,7 +145,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 3. Any legacy flat SBOM files at the top of `/sboms/` are removed (none in this case).
 4. For each per-application subdirectory, the 10 most recent files are kept and older files are
    deleted.
-5. The total size of `/sboms/` after per-application SBOM retention is at or below the 1200 MB
+5. The total size of `/sboms/` after per-application SBOM retention is at or below the 600 MB
    limit. The total size limit step does not run.
 6. The effective set generation completes.
 
@@ -179,7 +179,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
      keep_versions_per_app: 3  # only keep 3 most recent versions
    ```
 
-4. Total size of `/sboms/` is 350 MB (below the 1200 MB limit)
+4. Total size of `/sboms/` is 350 MB (below the 600 MB limit)
 
 **Trigger:**
 
@@ -194,7 +194,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 2. SBOM retention is enabled with `keep_versions_per_app: 3`. The cleanup procedure starts.
 3. Any legacy flat SBOM files at the top of `/sboms/` are removed (none in this case).
 4. For `/sboms/postgres/`, the 3 most recent files are kept and the 7 older files are deleted.
-5. The total size of `/sboms/` after per-application SBOM retention is at or below the 1200 MB
+5. The total size of `/sboms/` after per-application SBOM retention is at or below the 600 MB
    limit. The total size limit step does not run.
 6. The effective set generation completes.
 
@@ -211,7 +211,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
      deleted file)
    - `Directory size <X> MB`
 
-### UC-SBOM-5: Total /sboms/ size exceeds 1200 MB - keeps newest per application
+### UC-SBOM-5: Total /sboms/ size exceeds 600 MB - keeps newest per application
 
 **Pre-requisites:**
 
@@ -226,7 +226,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
      keep_versions_per_app: 10
    ```
 
-4. Total size of `/sboms/` is 1300 MB (above the 1200 MB limit). Per-application retention is not
+4. Total size of `/sboms/` is 1300 MB (above the 600 MB limit). Per-application retention is not
    able to reduce the total below the limit because no per-application subdirectory exceeds
    `keep_versions_per_app`
 
@@ -244,7 +244,7 @@ Instance pipeline (GitLab or GitHub) is started with parameters:
 3. Any legacy flat SBOM files at the top of `/sboms/` are removed (none in this case).
 4. Per-application SBOM retention runs over each subdirectory. No subdirectory exceeds
    `keep_versions_per_app`, so no per-application files are deleted.
-5. The total size of `/sboms/` exceeds the 1200 MB limit. The total size limit step runs over
+5. The total size of `/sboms/` exceeds the 600 MB limit. The total size limit step runs over
    each subdirectory and keeps only the most recently modified file. Older files in each
    subdirectory are deleted.
 6. The effective set generation completes.

--- a/gsf_packages/envgene_instance_project/git-system-follower-package/scripts/templates/default/{{ cookiecutter.gsf_repository_name }}/example/configuration/config.yml
+++ b/gsf_packages/envgene_instance_project/git-system-follower-package/scripts/templates/default/{{ cookiecutter.gsf_repository_name }}/example/configuration/config.yml
@@ -17,5 +17,5 @@ crypt: false
   # Per-application SBOM retention runs only when this is set to a positive integer.
   # If the field is omitted or set to 0, this step is skipped and only the total
   # size limit step runs (keeping the most recent file per application subdirectory
-  # when /sboms/ exceeds 1200 MB)
+  # when /sboms/ exceeds 600 MB)
   # keep_versions_per_app: 10

--- a/gsf_packages/envgene_instance_project/git-system-follower-package/scripts/templates/default/{{ cookiecutter.gsf_repository_name }}/git_hooks/config.schema.json
+++ b/gsf_packages/envgene_instance_project/git-system-follower-package/scripts/templates/default/{{ cookiecutter.gsf_repository_name }}/git_hooks/config.schema.json
@@ -61,7 +61,7 @@
     "sbom_retention": {
       "type": "object",
       "title": "SBOM Retention Configuration",
-      "description": "Configuration for automatic SBOM file cleanup. When enabled, per-application SBOM retention is applied to subdirectories of /sboms/ if keep_versions_per_app is set. A total size limit step then keeps only the most recently modified file in each per-application subdirectory if the total size of /sboms/ still exceeds 1200 MB.",
+      "description": "Configuration for automatic SBOM file cleanup. When enabled, per-application SBOM retention is applied to subdirectories of /sboms/ if keep_versions_per_app is set. A total size limit step then keeps only the most recently modified file in each per-application subdirectory if the total size of /sboms/ still exceeds 600 MB.",
       "additionalProperties": false,
       "properties": {
         "enabled": {

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -61,7 +61,7 @@
     "sbom_retention": {
       "type": "object",
       "title": "SBOM Retention Configuration",
-      "description": "Configuration for automatic SBOM file cleanup. When enabled, per-application SBOM retention is applied to subdirectories of /sboms/ if keep_versions_per_app is set. A total size limit step then keeps only the most recently modified file in each per-application subdirectory if the total size of /sboms/ still exceeds 1200 MB.",
+      "description": "Configuration for automatic SBOM file cleanup. When enabled, per-application SBOM retention is applied to subdirectories of /sboms/ if keep_versions_per_app is set. A total size limit step then keeps only the most recently modified file in each per-application subdirectory if the total size of /sboms/ still exceeds 600 MB.",
       "additionalProperties": false,
       "properties": {
         "enabled": {


### PR DESCRIPTION
## Summary

The implementation constant `CI_JOB_ARTIFACT_MAX_SIZE_MB` is 600, while the documentation claimed a
1200 MB SBOM total-size limit. In the 600-1200 MB range the documented and the actual behavior were
opposite: the docs promised no cleanup while the code trims every application directory to a single file.
The maintainer verdict is that the docs are wrong and 600 is the intended value, so every user-facing
mention of 1200 MB is corrected to 600 MB:

- `docs/features/sbom-retention.md` (7 mentions, including the relation to the 1500 MB job-artifacts
  limit, which stays true)
- `docs/use-cases/sbom-retention.md` (12 mentions, including the `UC-SBOM-5` heading, its TOC entry and
  anchor - all size examples remain on the correct side of the new value)
- `docs/envgene-configs.md` (2 mentions in the `sbom_retention` config comments)
- `schemas/config.schema.json` and its GSF template copy (the `sbom_retention` description surfaced in
  editor tooling)
- the GSF example `configuration/config.yml` comment shipped to new instance repositories

## Issue

No issue: docs-only alignment with no implementation change. Findings come from the test review of
PR #1637 (the earlier PR #1586 attempted to change the constant to 1200 inside a test PR instead - that
direction was rejected).

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

docs

## Tests / Evidence

Verified against the implementation: `CI_JOB_ARTIFACT_MAX_SIZE_MB = 600` and its consumer
`sboms_retention_policy.py`. A repo-wide sweep confirms no remaining 1200 MB mention of the limit, all
size examples in the use cases stay on the correct side of 600, and both JSON schemas remain valid.

## Additional Notes

The `UC-SBOM-5` scenario title and the inflation-step docstring in PR #1637 still say 1200 MB - flagged
to the author in the test review of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)