### PR TITLE
feat: Add use_committed_sd to enter No-SD Mode when a run has no incoming SD

### DIFF
--- a/build_effective_set_generator/scripts/effective_set_entrypoint.py
+++ b/build_effective_set_generator/scripts/effective_set_entrypoint.py
@@ -4,7 +4,8 @@ from os import getenv
 
 from envgenehelper.business_helper import get_current_env_dir_from_env_vars
 from envgenehelper.effective_set_helper import GenerationMode, PartialMergeMode, \
-    resolve_partial_merge_mode, ES_MAPPING_FILE, ESGenerationContext, ES_DIR_NAME, get_es_generation_mode
+    resolve_partial_merge_mode, ES_MAPPING_FILE, ESGenerationContext, ES_DIR_NAME, get_es_generation_mode, \
+    get_full_generation_sd_path
 from envgenehelper.file_helper import delete_dir, deleteFileIfExists, delete_dir_if_exists
 from envgenehelper.logger import logger
 from envgenehelper.sd_helper import get_sd_dir, DELTA_SD_FILE_NAME, SD_FILE_NAME
@@ -25,7 +26,7 @@ def effective_set_entrypoint():
         else:
             _run_forward_merge(effective_set_dir, full_env_name, delta_sd_path)
     else:
-        _run_full_generation(effective_set_dir, full_env_name, sd_path)
+        _run_full_generation(effective_set_dir, full_env_name, get_full_generation_sd_path())
 
     # do not commit delta sd to repo
     deleteFileIfExists(delta_sd_path)
@@ -138,7 +139,7 @@ def _build_cli_cmd(effective_set_dir, full_env_name, sd_path):
         f"--output={effective_set_dir}",
     ]
 
-    if sd_path.is_file():
+    if sd_path is not None and sd_path.is_file():
         cmd.extend([
             "--registries=${CI_PROJECT_DIR}/configuration/registry.yml",
             "--sboms-path=$CI_PROJECT_DIR/sboms",

--- a/python/envgene/envgenehelper/effective_set_helper.py
+++ b/python/envgene/envgenehelper/effective_set_helper.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from os import getenv
+from pathlib import Path
 
 from envgenehelper import get_envgene_config_yaml, calculate_merge_mode, MergeType, logger, get_sd_dir, SD_FILE_NAME, \
     get_sd_dir_by_env_cluster_name, getenv_with_error
@@ -37,6 +38,15 @@ def resolve_partial_merge_mode():
         return PartialMergeMode.FORWARD
 
     raise ValueError(f"Unsupported merge mode for partial: {merge_mode}")
+
+
+def get_full_generation_sd_path() -> Path | None:
+    sd_input = bool(getenv("SD_DATA") or getenv("SD_VERSION"))
+    use_committed_sd = get_envgene_config_yaml().get("use_committed_sd", True)
+    if not sd_input and not use_committed_sd:
+        logger.info("No-SD Mode: no incoming SD and use_committed_sd=false")
+        return None
+    return get_sd_dir().joinpath(SD_FILE_NAME)
 
 
 def resolve_es_generation_mode(cluster_name, env_name):

--- a/python/envgene/envgenehelper/test_effective_set_helper.py
+++ b/python/envgene/envgenehelper/test_effective_set_helper.py
@@ -1,0 +1,11 @@
+import pytest
+from unittest.mock import patch
+
+from envgenehelper.effective_set_helper import get_full_generation_sd_path
+
+@pytest.mark.unit
+def test_returns_none_when_committed_sd_disabled(monkeypatch):
+    monkeypatch.setattr("envgenehelper.effective_set_helper.getenv", lambda key: None,)
+    monkeypatch.setattr("envgenehelper.effective_set_helper.get_envgene_config_yaml", lambda: {"use_committed_sd": False},)
+
+    assert get_full_generation_sd_path() is None

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -86,6 +86,16 @@
           ]
         }
       }
+    },
+    "use_committed_sd": {
+      "type": "boolean",
+      "title": "Use Committed Full SD",
+      "description": "When false and no incoming SD is provided, EnvGene enters No-SD Mode: only topology and pipeline contexts are generated, registry requests are skipped. When true (default) or omitted, the committed Full SD is used and Full Generation runs as normal.",
+      "default": true,
+      "examples": [
+        true,
+        false
+      ]
     }
   }
 }


### PR DESCRIPTION
# Pull Request

## Summary

when use_committed_sd is set to false in configuration/config.xml file, and there is no sd_data passed as input, run the effective set with no_sd mode and sbom generation also needs to be skipped. 

## Issue

https://github.com/Netcracker/qubership-envgene/issues/1631

## Breaking Change?

- [ ] Yes
- [ X] No

## Scope / Project

effective set job

## Implementation Notes

in generation mode full, if the use_committed_sd is false, pass an empty sd. 

## Tests / Evidence

- Tests added

## Additional Notes

Include any extra information, such as:
