### PR TITLE
feat: Computed `current_env.composite_topology` environment variable

### DIFF
--- a/schemas/composite-structure.schema.json
+++ b/schemas/composite-structure.schema.json
@@ -129,27 +129,124 @@
     "satellites": {
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Name of the satellite component"
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "Namespace Satellite",
+            "description": "Satellite defined as a simple namespace",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the satellite component"
+              },
+              "type": {
+                "type": "string",
+                "description": "Type of the satellite component",
+                "enum": [
+                  "namespace"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "type"
+            ],
+            "additionalProperties": false
           },
-          "type": {
-            "type": "string",
-            "description": "Type of the satellite component",
-            "enum": [
-              "namespace"
-            ]
+          {
+            "type": "object",
+            "title": "BG Domain Satellite",
+            "description": "Satellite defined as a Blue-Green Domain",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the BG Domain"
+              },
+              "type": {
+                "type": "string",
+                "description": "Type of the satellite component",
+                "enum": [
+                  "bgdomain"
+                ]
+              },
+              "originNamespace": {
+                "type": "object",
+                "description": "The currently active namespace in the BG Domain",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the origin namespace"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "Type of the namespace reference",
+                    "enum": [
+                      "namespace"
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ],
+                "additionalProperties": false
+              },
+              "peerNamespace": {
+                "type": "object",
+                "description": "The standby namespace in the BG Domain",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the peer namespace"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "Type of the namespace reference",
+                    "enum": [
+                      "namespace"
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ],
+                "additionalProperties": false
+              },
+              "controllerNamespace": {
+                "type": "object",
+                "description": "The namespace that manages BG Domain lifecycle operations",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the controller namespace"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "Type of the namespace reference",
+                    "enum": [
+                      "namespace"
+                    ]
+                  }
+                },
+                "required": [
+                  "name",
+                  "type"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name",
+              "type",
+              "originNamespace",
+              "peerNamespace",
+              "controllerNamespace"
+            ],
+            "additionalProperties": false
           }
-        },
-        "required": [
-          "name",
-          "type"
-        ],
-        "additionalProperties": false
+        ]
       },
-      "minItems": 1,
       "description": "List of satellite components"
     }
   },

--- a/scripts/build_env/render_config_env.py
+++ b/scripts/build_env/render_config_env.py
@@ -636,7 +636,7 @@ class EnvGenerator:
 
         raise ValueError(f"Unknown composite member type: {member_type}")
 
-    def generate_composite_topology(self):
+    def compute_composite_topology()(self):
         cs_file = Path(self.ctx.current_env_dir) / "composite_structure.yml"
 
         if not cs_file.exists():
@@ -696,7 +696,7 @@ class EnvGenerator:
             self.ctx.current_env_dir = current_env_dir
             self.set_env_templates()
             self.generate_composite_structure()
-            self.generate_composite_topology()
+            self.compute_composite_topology()()
             self.generate_bgd_file()
             self.generate_solution_structure()
             self.generate_tenant_file()

--- a/scripts/build_env/render_config_env.py
+++ b/scripts/build_env/render_config_env.py
@@ -696,7 +696,7 @@ class EnvGenerator:
             self.ctx.current_env_dir = current_env_dir
             self.set_env_templates()
             self.generate_composite_structure()
-            self.compute_composite_topology()()
+            self.compute_composite_topology()
             self.generate_bgd_file()
             self.generate_solution_structure()
             self.generate_tenant_file()

--- a/scripts/build_env/render_config_env.py
+++ b/scripts/build_env/render_config_env.py
@@ -636,7 +636,7 @@ class EnvGenerator:
 
         raise ValueError(f"Unknown composite member type: {member_type}")
 
-    def compute_composite_topology()(self):
+    def compute_composite_topology(self):
         cs_file = Path(self.ctx.current_env_dir) / "composite_structure.yml"
 
         if not cs_file.exists():

--- a/scripts/build_env/render_config_env.py
+++ b/scripts/build_env/render_config_env.py
@@ -434,7 +434,7 @@ class EnvGenerator:
             cs_file.parent.mkdir(parents=True, exist_ok=True)
             self.render_from_file_to_file(Template(composite_structure).render(self.ctx.as_dict()), str(cs_file))
             validate_yaml_by_scheme_or_fail(cs_file, COMPOSITE_SCHEMA)
-    
+
     def generate_external_cred(self):
         #render external creds
         external_credential_template = self.ctx.current_env_template.get("external_credential_template")
@@ -619,6 +619,50 @@ class EnvGenerator:
 
             self.validate_appregdefs()
 
+    def _resolve_composite_member(self, member: dict) -> dict:
+        member_type = member.get("type")
+
+        if member_type == "namespace":
+            return {
+                "originNamespace": member["name"]
+            }
+
+        if member_type == "bgdomain":
+            return {
+                "originNamespace": member["originNamespace"]["name"],
+                "peerNamespace": member["peerNamespace"]["name"],
+                "controllerNamespace": member["controllerNamespace"]["name"],
+            }
+
+        raise ValueError(f"Unknown composite member type: {member_type}")
+
+    def generate_composite_topology(self):
+        cs_file = Path(self.ctx.current_env_dir) / "composite_structure.yml"
+
+        if not cs_file.exists():
+            logger.info("Composite Structure not found. composite_topology={}")
+            self.ctx.current_env["composite_topology"] = {}
+            return
+
+        composite = openYaml(cs_file)
+
+        baseline = composite.get("baseline")
+        if not baseline:
+            raise ValueError("Composite Structure is missing required 'baseline'")
+        topology = {
+            "baseline": self._resolve_composite_member(baseline)
+        }
+        satellites = [
+            self._resolve_composite_member(member)
+            for member in composite.get("satellites", [])
+        ]
+        if satellites:
+            topology["satellites"] = satellites
+        self.ctx.current_env["composite_topology"] = topology
+        logger.info(
+            f"Resolved composite_topology:\n{dump_as_yaml_format(topology)}"
+        )
+
     def render_config_env(self, env_name: str, extra_env: dict):
         logger.info(f"Starting rendering environment {env_name}. Input params are:\n{dump_as_yaml_format(extra_env)}")
         with self.ctx.use():
@@ -651,13 +695,13 @@ class EnvGenerator:
             current_env_dir = f'{self.ctx.render_dir}/{self.ctx.env}'
             self.ctx.current_env_dir = current_env_dir
             self.set_env_templates()
-
+            self.generate_composite_structure()
+            self.generate_composite_topology()
             self.generate_bgd_file()
             self.generate_solution_structure()
             self.generate_tenant_file()
             self.generate_cloud_file()
             self.generate_namespace_files()
-            self.generate_composite_structure()
             self.generate_external_cred()
 
             env_specific_schema = self.ctx.current_env_template.get("envSpecificSchema")


### PR DESCRIPTION
# Pull Request

## Summary

EnvGene resolves an environment's composite topology, its baseline plus satellites including Blue-Green domains, but
does not expose that topology to templates. This ticket adds a computed current_env.composite_topology variable that
carries the rendered Kubernetes namespace names of every member. A namespace-CR application and a cluster-wide
operator consume it to create secrets per namespace.

## Issue
https://github.com/Netcracker/qubership-envgene/issues/1545

## Breaking Change?

- [ ] Yes
- [X] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

1.Add the [current_env.composite_topology](https://github.com/docs/template-macros.md#current_envcomposite_topology) Jinja macro,
resolved at [Environment Instance](https://github.com/docs/envgene-objects.md#environment-instance-objects) generation.
Type HashMap, default {}.
2.Populate the value only for composite environments, including composite environments that contain Blue-Green
domains. Resolve to {} for environments without a [Composite Structure](https://github.com/docs/envgene-objects.md#composite-structure).
3.Build the value from the [Composite Structure](https://github.com/docs/envgene-objects.md#composite-structure) object, which embeds
any inline Blue-Green domain. Copy the baseline and satellites tree, and resolve each member's namespace
template to its rendered namespace name as originNamespace.
4.Expand a bgdomain member into originNamespace, peerNamespace, and controllerNamespace. Keep a namespace
member with only originNamespace.
5.Widen the [Composite Structure](https://github.com/docs/envgene-objects.md#composite-structure) schema
(schemas/composite-structure.schema.json) so the cases below are representable in the source object. Allow a
bgdomain satellite member, mirroring the bgdomain baseline (Case D and Case E). Remove the minItems: 1
constraint on satellites so a baseline-only composite is valid (Case A). The full target schema is attached
under [Target schema](https://github.com/Netcracker/qubership-envgene/issues/1545#target-schema).

## Tests / Evidence

Describe how the changes were verified, including:

- Tests added or updated (e.g., unit, integration, end-to-end)
- Manual testing steps or results
- Screenshots, logs, or other evidence (if applicable)

## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
