### PR TITLE
docs: refine system certificate docs and document SSL_CERTIFICATES_BUNDLE

### DIFF
--- a/docs/envgene-repository-variables.md
+++ b/docs/envgene-repository-variables.md
@@ -60,7 +60,8 @@ This variable is passed to the pipeline and is supported by EnvGene Python and J
 
 ### `SECRET_KEY`
 
-**Description**: Fernet key. Used to encrypt/decrypt credentials when [`crypt_backend`](/docs/envgene-configs.md#configyml) is set to `Fernet`
+**Description**: Fernet key. Used to encrypt/decrypt credentials when
+[`crypt_backend`](/docs/envgene-configs.md#configyml) is set to `Fernet`
 
 Used by EnvGene at runtime, when using pre-commit hooks, the same value must be specified in `.git/secret_key.txt`.
 
@@ -74,7 +75,8 @@ Used by EnvGene at runtime, when using pre-commit hooks, the same value must be 
 
 **Description**: Access token used to authenticate with GitLab for accessing repository.
 
-Used by EnvGene to commit changes to the GitLab repository where the EnvGene pipeline is executed during the execution of the [git_commit](/docs/envgene-pipelines.md) job in GitLab
+Used by EnvGene to commit changes to the GitLab repository where the EnvGene pipeline is executed during the execution
+of the [git_commit](/docs/envgene-pipelines.md) job in GitLab
 
 **Default Value**: None
 
@@ -84,7 +86,8 @@ Used by EnvGene to commit changes to the GitLab repository where the EnvGene pip
 
 ### `ENVGENE_AGE_PRIVATE_KEY`
 
-**Description**: Private key from EnvGene's AGE key pair. Used to decrypt credentials when [`crypt_backend`](/docs/envgene-configs.md#configyml) is set to `SOPS`
+**Description**: Private key from EnvGene's AGE key pair. Used to decrypt credentials when
+[`crypt_backend`](/docs/envgene-configs.md#configyml) is set to `SOPS`
 
 Used by EnvGene at runtime. When using pre-commit hooks, the same value must be specified in `.git/private-age-key.txt`.
 
@@ -96,13 +99,16 @@ Used by EnvGene at runtime. When using pre-commit hooks, the same value must be 
 
 ### `ENVGENE_AGE_PUBLIC_KEY`
 
-**Description**: Public key from EnvGene's AGE key pair. Added for logical completeness (not currently used in operations). **For encryption, `PUBLIC_AGE_KEYS` is used instead.**
+**Description**: Public key from EnvGene's AGE key pair. Added for logical completeness (not currently used in
+operations). **For encryption, `PUBLIC_AGE_KEYS` is used instead.**
 
 **Example**: `key-placeholder-123`
 
 ### `PUBLIC_AGE_KEYS`
 
-**Description**: Contains a comma-separated list of public AGE keys from EnvGene and external systems (`<key_1>,<key_2>,...,<key_N>`). Used for credential encryption when [`crypt_backend`](/docs/envgene-configs.md#configyml) is `SOPS`
+**Description**: Contains a comma-separated list of public AGE keys from EnvGene and external systems
+(`<key_1>,<key_2>,...,<key_N>`). Used for credential encryption when
+[`crypt_backend`](/docs/envgene-configs.md#configyml) is `SOPS`
 
 Must include at least one key: EnvGene's own AGE public key.
 If an external system provides encrypted parameters, its public AGE key must also be included.
@@ -116,7 +122,8 @@ Used by EnvGene at runtime. When using pre-commit hooks, the same value must be 
 
 ### `GITLAB_RUNNER_TAG_NAME`
 
-**Description**: The tag that identifies the GitLab runner used for executing CI jobs. This tag is used to specify which runner will pick up and execute the job in the CI pipeline.
+**Description**: The tag that identifies the GitLab runner used for executing CI jobs. This tag is used to specify which
+runner will pick up and execute the job in the CI pipeline.
 
 **Default Value**: None
 
@@ -126,7 +133,8 @@ Used by EnvGene at runtime. When using pre-commit hooks, the same value must be 
 
 ### `GH_RUNNER_TAG_NAME`
 
-**Description**: The tag that identifies the GitHub runner used for executing CI jobs. This tag is used to specify which runner will pick up and execute the job in the CI pipeline.
+**Description**: The tag that identifies the GitHub runner used for executing CI jobs. This tag is used to specify which
+runner will pick up and execute the job in the CI pipeline.
 
 **Default Value**: `ubuntu-22.04`
 
@@ -136,7 +144,9 @@ Used by EnvGene at runtime. When using pre-commit hooks, the same value must be 
 
 ### `RUNNER_SCRIPT_TIMEOUT`
 
-**Description**: Specifies the maximum duration allowed for a job to run before being forcibly terminated by the runner. This value is typically used to control job timeouts in automation pipelines to avoid hanging or long-running processes.The parameter value must be specified in [Go's duration format](https://pkg.go.dev/time#ParseDuration).
+**Description**: Specifies the maximum duration allowed for a job to run before being forcibly terminated by the runner.
+This value is typically used to control job timeouts in automation pipelines to avoid hanging or long-running
+processes.The parameter value must be specified in [Go's duration format](https://pkg.go.dev/time#ParseDuration).
 
 **Default Value**: 10m
 
@@ -146,9 +156,14 @@ Used by EnvGene at runtime. When using pre-commit hooks, the same value must be 
 
 ### `GH_RUNNER_SCRIPT_TIMEOUT`
 
-**Description**: Specifies the maximum duration allowed for a job to run before being forcibly terminated by the runner in GitHub pipeline. This value is passed to the `timeout-minutes` attribute of the pipeline job. This value is typically used to control job timeouts in automation pipelines to avoid hanging or long-running processes. The parameter value must be specified as a number in minutes.
+**Description**: Specifies the maximum duration allowed for a job to run before being forcibly terminated by the runner
+in GitHub pipeline. This value is passed to the `timeout-minutes` attribute of the pipeline job. This value is typically
+used to control job timeouts in automation pipelines to avoid hanging or long-running processes. The parameter value
+must be specified as a number in minutes.
 
-This parameter is only available in the GitHub version of the pipeline. For more information about `timeout-minutes`, see the [official GitHub Actions documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes).
+This parameter is only available in the GitHub version of the pipeline. For more information about `timeout-minutes`,
+see the [official GitHub Actions
+documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes).
 
 **Default Value**: `10`
 
@@ -158,7 +173,8 @@ This parameter is only available in the GitHub version of the pipeline. For more
 
 ### `CALCULATOR_CLI_JAVA_OPTIONS`
 
-**Description**: Java options passed to the Calculator CLI to override default settings. Used to control heap size and ForkJoinPool thread count (number of applications processed in parallel during effective set generation).
+**Description**: Java options passed to the Calculator CLI to override default settings. Used to control heap size and
+ForkJoinPool thread count (number of applications processed in parallel during effective set generation).
 
 **Default Value**: None
 
@@ -182,7 +198,10 @@ CALCULATOR_CLI_JAVA_OPTIONS="-Djava.util.concurrent.ForkJoinPool.common.parallel
 
 ### `DOCKER_CLOUD_REGISTRY_PROVIDER`
 
-**Description**: Cloud provider for Docker registry authentication when pulling EnvGene Docker images. Currently, the only supported value is `GCP`. When set to `GCP`, the GitHub workflow authenticates to Google Artifact Registry (GAR) before pulling EnvGene images. Used together with [`DOCKER_REGISTRY`](#docker_registry-in-instance-repository) and [`GCP_SA_KEY`](#gcp_sa_key).
+**Description**: Cloud provider for Docker registry authentication when pulling EnvGene Docker images. Currently, the
+only supported value is `GCP`. When set to `GCP`, the GitHub workflow authenticates to Google Artifact Registry (GAR)
+before pulling EnvGene images. Used together with [`DOCKER_REGISTRY`](#docker_registry-in-instance-repository) and
+[`GCP_SA_KEY`](#gcp_sa_key).
 
 **Default Value**: None
 
@@ -192,11 +211,14 @@ CALCULATOR_CLI_JAVA_OPTIONS="-Djava.util.concurrent.ForkJoinPool.common.parallel
 
 **Example**: `GCP`
 
-**Note**: This parameter is used only in the GitHub EnvGene pipeline. For GitLab, use runner-level configuration. See [Docker Registry Configuration](/docs/how-to/docker-registry-configuration.md) for details.
+**Note**: This parameter is used only in the GitHub EnvGene pipeline. For GitLab, use runner-level configuration. See
+[Docker Registry Configuration](/docs/how-to/docker-registry-configuration.md) for details.
 
 ### `GCP_SA_KEY`
 
-**Description**: Full JSON content of the GCP service account key. Used for authenticating to Google Artifact Registry (GAR) when pulling EnvGene Docker images. Required only when [`DOCKER_CLOUD_REGISTRY_PROVIDER`](#docker_cloud_registry_provider) is set to `GCP`.
+**Description**: Full JSON content of the GCP service account key. Used for authenticating to Google Artifact Registry
+(GAR) when pulling EnvGene Docker images. Required only when
+[`DOCKER_CLOUD_REGISTRY_PROVIDER`](#docker_cloud_registry_provider) is set to `GCP`.
 
 **Default Value**: None
 
@@ -204,7 +226,9 @@ CALCULATOR_CLI_JAVA_OPTIONS="-Djava.util.concurrent.ForkJoinPool.common.parallel
 
 **Example**: `{"type":"service_account","project_id":"...",...}`
 
-**Note**: Store as a secret (GitHub Actions Secrets) or masked variable. Never commit to the repository. Use a service account with at least `Artifact Registry Reader` role. See [Docker Registry Configuration](/docs/how-to/docker-registry-configuration.md) for details.
+**Note**: Store as a secret (GitHub Actions Secrets) or masked variable. Never commit to the repository. Use a service
+account with at least `Artifact Registry Reader` role. See [Docker Registry
+Configuration](/docs/how-to/docker-registry-configuration.md) for details.
 
 ### `VAULT_ADDR`
 
@@ -309,7 +333,8 @@ The same as [`DOCKER_REGISTRY` in instance repository](#docker_registry-in-insta
 
 **Description**: Specifies the Docker registry where the `qubership-cloud-passport-cli` image is located.
 
-Set by the GSF installer during Discovery repository initialization. For on-premises deployments, set this to the internal registry.
+Set by the GSF installer during Discovery repository initialization. For on-premises deployments, set this to the
+internal registry.
 
 **Default Value**: `ghcr.io`
 
@@ -329,11 +354,13 @@ Set by the GSF installer during Discovery repository initialization. For on-prem
 
 ### `K8S_HOST`
 
-**Description**: Kubernetes API server URL used to connect to the cluster when no kubeconfig file is present in the Discovery repository.
+**Description**: Kubernetes API server URL used to connect to the cluster when no kubeconfig file is present in the
+Discovery repository.
 
 The Discovery pipeline resolves the host in the following order of precedence:
 
-1. Per-environment variable: `K8S_HOST_<env_name>` (where `<env_name>` is derived from `ENV_NAME` — e.g., for `ocp-01/platform` the variable name is `K8S_HOST_ocp-01_platform`)
+1. Per-environment variable: `K8S_HOST_<env_name>` (where `<env_name>` is derived from `ENV_NAME` — e.g., for
+   `ocp-01/platform` the variable name is `K8S_HOST_ocp-01_platform`)
 2. Generic fallback: `K8S_HOST`
 
 If neither is set and no kubeconfig file is found in the repository, the pipeline fails.
@@ -346,7 +373,8 @@ If neither is set and no kubeconfig file is found in the repository, the pipelin
 
 ### `K8S_TOKEN`
 
-**Description**: Kubernetes API bearer token used to authenticate with the cluster when no kubeconfig file is present in the Discovery repository.
+**Description**: Kubernetes API bearer token used to authenticate with the cluster when no kubeconfig file is present in
+the Discovery repository.
 
 Resolved with the same per-environment precedence as [`K8S_HOST`](#k8s_host):
 
@@ -363,7 +391,8 @@ Store as a **masked** CI/CD variable to prevent the token from appearing in job 
 
 ### `SECRET_KEY` (in discovery repository)
 
-**Description**: Fernet key used by the `cloud_passport_cli` to encrypt credential values in the generated Cloud Passport.
+**Description**: Fernet key used by the `cloud_passport_cli` to encrypt credential values in the generated Cloud
+Passport.
 
 Resolved with per-environment precedence:
 

--- a/docs/envgene-repository-variables.md
+++ b/docs/envgene-repository-variables.md
@@ -298,7 +298,7 @@ identifier is not `default_store`, set the prefixed variant `<id>_AWS_SECRET_ACC
 
 ### `SSL_CERTIFICATES_BUNDLE`
 
-**Description**: Base64-encoded PEM CA certificate or bundle that EnvGene installs into the runner trust store during
+**Description**: base64-encoded PEM CA certificate or bundle that EnvGene installs into the runner trust store during
 the Instance EnvGene pipeline, so later steps trust internal services and artifact repositories that use private or
 self-signed certificate authorities. See
 [System certificate configuration](/docs/features/system-certificate.md).

--- a/docs/envgene-repository-variables.md
+++ b/docs/envgene-repository-variables.md
@@ -22,6 +22,7 @@
     - [`GOOGLE_APPLICATION_CREDENTIALS`](#google_application_credentials)
     - [`AWS_ACCESS_KEY_ID`](#aws_access_key_id)
     - [`AWS_SECRET_ACCESS_KEY`](#aws_secret_access_key)
+    - [`SSL_CERTIFICATES_BUNDLE`](#ssl_certificates_bundle)
   - [Template EnvGene Repository](#template-envgene-repository)
     - [`ENV_TEMPLATE_TEST`](#env_template_test)
     - [`ENVGENE_LOG_LEVEL` (in template repository)](#envgene_log_level-in-template-repository)
@@ -270,6 +271,17 @@ identifier is not `default_store`, set the prefixed variant `<id>_AWS_SECRET_ACC
 **Default Value**: None
 
 **Mandatory**: Yes, if any external Credential references an AWS Secrets Manager Secret Store
+
+### `SSL_CERTIFICATES_BUNDLE`
+
+**Description**: Base64-encoded PEM CA certificate or bundle that EnvGene installs into the runner trust store during
+the Instance EnvGene pipeline, so later steps trust internal services and artifact repositories that use private or
+self-signed certificate authorities. See
+[System certificate configuration](/docs/features/system-certificate.md).
+
+**Default Value**: None
+
+**Mandatory**: No
 
 ## Template EnvGene Repository
 

--- a/docs/features/system-certificate.md
+++ b/docs/features/system-certificate.md
@@ -3,6 +3,7 @@
 - [System certificate configuration](#system-certificate-configuration)
   - [Problem statement](#problem-statement)
   - [Approach](#approach)
+    - [Certificate sources](#certificate-sources)
     - [Certificate management process](#certificate-management-process)
     - [Supported certificate types](#supported-certificate-types)
   - [Technical implementation](#technical-implementation)
@@ -12,73 +13,75 @@ For step-by-step instructions on placing, obtaining, and verifying certificates,
 
 ## Problem statement
 
-When deploying environments in enterprise settings, teams face several certificate-related challenges:
+When deploying environments in enterprise settings, teams face certificate-related challenges.
+Internal services and artifact repositories are often exposed over TLS with self-signed certificates
+or private certificate authorities that the runner does not trust by default. Installing these
+certificates on build agents by hand is error-prone, updates require manual intervention, and
+different environments can require different certificates.
 
-1. Secure communication barriers:
-   1. Internal services use self-signed certificates that are not trusted by default.
-   2. Artifact repositories are exposed over TLS with private certificate authorities.
-
-2. Manual certificate management:
-   1. Installing certificates on build agents by hand is error-prone.
-   2. Certificate updates require manual intervention.
-   3. Different environments may require different certificates.
-
-Goals:
+The system certificate mechanism has these goals:
 
 1. Provide a consistent way to manage certificates across all environments.
-2. Automate certificate installation during pipeline execution.
-3. Eliminate manual certificate management on build agents.
+2. Install certificates automatically during pipeline execution.
+3. Remove the need to manage certificates on build agents by hand.
 
 ## Approach
 
-EnvGene provides a built-in mechanism for managing system certificates through a dedicated directory in the
-environment instance repository. Certificates placed in this directory are automatically loaded and added to the
-runner trust store during pipeline execution.
+EnvGene provides a built-in mechanism for managing system certificates during pipeline execution.
+EnvGene reads certificates from a CI/CD variable and from a directory in the environment instance
+repository, then adds them to the trust store before the other pipeline steps run.
+
+### Certificate sources
+
+EnvGene reads certificates from the sources below.
+
+| Source                    | Kind              | Value format                                | Location                                               |
+|---------------------------|-------------------|---------------------------------------------|--------------------------------------------------------|
+| `SSL_CERTIFICATES_BUNDLE` | CI/CD variable    | Base64-encoded PEM CA certificate or bundle | Pipeline CI/CD variable                                |
+| `configuration/certs/`    | Repository folder | One or more PEM certificate files           | `configuration/certs/` at the instance repository root |
+| Default certificate       | Runner image file | PEM certificate                             | `/default_cert.pem`, built into the runner image       |
+
+EnvGene applies `SSL_CERTIFICATES_BUNDLE` and `configuration/certs/` independently and adds every
+certificate they hold to the trust store. If `SSL_CERTIFICATES_BUNDLE` is not set and
+`configuration/certs/` contains no files, EnvGene falls back to the default certificate built into
+the runner image, when one is present. When no source provides a certificate, EnvGene installs
+nothing and the pipeline continues.
 
 ### Certificate management process
 
-The feature handles certificates placed in the `configuration/certs/` directory of your environment instance
-repository. During pipeline execution:
-
-1. EnvGene checks for certificate files in the `configuration/certs/` directory.
-2. Each certificate is added to the runner operating system trust store.
-3. The system trust store is rebuilt so later pipeline steps use the updated certificates.
+During pipeline execution, EnvGene reads the configured sources, installs the certificates it finds,
+and rebuilds the trust store so that the other pipeline steps use it.
 
 ```mermaid
 flowchart TD
-    A[Place certificates in configuration/certs/] --> B[Pipeline execution begins]
-    B --> C[Certificate detection]
-    C --> D[Certificates copied to the OS trust anchors]
-    D --> E[System trust store rebuilt]
-    E --> F[Later pipeline steps use the updated trust store]
+    A[Job starts] --> B{SSL_CERTIFICATES_BUNDLE set?}
+    B -->|Yes| C[Decode base64 and install the bundle]
+    B -->|No| D[Skip the CI/CD variable]
+    C --> E{configuration/certs/ has files?}
+    D --> E
+    E -->|Yes| F[Install each certificate file]
+    E -->|No| G{Bundle set or certs found?}
+    F --> G
+    G -->|No| H[Install the default certificate, if present]
+    G -->|Yes| J[The other pipeline steps use the trust store]
+    H --> J
 ```
 
-> [!NOTE]
-> If `configuration/certs/` is absent or empty, EnvGene applies a default certificate baked into the runner image,
-> when one is present. Otherwise the step is a no-op and no certificate is installed.
+> [!IMPORTANT]
+> `SSL_CERTIFICATES_BUNDLE` must hold base64-encoded PEM content. If the value is not valid base64,
+> the job fails with an explicit error.
 
 ### Supported certificate types
 
-The trust-store mechanism processes CA certificates in PEM format:
-
-- **CA certificates** (`.crt`, `.pem`): root or intermediate certificates used to validate server certificates.
-
-A single file may contain a full chain of concatenated PEM certificates. For how to assemble a chain file, see
+EnvGene processes CA certificates in PEM format: root or intermediate certificates (`.crt`, `.pem`)
+used to validate server certificates. A single file may contain a full chain of concatenated PEM
+certificates. For how to assemble a chain file, see
 [Build a certificate chain file](/docs/how-to/configure-system-certificates.md#build-a-certificate-chain-file).
 
 ## Technical implementation
 
-Under the hood, EnvGene runs a certificate handling script that:
+EnvGene runs a certificate handling script. For each certificate the script:
 
-1. Detects the operating system of the runner.
-2. Copies each certificate to the OS trust anchor directory:
-   - Debian, Ubuntu, and Alpine: `/usr/local/share/ca-certificates/`
-   - CentOS and Red Hat: `/etc/pki/ca-trust/source/anchors/`
-3. Rebuilds the trust store with the command for the detected OS:
-   - Debian and Ubuntu: `update-ca-certificates --fresh`
-   - Alpine: `update-ca-certificates`
-   - CentOS and Red Hat: `update-ca-trust`
-4. Makes the refreshed trust store available to tools and libraries used by later pipeline steps.
-
-Each source file keeps its own base name at the destination, with a `.crt` extension, so multiple certificate
-files do not overwrite each other.
+1. Copies the certificate to `/usr/local/share/ca-certificates/` under a `<basename>.crt` filename,
+   so multiple certificate files do not overwrite each other.
+2. Rebuilds the trust store with `update-ca-certificates`.

--- a/docs/features/system-certificate.md
+++ b/docs/features/system-certificate.md
@@ -37,7 +37,7 @@ EnvGene reads certificates from the sources below.
 
 | Source                    | Kind              | Value format                                | Location                                               |
 |---------------------------|-------------------|---------------------------------------------|--------------------------------------------------------|
-| `SSL_CERTIFICATES_BUNDLE` | CI/CD variable    | Base64-encoded PEM CA certificate or bundle | Pipeline CI/CD variable                                |
+| `SSL_CERTIFICATES_BUNDLE` | CI/CD variable    | base64-encoded PEM CA certificate or bundle | Pipeline CI/CD variable                                |
 | `configuration/certs/`    | Repository folder | One or more PEM certificate files           | `configuration/certs/` at the instance repository root |
 | Default certificate       | Runner image file | PEM certificate                             | `/default_cert.pem`, built into the runner image       |
 

--- a/docs/how-to/configure-system-certificates.md
+++ b/docs/how-to/configure-system-certificates.md
@@ -52,7 +52,7 @@ To keep certificate files out of the repository, store the base64-encoded PEM bu
 before the other steps run.
 
 1. Verify the PEM bundle with the steps in [Verify a certificate](#verify-a-certificate).
-2. Base64-encode the file as a single line:
+2. base64-encode the file as a single line:
 
    ```bash
    base64 -w 0 ca-bundle.pem

--- a/docs/how-to/configure-system-certificates.md
+++ b/docs/how-to/configure-system-certificates.md
@@ -9,6 +9,7 @@ For background on the mechanism, see [System certificate configuration](/docs/fe
 - [Configure system certificates](#configure-system-certificates)
   - [Prerequisites](#prerequisites)
   - [Steps](#steps)
+  - [Use a CI/CD variable instead of committed files](#use-a-cicd-variable-instead-of-committed-files)
   - [Obtain the required certificates](#obtain-the-required-certificates)
     - [Retrieve server certificates with OpenSSL](#retrieve-server-certificates-with-openssl)
     - [Extract individual certificates from a chain](#extract-individual-certificates-from-a-chain)
@@ -21,7 +22,6 @@ For background on the mechanism, see [System certificate configuration](/docs/fe
   - [Usage examples](#usage-examples)
     - [Secure artifact repositories](#secure-artifact-repositories)
     - [Internal services with self-signed certificates](#internal-services-with-self-signed-certificates)
-  - [Troubleshooting](#troubleshooting)
 
 ## Prerequisites
 
@@ -44,6 +44,32 @@ For background on the mechanism, see [System certificate configuration](/docs/fe
    extension.
 3. Commit and push the changes to your repository.
 4. Run the pipeline. EnvGene loads the certificates and rebuilds the runner trust store before the other steps run.
+
+## Use a CI/CD variable instead of committed files
+
+To keep certificate files out of the repository, store the base64-encoded PEM bundle in the
+`SSL_CERTIFICATES_BUNDLE` CI/CD variable. EnvGene decodes the value and installs it into the runner trust store
+before the other steps run.
+
+1. Verify the PEM bundle with the steps in [Verify a certificate](#verify-a-certificate).
+2. Base64-encode the file as a single line:
+
+   ```bash
+   base64 -w 0 ca-bundle.pem
+   ```
+
+   On macOS, use `base64 -i ca-bundle.pem | tr -d '\n'`.
+
+3. Create a CI/CD variable named `SSL_CERTIFICATES_BUNDLE` with the encoded string as its value. Mask the
+   variable when your CI/CD platform allows it.
+4. Run the pipeline.
+
+> [!IMPORTANT]
+> The value must be valid base64 of PEM content. If decoding fails, the job stops with an explicit error.
+
+`SSL_CERTIFICATES_BUNDLE` and `configuration/certs/` can be used together. EnvGene installs certificates from
+both sources. For a bundle that exceeds your CI/CD platform's variable size limit, use `configuration/certs/`
+instead. See [Certificate sources](/docs/features/system-certificate.md#certificate-sources).
 
 ## Obtain the required certificates
 
@@ -205,14 +231,3 @@ curl --cacert "$CERT" -sSf "https://$HOST:$PORT" -o /dev/null && echo "curl OK"
    ```
 
 3. Commit and push. The next pipeline run adds the certificate to the trust store.
-
-## Troubleshooting
-
-| Symptom                    | Check                                                       |
-|----------------------------|-------------------------------------------------------------|
-| Certificate not recognized | PEM encoding, `.crt` or `.pem` extension, correct directory |
-| Connection failures        | Certificate not expired, chain complete                     |
-| Pipeline failures          | Pipeline logs show certificate loading errors               |
-
-To check expiry and chain completeness, rerun the commands in [Verify a certificate](#verify-a-certificate)
-against the target host from the runner.


### PR DESCRIPTION
## Summary

Refine the system certificate documentation and close a variable-reference gap.

- Remove `REQUESTS_CA_BUNDLE` from the system-certificate feature doc and how-to (internal variable, not user-facing).
- Refactor the feature doc for accuracy against `scripts/utils/handle_certs.sh`: correct the default-certificate
  fallback condition (fires when `SSL_CERTIFICATES_BUNDLE` is unset **and** `configuration/certs/` has no files),
  align the flow diagram with the presence-based `certs_applied` logic, unify trust-store terminology, and flatten
  the problem statement.
- Drop the low-value Troubleshooting section from the how-to (it restated requirements already covered by the
  Sources, Verify, and base64 callout content).
- Document `SSL_CERTIFICATES_BUNDLE` in `docs/envgene-repository-variables.md` (Instance EnvGene Repository).

## Issue

No tracked issue. Documentation-accuracy follow-up on the system-certificate feature.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`docs`

## Implementation Notes

Claims were verified against `scripts/utils/handle_certs.sh`. Known accepted doc-vs-code divergence: the script still
sets `REQUESTS_CA_BUNDLE`, intentionally omitted from the docs per product decision.

## Tests / Evidence

Docs-only. Verified: no em/en dashes or semicolons in modified prose, prose wrapped at 120, ToC and cross-links
resolve, and every factual claim cross-checked against the certificate handling script. Two independent author-critic
review rounds on the feature doc.

## Additional Notes

Follow-up candidate: remove `REQUESTS_CA_BUNDLE` from `handle_certs.sh` to fully close the doc-vs-code gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)