### PR TITLE
feat: Add use_committed_sd to enter No-SD Mode when a run has no incoming SD

### DIFF
--- a/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/repository/implementation/FileDataRepositoryImpl.java
+++ b/build_effective_set_generator/effective-set-generator/src/main/java/org/qubership/cloud/devops/cli/repository/implementation/FileDataRepositoryImpl.java
@@ -395,19 +395,20 @@ public class FileDataRepositoryImpl implements FileDataRepository {
     }
 
     private void loadApplicationListData(Map<String, List<String>> nsWithAppsFromSD, Set<String> appsToProcess) {
-        String deployPlanPath = sharedData.getDeployPlanPath()
-                .orElseThrow(() -> new IllegalArgumentException("--deploy-plan-path is required"));
-        List<DeployPlanEntityDTO> entities = fileDataConverter.parseInputFile(
-                new TypeReference<List<DeployPlanEntityDTO>>() {
-                }, new File(deployPlanPath));
-        if (CollectionUtils.isEmpty(entities)) {
-            throw new FileParseException("Deploy plan at " + deployPlanPath + " must be a non-empty YAML list");
-        }
-        List<SBApplicationDTO> applications = entities.stream()
-                .map(entity -> getSbApplicationDTOFromDeployPlan(nsWithAppsFromSD, appsToProcess, entity))
-                .collect(Collectors.toList());
+        Optional<String> deployPlanPath = sharedData.getDeployPlanPath();
+        if (deployPlanPath.isPresent()) {
+            List<DeployPlanEntityDTO> entities = fileDataConverter.parseInputFile(
+                    new TypeReference<List<DeployPlanEntityDTO>>() {
+                    }, new File(deployPlanPath.get()));
+            if (CollectionUtils.isEmpty(entities)) {
+                throw new FileParseException("Deploy plan at " + deployPlanPath + " must be a non-empty YAML list");
+            }
+            List<SBApplicationDTO> applications = entities.stream()
+                    .map(entity -> getSbApplicationDTOFromDeployPlan(nsWithAppsFromSD, appsToProcess, entity))
+                    .collect(Collectors.toList());
 
-        inputData.setSolutionBomDTO(Optional.ofNullable(SolutionBomDTO.builder().applications(applications).build()));
+            inputData.setSolutionBomDTO(Optional.ofNullable(SolutionBomDTO.builder().applications(applications).build()));
+        }
     }
 
     private SBApplicationDTO getSbApplicationDTOFromDeployPlan(Map<String, List<String>> nsWithAppsFromSD, Set<String> appsToProcess, DeployPlanEntityDTO entity) {

--- a/modules/envgene/envgenehelper/effective_set_helper.py
+++ b/modules/envgene/envgenehelper/effective_set_helper.py
@@ -1,8 +1,10 @@
 from enum import Enum
 from os import getenv
+from pathlib import Path
 
 from envgenehelper import get_envgene_config_yaml, calculate_merge_mode, MergeType, logger, get_sd_dir, SD_FILE_NAME, \
     get_sd_dir_by_env_cluster_name, getenv_with_error
+from envgenehelper.deploy_plan_adapter import EnvgeneDeployPlan
 from .models import PipelineType
 
 
@@ -26,6 +28,19 @@ class GenerationMode(Enum):
 class PartialMergeMode(Enum):
     FORWARD = "forward"
     REVERSE = "reverse"
+
+
+def is_committed_sd_enabled() -> bool:
+    return get_envgene_config_yaml().get("use_committed_sd", True)
+
+
+def get_deployment_plan_path() -> Path | None:
+    sd_input = bool(getenv("SD_DATA") or getenv("SD_VERSION"))
+    application_versions = getenv("APPLICATION_VERSIONS")
+    if not sd_input and not application_versions and not is_committed_sd_enabled():
+        logger.info("No-SD Mode: no incoming SD/application_versions and use_committed_sd=false — skipping committed DP")
+        return None
+    return EnvgeneDeployPlan.path()
 
 
 def resolve_partial_merge_mode():

--- a/modules/envgene/envgenehelper/test_effective_set_helper.py
+++ b/modules/envgene/envgenehelper/test_effective_set_helper.py
@@ -1,0 +1,11 @@
+import pytest
+from unittest.mock import patch
+
+from envgenehelper.effective_set_helper import get_deployment_plan_path
+
+@pytest.mark.unit
+def test_returns_none_when_committed_sd_disabled(monkeypatch):
+    monkeypatch.setattr("envgenehelper.effective_set_helper.getenv", lambda key: None,)
+    monkeypatch.setattr("envgenehelper.effective_set_helper.get_envgene_config_yaml", lambda: {"use_committed_sd": False},)
+
+    assert get_deployment_plan_path() is None

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -58,6 +58,16 @@
         "local"
       ]
     },
+    "use_committed_sd": {
+      "type": "boolean",
+      "title": "Use Committed Full SD",
+      "description": "When false and no incoming SD is provided, EnvGene enters No-SD Mode: only topology and pipeline contexts are generated, registry requests are skipped. When true (default) or omitted, the committed Full SD is used and Full Generation runs as normal.",
+      "default": true,
+      "examples": [
+        true,
+        false
+      ]
+    },
     "sbom_retention": {
       "type": "object",
       "title": "SBOM Retention Configuration",

--- a/scripts/effective_set/effective_set_entrypoint.py
+++ b/scripts/effective_set/effective_set_entrypoint.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from envgenehelper.business_helper import get_current_env_dir_from_env_vars
 from envgenehelper.deploy_plan_adapter import DeployPlanEntity, EnvgeneDeployPlan, GenerationType
 from envgenehelper.effective_set_helper import ES_DIR_NAME, ES_MAPPING_FILE, ESGenerationContext, GenerationMode, \
-    PartialMergeMode
+    PartialMergeMode, get_deployment_plan_path
 from envgenehelper.file_helper import delete_dir, delete_dir_if_exists, deleteFileIfExists
 from envgenehelper.logger import logger
 from envgenehelper.sd_helper import get_sd_dir, DELTA_SD_FILE_NAME
@@ -161,7 +161,7 @@ def _restore_saved_dirs(tmp_root, saved):
 
 
 def _build_cli_cmd(effective_set_dir, full_env_name):
-    dp_path = EnvgeneDeployPlan.path()
+    dp_path = get_deployment_plan_path()
     cmd = [
         getenv("EFFECTIVE_SET_CLI_PATH", "/module/scripts/utils/run_effective_set_cli.sh"),
         f"--env-id={full_env_name}",
@@ -169,7 +169,7 @@ def _build_cli_cmd(effective_set_dir, full_env_name):
         f"--output={effective_set_dir}",
     ]
 
-    if dp_path.is_file():
+    if dp_path is not None and dp_path.is_file():
         cmd.extend([
             "--registries=${CI_PROJECT_DIR}/configuration/registry.yml",
             "--sboms-path=$CI_PROJECT_DIR/sboms",

--- a/scripts/pipeline/orchestrator.py
+++ b/scripts/pipeline/orchestrator.py
@@ -10,7 +10,7 @@ from os import getenv
 from envgenehelper import logger, decrypt_all_cred_files_for_env, encrypt_all_cred_files_for_env, validate_creds, validate_parameters
 from envgenehelper.business_helper import is_inventory_generation_needed
 from envgenehelper.plugin_engine import PluginEngine
-from envgenehelper.effective_set_helper import GenerationMode, resolve_partial_merge_mode
+from envgenehelper.effective_set_helper import GenerationMode, resolve_partial_merge_mode, is_committed_sd_enabled
 from envgenehelper.sd_helper import SD_FILE_NAME, DELTA_SD_FILE_NAME, get_sd_dir
 
 from bg_manage.bg_manage import run_bg_manage
@@ -146,6 +146,9 @@ class MigrateSdToDeployPlanStep(PipelineStep):
             raise ValueError("SD_VERSION and SD_DATA cannot be provided at the same time")
         if sd_version or sd_data:
             return True
+        if not is_committed_sd_enabled():
+            logger.info("Skipping SD migration: use_committed_sd=false, no incoming SD (No-SD Mode)")
+            return False
         needs_migration = get_sd_dir().joinpath(SD_FILE_NAME).is_file() and not EnvgeneDeployPlan.path().is_file()
         if needs_migration:
             logger.info("No new SD input this run, but sd.yaml exists without a deploy-plan.yml yet - "


### PR DESCRIPTION
# Pull Request

## Summary

when use_committed_sd is set to false in configuration/config.xml file, and there is no sd_data passed as input, run the effective set with no_sd mode and sbom generation also needs to be skipped.

## Issue

https://github.com/Netcracker/qubership-envgene/issues/1631

## Breaking Change?

- [ ] Yes
- [X] No

## Scope / Project



## Implementation Notes

skipped migrate_sd_to_deploy_plan  step when use_committed_sd is false
sbom genration is skipped
effective_set is called without deploymentplan
modified effective set cli to handle no sd case

## Tests / Evidence

- Tests added 
- 
## Additional Notes

Include any extra information, such as:

