### PR TITLE
docs: add deployment architecture doc and noCmdbVersion attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ After the pipeline finishes, the Environment configuration will be generated and
 
 - [**EnvGene Objects**](/docs/envgene-objects.md) - What are EnvGene objects and how they work
 - [**Configuration Files**](/docs/envgene-configs.md) - File formats and config options
+- [**Deployment Architecture**](/docs/deployment-architecture.md) - CMDB and No-CMDB (v1, v2) toolset architectures and how to determine them
 - [**Pipeline Configuration**](/docs/envgene-pipelines.md) - How EnvGene pipelines work
 - [**Repository Variables**](/docs/envgene-repository-variables.md) - CI/CD variables used in EnvGene repositories
 - [**Template Macros**](/docs/template-macros.md) - How to use EnvGene macros in templates

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@
 
 - [**EnvGene Objects**](/docs/envgene-objects.md) - What are EnvGene objects and how they work
 - [**Configuration Files**](/docs/envgene-configs.md) - File formats and config options
+- [**Deployment Architecture**](/docs/deployment-architecture.md) - CMDB and No-CMDB (v1, v2) toolset architectures and how to determine them
 - [**Pipeline Configuration**](/docs/envgene-pipelines.md) - How EnvGene pipelines work
 - [**Repository Variables**](/docs/envgene-repository-variables.md) - CI/CD variables used in EnvGene repositories
 - [**Template Macros**](/docs/template-macros.md) - How to use EnvGene macros in templates

--- a/docs/deployment-architecture.md
+++ b/docs/deployment-architecture.md
@@ -1,0 +1,41 @@
+# Deployment architecture
+
+- [Deployment architecture](#deployment-architecture)
+  - [CMDB](#cmdb)
+  - [No-CMDB v1](#no-cmdb-v1)
+  - [No-CMDB v2](#no-cmdb-v2)
+  - [Determine an environment's architecture](#determine-an-environments-architecture)
+
+The DevOps toolset, including EnvGene, operates each environment in one of three deployment
+architectures. An architecture defines where EnvGene delivers its output and which component deploys
+it. Each environment declares its architecture in its
+[Environment Inventory](/docs/envgene-configs.md#env_definitionyml). Environments in the same
+repository can use different architectures.
+
+## CMDB
+
+EnvGene imports the Environment Instance into an external CMDB, integrated through
+`inventory.deployer`. The deployment tooling reads the parameters from the CMDB.
+
+## No-CMDB v1
+
+EnvGene generates the [Effective Set](/docs/features/effective-set-generation.md) and commits it to
+the Instance repository. The deployment tooling reads the Effective Set from the Instance repository.
+
+## No-CMDB v2
+
+EnvGene generates the Effective Set and splits it by context. It commits the topology and pipeline
+contexts to the Instance repository and pushes the other contexts to a separate DCL repository. In
+this architecture, the EnvGene pipeline also generates the Argo CD configuration and synchronises it
+with the cluster.
+
+## Determine an environment's architecture
+
+`inventory.noCmdbVersion` takes precedence over `inventory.deployer`. When `noCmdbVersion` is set, it
+selects the architecture on its own. When it is absent, `deployer` decides.
+
+| Architecture | Condition                                   |
+|--------------|---------------------------------------------|
+| No-CMDB v1   | `noCmdbVersion` is `v1`, or neither is set  |
+| No-CMDB v2   | `noCmdbVersion` is `v2`                     |
+| CMDB         | `noCmdbVersion` is unset, `deployer` is set |

--- a/docs/envgene-configs.md
+++ b/docs/envgene-configs.md
@@ -72,6 +72,13 @@ inventory:
   # Used by EnvGene extensions (not part of EnvGene Core) that implement integration with various CMDB systems
   # Should be listed in configuration/deployer.yml
   deployer: string
+  # Optional. Default value - `v1`
+  # Version of the No-CMDB deployment architecture: `v1` or `v2`
+  # Set manually by users. NOT processed by EnvGene Core
+  # Read by DevOps toolset components to determine how the Environment is delivered and deployed
+  # When set, takes precedence over `deployer`
+  # See Deployment architecture: /docs/deployment-architecture.md
+  noCmdbVersion: string
   # Optional
   # Environment description
   # This attribute's value is available for template rendering via the `current_env.description` variable

--- a/schemas/env-definition.schema.json
+++ b/schemas/env-definition.schema.json
@@ -54,6 +54,20 @@
             "deployer2"
           ]
         },
+        "noCmdbVersion": {
+          "type": "string",
+          "title": "No-CMDB Architecture Version",
+          "description": "Version of the No-CMDB deployment architecture. Set manually by users. NOT processed by EnvGene Core. Read by DevOps toolset components to determine how the environment is deployed. When set, it takes precedence over 'deployer'. Default 'v1'.",
+          "enum": [
+            "v1",
+            "v2"
+          ],
+          "default": "v1",
+          "examples": [
+            "v1",
+            "v2"
+          ]
+        },
         "cloudPassport": {
           "type": "string",
           "title": "Cloud Passport",


### PR DESCRIPTION
## Problem

DevOps toolset components (orchestration pipelines, Colly, Argo CD) need to know which deployment
architecture an environment uses - CMDB, No-CMDB v1, or No-CMDB v2. This was not recorded anywhere
in EnvGene.

## Decision

Add `inventory.noCmdbVersion` (`v1` | `v2`, default `v1`) to the Environment Definition. It is set
manually by users and read by external toolset components. EnvGene Core does not process it. CMDB is
signalled by `inventory.deployer`. When both are present, `noCmdbVersion` takes precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)