### PR TITLE
fix: allow additional top-level attributes in AppDef and RegDef schemas

### DIFF
--- a/python/envgene/envgenehelper/schemas/regdef-v2.schema.json
+++ b/python/envgene/envgenehelper/schemas/regdef-v2.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "version": {
       "type": "string",

--- a/python/envgene/envgenehelper/schemas/regdef.schema.json
+++ b/python/envgene/envgenehelper/schemas/regdef.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "name": {
       "type": "string"

--- a/schemas/appdef.schema.json
+++ b/schemas/appdef.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "name": {
       "type": "string"

--- a/schemas/regdef-v2.schema.json
+++ b/schemas/regdef-v2.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "version": {
       "type": "string",

--- a/schemas/regdef.schema.json
+++ b/schemas/regdef.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "name": {
       "type": "string"


### PR DESCRIPTION
## Summary

Relax the root object of the AppDef and RegDef JSON schemas from `additionalProperties: false` to
`additionalProperties: true`. AppDef and RegDef objects legitimately carry extra top-level fields that
the schemas do not model (for example `baseline` and `config`), and the strict root hard-failed schema
validation on otherwise valid objects.

Only the root object is relaxed. `required` fields and the declared types of known fields are
unchanged, and nested config blocks (`mavenConfig`, `dockerConfig`, `AuthConfig`, `gcpOIDC`, and the
rest) keep `additionalProperties: false`, so typo-catching there is preserved. The effect is that only
unknown optional top-level fields become permissible.

## Issue

Closes #1663

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`schemas` - AppDef and RegDef JSON schemas.

## Implementation Notes

Five files changed, one line each (the root `schemas/` copies and the in-package copies under
`python/envgene/envgenehelper/schemas/` are kept identical):

- `schemas/appdef.schema.json`
- `schemas/regdef.schema.json` (RegDef V1)
- `schemas/regdef-v2.schema.json` (RegDef V2)
- `python/envgene/envgenehelper/schemas/regdef.schema.json`
- `python/envgene/envgenehelper/schemas/regdef-v2.schema.json`

Validation touchpoints: `validate_appregdefs` in `scripts/build_env/render_config_env.py` for AppDef,
and `validate_regdef_or_fail` in `python/envgene/envgenehelper/config_helper.py` for RegDef V1 and V2.

## Tests / Evidence

JSON validity confirmed for all five files. Scope verified: root relaxed to `true`, nested config
blocks still `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)