### PR TITLE
docs: cloud passport single-file auto-association fallback

### DIFF
--- a/docs/features/cloud-passport-processing.md
+++ b/docs/features/cloud-passport-processing.md
@@ -153,8 +153,13 @@ The system looks for a default passport in the env's parent (cluster) directory,
 
 1. `cloud-passport/<cluster-name>.{yml|yaml}` (a file named after the cluster directory)
 2. `cloud-passport/passport.{yml|yaml}` (a generic fallback name)
+3. The single passport file in `cloud-passport/`. When the directory holds exactly one passport file
+   (any `<name>.{yml|yaml}` that is not a `-creds` file), that file is used regardless of its name.
 
-If neither file exists, no passport is applied and generation continues without one.
+If `cloud-passport/` holds more than one passport file and none matched by name in steps 1 and 2,
+generation fails with an ambiguous-passport error that lists the candidates. Set
+`inventory.cloudPassport` to select one. If `cloud-passport/` holds no passport file, no passport is
+applied and generation continues without one.
 
 ### Resolution summary
 
@@ -163,8 +168,12 @@ Decision flow:
 1. `cloudPassport` set → bottom-up search for `<name>.{yml|yaml}`. Resolved on exactly one match.
    Generation fails on zero matches (not-found) or multiple matches (duplicate).
 2. `cloudPassport` absent → try `cloud-passport/<cluster-name>.{yml|yaml}`, then
-   `cloud-passport/passport.{yml|yaml}`. Generation fails on multiple matches (duplicate).
-3. Nothing matched → no passport applied, generation continues.
+   `cloud-passport/passport.{yml|yaml}`, then the single passport file in `cloud-passport/` when
+   exactly one exists.
+3. `cloudPassport` absent and `cloud-passport/` holds more than one unmatched passport file →
+   generation fails with an ambiguous-passport error listing the candidates.
+4. `cloudPassport` absent and `cloud-passport/` holds no passport file → no passport applied,
+   generation continues.
 
 ## Merge into Cloud
 


### PR DESCRIPTION
## Summary

Documents a relaxation of Cloud Passport auto-association in the Cloud Passport processing feature
doc (Resolution section):

- Single-file fallback: when `cloudPassport` is not set and neither the cluster-name nor the
  `passport` default matches, the sole passport file in `cloud-passport/` is used regardless of its
  name.
- Ambiguous-passport error when more than one unmatched passport file is present.
- Scopes the "no passport file, generation continues" outcome to the `cloudPassport`-absent path.
  Explicit `cloudPassport` with a missing file still fails with a not-found error.

## Issue

Implementation is tracked in #1666. This PR is documentation only.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`docs` - `docs/features/cloud-passport-processing.md` (Resolution / Auto-association / Resolution
summary).

## Implementation Notes

Doc-ahead-of-code: this PR states the target resolver contract. The code change lands under #1666.
Wording was checked against the current resolver behavior and against the real instance-repository
corpus (133 `cloud-passport/` directories, 750 environments): the single-file fallback fires only
where resolution is currently a silent skip, and the change is backward compatible.

## Tests / Evidence

Documentation-only change. Verified prose against the AGENTS.md house rules (line length, no
semicolons, no em/en dashes).

## Additional Notes

Part of a two-part effort. The Cloud Passport discovery writer change (emit `passport.yml` /
`passport-creds.yml`) is a separate branch and PR.
