### PR TITLE
chore: add popoveugene as code owner of AI config and schemas

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,3 +28,13 @@ CONTRIBUTING.md @popoveugene
 LICENSE @popoveugene
 
 SECURITY.md @popoveugene
+
+#
+# AI agent configuration
+#
+
+/.claude/ @popoveugene
+
+AGENTS.md @popoveugene
+
+CLAUDE.md @popoveugene

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,6 +19,8 @@
 
 /test_data/ @popoveugene
 
+/schemas/ @popoveugene
+
 README.md @popoveugene
 
 CODEOWNERS @popoveugene


### PR DESCRIPTION
## What

Adds `@popoveugene` as code owner of the AI coding-assistant configuration and the schemas, matching the
existing per-path ownership already in `CODEOWNERS` (`/docs/`, `/test_data/`, `README.md`).

New entries:

- `/.claude/` - committed Claude Code skills and agent config
- `AGENTS.md` - AI agent rules for the repository
- `CLAUDE.md` - bare-filename pattern, matches a `CLAUDE.md` in any directory, following the same
  convention as the existing `README.md` entry
- `/schemas/` - the repository JSON schemas

## Note

`CLAUDE.md` currently has no instance on `main`, so its entry is a forward-looking pattern that takes
effect wherever a `CLAUDE.md` is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)