### PR TITLE
docs: instance pipeline parameters - PIPELINE_TYPE applicability, new deploy parameters, deprecations

### DIFF
--- a/docs/envgene-objects.md
+++ b/docs/envgene-objects.md
@@ -1342,7 +1342,7 @@ satellites:
 
 #### BG Domain
 
-The BG Domain object defines the Blue-Green Domain structure and namespace mappings for environments that use BGD support. This object is used for alias resolution in the [`NS_BUILD_FILTER`](/docs/instance-pipeline-parameters.md#ns_build_filter) parameter and BGD lifecycle management.
+The BG Domain object defines the Blue-Green Domain structure and namespace mappings for environments that use BGD support. This object is used for alias resolution in the `NS_BUILD_FILTER` parameter and BGD lifecycle management.
 
 The standalone BG Domain object represents a BG Domain that is not part of a
 [Composite Structure](#composite-structure).

--- a/docs/envgene-pipelines.md
+++ b/docs/envgene-pipelines.md
@@ -53,7 +53,7 @@ flowchart TB
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
 4. **bg_manage**
-   - **Condition**: Runs if [`BG_MANAGE: true`](/docs/instance-pipeline-parameters.md#bg_manage).
+   - **Condition**: Runs if `BG_MANAGE: true`.
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
 5. **env_inventory_generation**:
@@ -75,7 +75,7 @@ flowchart TB
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
 7. **process_sd**:
-   - **Condition**: Runs if ( [`SD_SOURCE_TYPE: json`](/docs/instance-pipeline-parameters.md#sd_source_type) AND [`SD_DATA`](/docs/instance-pipeline-parameters.md#sd_data) is provided ) OR ( [`SD_SOURCE_TYPE: artifact`](/docs/instance-pipeline-parameters.md#sd_source_type) AND [`SD_VERSION`](/docs/instance-pipeline-parameters.md#sd_version) is provided )
+   - **Condition**: Runs if ( `SD_SOURCE_TYPE: json` AND [`SD_DATA`](/docs/instance-pipeline-parameters.md#sd_data) is provided ) OR ( `SD_SOURCE_TYPE: artifact` AND [`SD_VERSION`](/docs/instance-pipeline-parameters.md#sd_version) is provided )
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
 8. **env_build**:

--- a/docs/features/app-reg-defs.md
+++ b/docs/features/app-reg-defs.md
@@ -115,11 +115,11 @@ definition override applies later and replaces the whole definition, including a
 An External Job is an extension point: a job, not implemented by EnvGene, produces AppDef and RegDef YAML files in its
 job artifact. The following Instance pipeline parameters configure it:
 
-- [`APP_REG_DEFS_JOB`](/docs/instance-pipeline-parameters.md#app_reg_defs_job) - specifies the job that produces the
+- `APP_REG_DEFS_JOB` - specifies the job that produces the
   artifact
-- [`APP_DEFS_PATH`](/docs/instance-pipeline-parameters.md#app_defs_path) - specifies the path within the artifact where
+- `APP_DEFS_PATH` - specifies the path within the artifact where
   Application Definitions are located
-- [`REG_DEFS_PATH`](/docs/instance-pipeline-parameters.md#reg_defs_path) - specifies the path within the artifact where
+- `REG_DEFS_PATH` - specifies the path within the artifact where
   Registry Definitions are located
 
 The pipeline copies the files from the artifact into the per-environment folders before Solution Descriptor processing

--- a/docs/features/blue-green-deployment.md
+++ b/docs/features/blue-green-deployment.md
@@ -123,8 +123,8 @@ The criteria for running the job and its order relative to other jobs are descri
 ## BG-related Instance pipeline parameters
 
 - [`ENV_NAMES`](/docs/instance-pipeline-parameters.md#env_names)
-- [`BG_MANAGE`](/docs/instance-pipeline-parameters.md#bg_manage)
-- [`BG_STATE`](/docs/instance-pipeline-parameters.md#bg_state)
+- `BG_MANAGE`
+- `BG_STATE`
 - [`GH_ADDITIONAL_PARAMS`](/docs/instance-pipeline-parameters.md#gh_additional_params)
 
 The parameter set differs between the GitLab and GitHub pipelines.

--- a/docs/how-to/blue-green-deployment-deploy-operations.md
+++ b/docs/how-to/blue-green-deployment-deploy-operations.md
@@ -62,8 +62,8 @@ origin and peer swap the `active` and `candidate`
    - Persist it in the Environment Inventory: `envTemplate.bgNsArtifacts.origin` or
      `envTemplate.bgNsArtifacts.peer`.
    - Set the pipeline parameter
-     [`ENV_TEMPLATE_VERSION_ORIGIN`](/docs/instance-pipeline-parameters.md#env_template_version_origin)
-     or [`ENV_TEMPLATE_VERSION_PEER`](/docs/instance-pipeline-parameters.md#env_template_version_peer)
+     `ENV_TEMPLATE_VERSION_ORIGIN`
+     or `ENV_TEMPLATE_VERSION_PEER`
      for this run. EnvGene writes the value into the matching `bgNsArtifacts` field.
 
    When neither is set, the namespace renders from the common `envTemplate.artifact`.
@@ -145,19 +145,19 @@ be selected by exclusion: `! @peer,@origin,@controller`.
 
 ## Pipeline parameters by deploy operation
 
-| Parameter                                                                                          | Used for                                                        |
-|----------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
-| [`ENV_NAMES`](/docs/instance-pipeline-parameters.md#env_names)                                     | Target environment, `<cluster-name>/<environment-name>`         |
-| [`ENV_BUILDER`](/docs/instance-pipeline-parameters.md#env_builder)                                 | Enable Environment Instance generation                          |
-| [`NS_BUILD_FILTER`](/docs/instance-pipeline-parameters.md#ns_build_filter)                         | Limit which namespaces are regenerated                          |
-| [`ENV_TEMPLATE_VERSION`](/docs/instance-pipeline-parameters.md#env_template_version)               | Override `envTemplate.artifact` for this run                    |
-| [`ENV_TEMPLATE_VERSION_ORIGIN`](/docs/instance-pipeline-parameters.md#env_template_version_origin) | Override `envTemplate.bgNsArtifacts.origin`                     |
-| [`ENV_TEMPLATE_VERSION_PEER`](/docs/instance-pipeline-parameters.md#env_template_version_peer)     | Override `envTemplate.bgNsArtifacts.peer`                       |
-| [`GENERATE_EFFECTIVE_SET`](/docs/instance-pipeline-parameters.md#generate_effective_set)           | Produce the Effective Set                                       |
-| [`CMDB_IMPORT`](/docs/instance-pipeline-parameters.md#cmdb_import)                                 | Export the Environment Instance to a CMDB                       |
-| [`BG_MANAGE`](/docs/instance-pipeline-parameters.md#bg_manage)                                     | Run BG lifecycle job (not used for ordinary deploy-only runs)   |
-| [`BG_STATE`](/docs/instance-pipeline-parameters.md#bg_state)                                       | Target BG states for `bg_manage`                                |
-| [`GH_ADDITIONAL_PARAMS`](/docs/instance-pipeline-parameters.md#gh_additional_params)               | Carrier for parameters without dedicated GitHub workflow inputs |
+| Parameter                                                                                | Used for                                                        |
+|------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| [`ENV_NAMES`](/docs/instance-pipeline-parameters.md#env_names)                           | Target environment, `<cluster-name>/<environment-name>`         |
+| [`ENV_BUILDER`](/docs/instance-pipeline-parameters.md#env_builder)                       | Enable Environment Instance generation                          |
+| `NS_BUILD_FILTER`                                                                        | Limit which namespaces are regenerated                          |
+| [`ENV_TEMPLATE_VERSION`](/docs/instance-pipeline-parameters.md#env_template_version)     | Override `envTemplate.artifact` for this run                    |
+| `ENV_TEMPLATE_VERSION_ORIGIN`                                                            | Override `envTemplate.bgNsArtifacts.origin`                     |
+| `ENV_TEMPLATE_VERSION_PEER`                                                              | Override `envTemplate.bgNsArtifacts.peer`                       |
+| [`GENERATE_EFFECTIVE_SET`](/docs/instance-pipeline-parameters.md#generate_effective_set) | Produce the Effective Set                                       |
+| [`CMDB_IMPORT`](/docs/instance-pipeline-parameters.md#cmdb_import)                       | Export the Environment Instance to a CMDB                       |
+| `BG_MANAGE`                                                                              | Run BG lifecycle job (not used for ordinary deploy-only runs)   |
+| `BG_STATE`                                                                               | Target BG states for `bg_manage`                                |
+| [`GH_ADDITIONAL_PARAMS`](/docs/instance-pipeline-parameters.md#gh_additional_params)     | Carrier for parameters without dedicated GitHub workflow inputs |
 
 For BG lifecycle operations (warmup, promote, commit), see
 [Blue-Green Deployment Use Cases](/docs/use-cases/blue-green-deployment.md).

--- a/docs/instance-pipeline-parameters.md
+++ b/docs/instance-pipeline-parameters.md
@@ -4,73 +4,209 @@
 - [Instance Pipeline Parameters](#instance-pipeline-parameters)
   - [Parameters](#parameters)
     - [`ENV_NAMES`](#env_names)
+    - [`CLUSTER_NAME`](#cluster_name)
+    - [`ENVIRONMENT_NAME`](#environment_name)
+    - [`PIPELINE_TYPE`](#pipeline_type)
+    - [`OPERATION_TYPE`](#operation_type)
+    - [`BGD_OPERATION`](#bgd_operation)
+    - [`BG_NS_TARGET`](#bg_ns_target)
+    - [`NAMESPACE_NAMES`](#namespace_names)
+    - [`DELTA_DEPLOY`](#delta_deploy)
     - [`ENV_BUILDER`](#env_builder)
     - [`GET_PASSPORT`](#get_passport)
     - [`CMDB_IMPORT`](#cmdb_import)
+    - [`CMDB_IMPORT_APP_DEFS`](#cmdb_import_app_defs)
+    - [`CMDB_IMPORT_REG_DEFS`](#cmdb_import_reg_defs)
     - [`DEPLOYMENT_TICKET_ID`](#deployment_ticket_id)
     - [`ENV_TEMPLATE_VERSION`](#env_template_version)
     - [`ENV_TEMPLATE_VERSION_UPDATE_MODE`](#env_template_version_update_mode)
-    - [`ENV_SPECIFIC_PARAMS`](#env_specific_params)
     - [`ENV_INVENTORY_CONTENT`](#env_inventory_content)
     - [`GENERATE_EFFECTIVE_SET`](#generate_effective_set)
     - [`EFFECTIVE_SET_CONFIG`](#effective_set_config)
     - [`CUSTOM_PARAMS`](#custom_params)
-    - [`APP_REG_DEFS_JOB`](#app_reg_defs_job)
-    - [`APP_DEFS_PATH`](#app_defs_path)
-    - [`REG_DEFS_PATH`](#reg_defs_path)
-    - [`SD_SOURCE_TYPE`](#sd_source_type)
+    - [`APPLICATION_VERSIONS`](#application_versions)
+    - [`DEPLOY_POSTFIXES_FILTER`](#deploy_postfixes_filter)
+    - [`NAMESPACE_NAMES_FILTER`](#namespace_names_filter)
+    - [`COMPONENT_NAMES_FILTER`](#component_names_filter)
+    - [`WAVE_NAMES_FILTER`](#wave_names_filter)
     - [`SD_VERSION`](#sd_version)
     - [`SD_DATA`](#sd_data)
     - [`SD_REPO_MERGE_MODE`](#sd_repo_merge_mode)
-    - [`NS_BUILD_FILTER`](#ns_build_filter)
     - [`DEPLOYMENT_SESSION_ID`](#deployment_session_id)
     - [`CRED_ROTATION_PAYLOAD`](#cred_rotation_payload)
       - [Affected Parameters and Troubleshooting](#affected-parameters-and-troubleshooting)
     - [`CRED_ROTATION_FORCE`](#cred_rotation_force)
     - [`GH_ADDITIONAL_PARAMS`](#gh_additional_params)
-    - [`BG_MANAGE`](#bg_manage)
-    - [`BG_STATE`](#bg_state)
   - [Deprecated Parameters](#deprecated-parameters)
     - [`SD_DELTA`](#sd_delta)
-  - [Archived Parameters](#archived-parameters)
+    - [`ENV_SPECIFIC_PARAMS`](#env_specific_params)
+    - [`ENV_TEMPLATE_NAME`](#env_template_name)
+    - [`ENV_INVENTORY_INIT`](#env_inventory_init)
+  - [Parameter value formats](#parameter-value-formats)
   - [Multiple Values Support](#multiple-values-support)
 
-The following are the launch parameters for the instance repository pipeline. These parameters influence, the execution of specific jobs within the pipeline.
+The following are the launch parameters for the instance repository pipeline. These parameters influence, the execution
+of specific jobs within the pipeline.
 
 All parameters are of the string data type
 
 > [!IMPORTANT]
-> EnvGene recognises and processes **only the parameters listed on this page**. Passing any variable not documented here has no effect on pipeline behaviour and will be silently ignored. Do not rely on undocumented parameters — they are not part of the EnvGene contract and may be removed or conflict with future additions without notice.
+> EnvGene recognises and processes **only the parameters listed on this page**. Passing any variable not documented here
+> has no effect on pipeline behaviour and will be silently ignored.
+>
+> Do not rely on undocumented parameters - they are not part of the EnvGene contract and may be removed or conflict with
+> future additions without notice.
 
 ## Parameters
 
 ### `ENV_NAMES`
 
-**Description**: Specifies the environment(s) for which processing will be triggered. Uses the `<cluster-name>/<env-name>` notation.
+**Description**: Specifies the environment(s) for which processing will be triggered. Uses the
+`<cluster-name>/<env-name>` notation. When `CLUSTER_NAME` and `ENVIRONMENT_NAME` are both provided, they are
+used for single-environment processing and take precedence over `ENV_NAMES`, which is ignored.
 
-If specifying more than one environment, separate them as described in [Multiple Values Support](#multiple-values-support).
-For multiple environments, each environment will initiate its own independent pipeline flow, using the same set of pipeline parameters for all.
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
+
+If specifying more than one environment, separate them as described in [Multiple Values
+Support](#multiple-values-support).
+For multiple environments, each environment will initiate its own independent pipeline flow, using the same set of
+pipeline parameters for all.
 
 **Default Value**: None
 
-**Mandatory**: Yes
+**Mandatory**: No. Required when `CLUSTER_NAME` and `ENVIRONMENT_NAME` are not provided.
 
 **Example**:
 
 - Single environment: `ocp-01/platform`
-- Multiple environments:
-  - `k8s-01/env-1\nk8s-01/env2`
-  - `k8s-01/env-1;k8s-01/env2`
-  - `k8s-01/env-1,k8s-01/env2`
-  - `k8s-01/env-1 k8s-01/env2`
+- Multiple environments: `k8s-01/env-1,k8s-01/env2`
 
-> [!IMPORTANT]
-> It is recommended to run a **maximum of 100 environments in parallel** within a single pipeline execution.
-> Each environment generates multiple jobs in the child pipeline configuration. Processing more than 100 environments in a single run may exceed GitLab pipeline configuration and job limits. If more environments need to be processed, split them across multiple pipeline runs.
+### `CLUSTER_NAME`
+
+**Description**: Cluster identifier of the target environment. Together with `ENVIRONMENT_NAME` it forms an `ENV_NAMES`
+entry in `<cluster-name>/<env-name>` notation. When `CLUSTER_NAME` and `ENVIRONMENT_NAME` are both provided, they are
+used for single-environment processing and take precedence over `ENV_NAMES`, which is ignored.
+
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
+
+**Default Value**: None
+
+**Mandatory**: No. Required when `ENV_NAMES` is not provided.
+
+**Example**: `k8s-01`
+
+### `ENVIRONMENT_NAME`
+
+**Description**: Environment identifier of the target environment. Together with `CLUSTER_NAME` it forms an `ENV_NAMES`
+entry in `<cluster-name>/<env-name>` notation. When `CLUSTER_NAME` and `ENVIRONMENT_NAME` are both provided, they are
+used for single-environment processing and take precedence over `ENV_NAMES`, which is ignored.
+
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
+
+**Default Value**: None
+
+**Mandatory**: No. Required when `ENV_NAMES` is not provided.
+
+**Example**: `env-1`
+
+### `PIPELINE_TYPE`
+
+**Description**: Selects the pipeline execution model.
+
+**Allowed values**: `GITLAB_DEPLOY`, `LEGACY`
+
+**Default Value**: `LEGACY`
+
+**Mandatory**: No
+
+**Example**: `GITLAB_DEPLOY`
+
+### `OPERATION_TYPE`
+
+**Description**: The pipeline operation type for the environment.
+
+Processed at both pipeline types. The `CLEAN` and `BGD` values are processed only at `PIPELINE_TYPE: GITLAB_DEPLOY`.
+
+**Allowed values**:
+
+- `DEPLOY`
+  Deploys the applications.
+- `CLEAN`
+  Cleans the namespaces.
+- `BGD`
+  Runs a Blue-Green operation selected by `BGD_OPERATION`.
+
+**Default Value**: `DEPLOY`
+
+**Mandatory**: No
+
+**Example**: `CLEAN`
+
+### `BGD_OPERATION`
+
+**Description**: Selects the Blue-Green operation. Processed only when `OPERATION_TYPE: BGD`.
+
+Processed only at `PIPELINE_TYPE: GITLAB_DEPLOY`.
+
+**Allowed values**: `warmup`, `commit`, `promote`, `rollback`, `init-domain`
+
+**Default Value**: None
+
+**Mandatory**: No
+
+**Example**: `warmup`
+
+### `BG_NS_TARGET`
+
+**Description**: Selects the physical Blue-Green side, origin or peer, for the operation. Used to resolve which
+`bgNsArtifacts` template version is updated with `ENV_TEMPLATE_VERSION`, and to resolve the origin or peer namespace of
+a `deployPostfix` in the namespace map.
+
+Processed only at `PIPELINE_TYPE: GITLAB_DEPLOY`.
+
+**Allowed values**: `ORIGIN`, `PEER`
+
+**Default Value**: None
+
+**Mandatory**: No
+
+**Example**: `ORIGIN`
+
+### `NAMESPACE_NAMES`
+
+**Description**: The namespaces to clean. Active only when `OPERATION_TYPE: CLEAN`, ignored under others (a warning is
+logged). An empty value means all namespaces of the environment.
+
+Processed only at `PIPELINE_TYPE: GITLAB_DEPLOY`.
+
+If specifying more than one, separate them as described in [Multiple Values Support](#multiple-values-support).
+
+**Default Value**: None. Empty means all namespaces of the environment.
+
+**Mandatory**: No
+
+**Example**: `env-1-bss,env-1-oss`
+
+### `DELTA_DEPLOY`
+
+**Description**: Controls the delta deployment mode.
+
+Processed only at `PIPELINE_TYPE: GITLAB_DEPLOY`.
+
+**Allowed values**: `NONE`, `DIFF`, `DIFF_AND_HEAL`
+
+**Default Value**: `NONE`
+
+**Mandatory**: No
+
+**Example**: `DIFF`
 
 ### `ENV_BUILDER`
 
 **Description**: Feature flag. Valid values ​​are `true` or `false`.
+
+Effective only at `PIPELINE_TYPE: LEGACY`. At `PIPELINE_TYPE: GITLAB_DEPLOY` the Environment Instance is generated
+based on the operation, regardless of this flag.
 
 If `true`:
 In the pipeline, Environment Instance generation job is executed. Environment Instance generation will be launched.
@@ -85,6 +221,8 @@ In the pipeline, Environment Instance generation job is executed. Environment In
 
 **Description**: Feature flag. Valid values ​​are `true` or `false`.
 
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
+
 If `true`:
   In the pipeline, Cloud Passport discovery job is executed. Cloud Passport discovery will be launched.
 
@@ -98,10 +236,40 @@ If `true`:
 
 **Description**: Feature flag. Valid values are `true` or `false`.
 
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
+
 If `true`:
   The Environment Instance will be exported to an external CMDB system.
 
-This parameter serves as a configuration for an extension point. Integration with a specific CMDB is not implemented in EnvGene.
+**Default Value**: `false`
+
+**Mandatory**: No
+
+**Example**: `true`
+
+### `CMDB_IMPORT_APP_DEFS`
+
+**Description**: Feature flag. Valid values are `true` or `false`.
+
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
+
+If `true`:
+  Application Definitions are exported to an external CMDB system.
+
+**Default Value**: `false`
+
+**Mandatory**: No
+
+**Example**: `true`
+
+### `CMDB_IMPORT_REG_DEFS`
+
+**Description**: Feature flag. Valid values are `true` or `false`.
+
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
+
+If `true`:
+  Registry Definitions are exported to an external CMDB system.
 
 **Default Value**: `false`
 
@@ -113,6 +281,8 @@ This parameter serves as a configuration for an extension point. Integration wit
 
 **Description**: Used as commit message prefix for commit into Instance repository.
 
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
+
 **Default Value**: None
 
 **Mandatory**: No
@@ -121,7 +291,11 @@ This parameter serves as a configuration for an extension point. Integration wit
 
 ### `ENV_TEMPLATE_VERSION`
 
-**Description**: If provided system update Environment Template version in the Environment Inventory. System overrides `envTemplate.templateArtifact.artifact.version` OR `envTemplate.artifact` at `/environments/<ENV_NAME>/Inventory/env_definition.yml`
+**Description**: If provided system update Environment Template version in the Environment Inventory. System overrides
+`envTemplate.templateArtifact.artifact.version` OR `envTemplate.artifact` at
+`/environments/<ENV_NAME>/Inventory/env_definition.yml`
+
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
 
 **Default Value**: None
 
@@ -133,19 +307,25 @@ This parameter serves as a configuration for an extension point. Integration wit
 
 **Description**: Controls how ENV_TEMPLATE_VERSION is applied during the pipeline run.
 
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
+
 **Allowed values**:
 
 - `PERSISTENT` (default)
-  Applies the standard behavior: the pipeline updates the template version in Environment Inventory by modifying `envTemplate.artifact` (or `envTemplate.templateArtifact.artifact.version`) in `env_definition.yml`.
+  Applies the standard behavior: the pipeline updates the template version in Environment Inventory by modifying
+`envTemplate.artifact` (or `envTemplate.templateArtifact.artifact.version`) in `env_definition.yml`.
 
 - `TEMPORARY`
-  Applies `ENV_TEMPLATE_VERSION` **only for the current pipeline execution** and **does not** update `envTemplate.artifact` (or `envTemplate.templateArtifact.artifact.version`) in `env_definition.yml`.
-  The pipeline updates `generatedVersions.generateEnvironmentLatestVersion` in `env_definition.yml` to reflect the template artifact version that was actually applied in this run, for example:
+  Applies `ENV_TEMPLATE_VERSION` **only for the current pipeline execution** and **does not** update
+`envTemplate.artifact` (or `envTemplate.templateArtifact.artifact.version`) in `env_definition.yml`.
+  The pipeline updates `generatedVersions.generateEnvironmentLatestVersion` in `env_definition.yml` to reflect the
+template artifact version that was actually applied in this run, for example:
 
   ```yaml
   # env_definition.yml
   generatedVersions:
     generateEnvironmentLatestVersion: "template-project:feature-diis1125-20251125.045717-2"
+  ```
 
 **Default Value**: `PERSISTENT`
 
@@ -153,71 +333,18 @@ This parameter serves as a configuration for an extension point. Integration wit
 
 **Example**: `PERSISTENT`
 
-### `ENV_TEMPLATE_VERSION_ORIGIN`
-
-**Description**: If provided, system updates the Blue-Green origin template artifact version in the Environment Inventory. System overrides `envTemplate.bgNsArtifacts.origin` at `/environments/<ENV_NAME>/Inventory/env_definition.yml`
-
-This parameter is used for environments that use Blue-Green Deployment support. The value should be in `application:version` notation.
-
-**Default Value**: None
-
-**Mandatory**: No
-
-**Example**: `project-env-template:v1.2.3`
-
-### `ENV_TEMPLATE_VERSION_PEER`
-
-**Description**: If provided, system updates the Blue-Green peer template artifact version in the Environment Inventory. System overrides `envTemplate.bgNsArtifacts.peer` at `/environments/<ENV_NAME>/Inventory/env_definition.yml`
-
-This parameter is used for environments that use Blue-Green Deployment support. The value should be in `application:version` notation.
-
-**Default Value**: None
-
-**Mandatory**: No
-
-**Example**: `project-env-template:v1.2.3`
-
-### `ENV_INVENTORY_INIT`
+### `ENV_INVENTORY_CONTENT`
 
 **Description**:
 
-If `true`:
-  In the pipeline, a job for generating the environment inventory is executed. The new Environment Inventory will be generated in the path `/environments/<ENV_NAME>/Inventory/env_definition.yml`. See details in [Environment Inventory Generation](/docs/features/env-inventory-generation.md)
+Provides the Environment Inventory and related artifacts to be created or updated.
+It allows external systems to manage `env_definition.yml` and additional files paramsets, credentials, resource profiles
+without manual changes in the Instance repository.
 
-**Note:** This parameter is deprecated and will be removed in future releases. Use `ENV_INVENTORY_CONTENT` instead.
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
 
-**Default Value**: `false`
-
-**Mandatory**: No
-
-**Example**: `true`
-
-### `ENV_TEMPLATE_NAME`
-
-**Description**: Specifies the template artifact value within the generated Environment Inventory. This is used together with `ENV_INVENTORY_INIT`.
-
-**Note:** This parameter is deprecated and will be removed in future releases. Use `ENV_INVENTORY_CONTENT` instead.
-
-System overrides `envTemplate.name` at `/environments/<ENV_NAME>/Inventory/env_definition.yml`:
-
-```yaml
-envTemplate:
-    name: <ENV_TEMPLATE_NAME>
-    ...
-...
-```
-
-**Default Value**: None
-
-**Mandatory**: No
-
-**Example**: `env-template:v1.2.3`
-
-### `ENV_SPECIFIC_PARAMS`
-
-**Description**: Specifies Environment Inventory and env-specific parameters. This is can used together with `ENV_INVENTORY_INIT`. **JSON in string** format. See details in [Environment Inventory Generation](/docs/features/env-inventory-generation.md)
-
-**Note:** This parameter is deprecated and will be removed in future releases. Use `ENV_INVENTORY_CONTENT` instead.
+See details in Environment Inventory Generation feature documentation [Environment Inventory
+Generation](/docs/features/env-inventory-generation.md)
 
 **Default Value**: None
 
@@ -225,32 +352,91 @@ envTemplate:
 
 **Example**:
 
-```text
-'{"clusterParams":{"clusterEndpoint":"<value>","clusterToken":"<value>"},"additionalTemplateVariables":{"<key>":"<value>"},"cloudName":"<value>","envSpecificParamsets":{"<ns-template-name>":["paramsetA"],"cloud":["paramsetB"]},"paramsets":{"paramsetA":{"version":"<paramset-version>","name":"<paramset-name>","parameters":{"<key>":"<value>"},"applications":[{"appName":"<app-name>","parameters":{"<key>":"<value>"}}]},"paramsetB":{"version":"<paramset-version>","name":"<paramset-name>","parameters":{"<key>":"<value>"},"applications":[]}},"credentials":{"credX":{"type":"<credential-type>","data":{"username":"<value>","password":"<value>"}},"credY":{"type":"<credential-type>","data":{"secret":"<value>"}}}}'
-```
-
-### `ENV_INVENTORY_CONTENT`
-
-**Description**:
-
-Provides the Environment Inventory and related artifacts to be created or updated.
-It allows external systems to manage `env_definition.yml` and additional files paramsets, credentials, resource profiles without manual changes in the Instance repository.
-
-See details in Environment Inventory Generation feature documentation [Environment Inventory Generation](/docs/features/env-inventory-generation.md)
-
-**Default Value**: None
-
-**Mandatory**: No
-
-**Example in string format**:
-
-```json
-"{\"envDefinition\":{\"action\":\"create_or_replace\",\"content\":{\"inventory\":{\"environmentName\":\"env-1\",\"tenantName\":\"Applications\",\"cloudName\":\"cluster-1\",\"description\":\"Fullsample\",\"owners\":\"Qubershipteam\",\"config\":{\"updateRPOverrideNameWithEnvName\":false,\"updateCredIdsWithEnvName\":true}},\"envTemplate\":{\"name\":\"composite-prod\",\"artifact\":\"project-env-template:master_20231024-080204\",\"additionalTemplateVariables\":{\"ci\":{\"CI_PARAM_1\":\"ci-param-val-1\",\"CI_PARAM_2\":\"ci-param-val-2\"},\"e2eParameters\":{\"E2E_PARAM_1\":\"e2e-param-val-1\",\"E2E_PARAM_2\":\"e2e-param-val-2\"}},\"sharedTemplateVariables\":[\"prod-template-variables\",\"sample-cloud-template-variables\"],\"envSpecificParamsets\":{\"bss\":[\"env-specific-bss\"]},\"envSpecificTechnicalParamsets\":{\"bss\":[\"env-specific-tech\"]},\"envSpecificE2EParamsets\":{\"cloud\":[\"cloud-level-params\"]},\"sharedMasterCredentialFiles\":[\"prod-integration-creds\"],\"envSpecificResourceProfiles\":{\"cloud\":[\"cloud-specific-profile\"]}}}},\"paramsets\":[{\"action\":\"create_or_replace\",\"place\":\"env\",\"content\":{\"version\":\"<paramset-version>\",\"name\":\"env-specific-bss\",\"parameters\":{\"key\":\"value\"},\"applications\":[]}}],\"credentials\":[{\"action\":\"create_or_replace\",\"place\":\"site\",\"content\":{\"prod-integration-creds\":{\"type\":\"<credential-type>\",\"data\":{\"username\":\"<value>\",\"password\":\"<value>\"}}}}],\"resourceProfiles\":[{\"action\":\"create_or_replace\",\"place\":\"cluster\",\"content\":{\"name\":\"cloud-specific-profile\",\"baseline\":\"dev\",\"description\":\"\",\"applications\":[{\"name\":\"core\",\"version\":\"release-20241103.225817\",\"sd\":\"\",\"services\":[{\"name\":\"operator\",\"parameters\":[{\"name\":\"GATEWAY_MEMORY_LIMIT\",\"value\":\"96Mi\"},{\"name\":\"GATEWAY_CPU_REQUEST\",\"value\":\"50m\"}]}]}],\"version\":0}}]}"
+```yaml
+envDefinition:
+  action: create_or_replace
+  content:
+    inventory:
+      environmentName: env-1
+      tenantName: Applications
+      cloudName: cluster-1
+      description: Fullsample
+      owners: Qubershipteam
+      config:
+        updateRPOverrideNameWithEnvName: false
+        updateCredIdsWithEnvName: true
+    envTemplate:
+      name: composite-prod
+      artifact: project-env-template:master_20231024-080204
+      additionalTemplateVariables:
+        ci:
+          CI_PARAM_1: ci-param-val-1
+          CI_PARAM_2: ci-param-val-2
+        e2eParameters:
+          E2E_PARAM_1: e2e-param-val-1
+          E2E_PARAM_2: e2e-param-val-2
+      sharedTemplateVariables:
+      - prod-template-variables
+      - sample-cloud-template-variables
+      envSpecificParamsets:
+        bss:
+        - env-specific-bss
+      envSpecificTechnicalParamsets:
+        bss:
+        - env-specific-tech
+      envSpecificE2EParamsets:
+        cloud:
+        - cloud-level-params
+      sharedMasterCredentialFiles:
+      - prod-integration-creds
+      envSpecificResourceProfiles:
+        cloud:
+        - cloud-specific-profile
+paramsets:
+- action: create_or_replace
+  place: env
+  content:
+    version: <paramset-version>
+    name: env-specific-bss
+    parameters:
+      key: value
+    applications: []
+credentials:
+- action: create_or_replace
+  place: site
+  content:
+    prod-integration-creds:
+      type: <credential-type>
+      data:
+        username: <value>
+        password: <value>
+resourceProfiles:
+- action: create_or_replace
+  place: cluster
+  content:
+    name: cloud-specific-profile
+    baseline: dev
+    description: ''
+    applications:
+    - name: core
+      version: release-20241103.225817
+      sd: ''
+      services:
+      - name: operator
+        parameters:
+        - name: GATEWAY_MEMORY_LIMIT
+          value: 96Mi
+        - name: GATEWAY_CPU_REQUEST
+          value: 50m
+    version: 0
 ```
 
 ### `GENERATE_EFFECTIVE_SET`
 
 **Description**: Feature flag. Valid values ​​are `true` or `false`.
+
+Effective only at `PIPELINE_TYPE: LEGACY`. At `PIPELINE_TYPE: GITLAB_DEPLOY` the Effective Set is generated based
+on the operation, regardless of this flag.
 
 If `true`:
   In the pipeline, Effective Set generation job is executed. Effective Parameter set generation will be launched
@@ -263,7 +449,9 @@ If `true`:
 
 ### `EFFECTIVE_SET_CONFIG`
 
-**Description**: Settings for effective set configuration. This is used together with `GENERATE_EFFECTIVE_SET`. **JSON in string** format.
+**Description**: Settings for effective set configuration. This is used together with `GENERATE_EFFECTIVE_SET`.
+
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
 
 ```yaml
 version: <v1.0|v2.0>
@@ -289,7 +477,8 @@ contexts:
 | **contexts.pipeline.consumers[].version** | Mandatory | The version of the [consumer-specific pipeline context component](/docs/features/calculator-cli.md#version-20-pipeline-parameter-context). If used without `contexts.pipeline.consumers[].schema`, the component must be pre-registered in EnvGene.                                                                                                                                                                                                                                                                                                                  | None                                   | `v1.0`                                             |
 | **contexts.pipeline.consumers[].schema**  | Optional  | The content of the consumer-specific pipeline context component JSON schema transformed into a string. It is used to generate a consumer-specific pipeline context for a consumer not registered in EnvGene. EnvGene saves the value as a JSON file with the name `<contexts.pipeline[].name>-<contexts.pipeline[].version>.schema.json` and passes the path to it to the Calculator command-line tool via `--pipeline-consumer-specific-schema-path` attribute. The schema obtained in this way is not saved between pipeline runs and must be passed for each run. | None                                   | [consumer-v1.0.json](/examples/consumer-v1.0.json) |
 
-Registered component JSON schemas are stored in the EnvGene Docker image as JSON files named: `<consumers-name>-<consumer-version>.schema.json`
+Registered component JSON schemas are stored in the EnvGene Docker image as JSON files named:
+`<consumers-name>-<consumer-version>.schema.json`
 
 Consumer-specific pipeline context components registered in EnvGene:
 
@@ -298,132 +487,181 @@ Consumer-specific pipeline context components registered in EnvGene:
 **Example**:
 
 ```yaml
-"{\"version\": \"v2.0\", \"app_chart_validation\": \"false\"}"
+version: v2.0
+app_chart_validation: 'false'
 ```
 
 ### `CUSTOM_PARAMS`
 
-**Description**: Session-scoped parameters injected into the Effective Set during parameter calculation. Custom Params are not persisted across parameter calculation sessions, have the highest priority in the parameter resolution hierarchy, and are treated as sensitive.
+**Description**: Session-scoped parameters injected into the Effective Set during parameter calculation. Custom Params
+are not persisted across parameter calculation sessions, have the highest priority in the parameter resolution
+hierarchy, and are treated as sensitive.
 
-`CUSTOM_PARAMS` is only applied when [`GENERATE_EFFECTIVE_SET`](#generate_effective_set) is `true`. If `GENERATE_EFFECTIVE_SET` is `false`, the `generate_effective_set` job does not run and `CUSTOM_PARAMS` has no effect.
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
 
-EnvGene passes the value unchanged to the Calculator CLI via `--custom-params`. See [Calculator CLI](/docs/features/calculator-cli.md) for how Custom Params are applied to the Effective Set.
+`CUSTOM_PARAMS` is only applied when [`GENERATE_EFFECTIVE_SET`](#generate_effective_set) is `true`. If
+`GENERATE_EFFECTIVE_SET` is `false`, the `generate_effective_set` job does not run and `CUSTOM_PARAMS` has no effect.
 
-**Format**: A string containing a JSON object (JSON-in-string). The JSON object must conform to the [schema](/schemas/custom-params.schema.json).
+EnvGene passes the value unchanged to the Calculator CLI via `--custom-params`. See [Calculator
+CLI](/docs/features/calculator-cli.md) for how Custom Params are applied to the Effective Set.
 
-Two modes are supported. The modes are **mutually exclusive** — a payload that contains both a top-level `deployment`/`runtime` key and a `namespaces` key is rejected with a validation error.
+**Format**: A map conforming to the [schema](/schemas/custom-params.schema.json). See
+[Parameter value formats](#parameter-value-formats).
 
-**Global mode** — parameters applied to every namespace.
+Two modes are supported. The modes are **mutually exclusive** - a payload that contains both a top-level
+`deployment`/`runtime` key and a `namespaces` key is rejected with a validation error.
 
-```json
-{
-  "deployment": {
-    "<key>": "<value>",
-    "...": "..."
-  },
-  "runtime": {
-    "<key>": "<value>",
-    "...": "..."
-  }
-}
+**Global mode** - parameters applied to every namespace.
+
+```yaml
+deployment:
+  <key>: <value>
+  '...': '...'
+runtime:
+  <key>: <value>
+  '...': '...'
 ```
 
-**Namespace-scoped mode** — parameters applied only to specific namespaces. If a namespace listed in the payload does not exist in the environment, the Calculator raises a validation error.
+**Namespace-scoped mode** - parameters applied only to specific namespaces. If a namespace listed in the payload does
+not exist in the environment, the Calculator raises a validation error.
 
-```json
-{
-  "namespaces": {
-    "<namespace-name>": {
-      "deployment": {
-        "<key>": "<value>",
-         "...": "..."
-      },
-      "runtime": {
-        "<key>": "<value>",
-         "...": "..."
-      }
-    }
-  }
-}
+```yaml
+namespaces:
+  <namespace-name>:
+    deployment:
+      <key>: <value>
+      '...': '...'
+    runtime:
+      <key>: <value>
+      '...': '...'
 ```
 
 > [!NOTE]
 >
 > 1. `<value>` can be complex, i.e. a map or a list
 > 2. All keys are optional
-> Passing both a top-level `deployment`/`runtime` key and a `namespaces` key in the same payload causes a validation error. The Calculator will fail before writing any Effective Set output.
+> Passing both a top-level `deployment`/`runtime` key and a `namespaces` key in the same payload causes a validation
+> error. The Calculator will fail before writing any Effective Set output.
 
 **Default Value**: None
 
 **Mandatory**: No
 
-**Example**: `"{\"deployment\":{\"MY_OVERRIDE\":\"value\"}}"`
+**Example**:
 
-### `APP_REG_DEFS_JOB`
+```yaml
+deployment:
+  MY_OVERRIDE: value
+```
 
-**Description**: Specifies the name of the job that is the source of [Application Definition](/docs/envgene-objects.md#application-definition) and [Registry Definitions](/docs/envgene-objects.md#registry-definition).
+### `APPLICATION_VERSIONS`
 
-This job must exist in the EnvGene instance pipeline.
+**Description**: One or more values to be deployed. Used to build the deployment plan and passed to ArgoCD repository
+generation. At `PIPELINE_TYPE: GITLAB_DEPLOY` it replaces `SD_VERSION`. Each value is either a standalone application or
+a Solution
+Descriptor, which is expanded into its applications.
 
-When this parameter is set, the system will:
+Processed only at `PIPELINE_TYPE: GITLAB_DEPLOY`.
 
-1. Download and unpack the `definitions.zip` file from the specified job artifact.
-2. Copy (with overwrite) Application Definitions from the extracted `definitions.zip` from the path specified in [`APP_DEFS_PATH`](#app_defs_path) to the root-level /appdefs folder.
-3. Copy (with overwrite) Registry Definitions from the extracted `definitions.zip` from the path specified in [`REG_DEFS_PATH`](#reg_defs_path) to the root-level /regdefs folder..
+An application value uses one of two notations:
+
+- `<application-name>:<version>`
+  The target namespace is resolved from the application `deployPostfix`.
+- `<namespace-name>:<application-name>:<version>`
+  The target namespace is set explicitly. Used when the application has no `deployPostfix`.
+
+Values may also be provided as a JSON or YAML list of objects:
+
+```yaml
+- version: <application-name>:<version>   # Mandatory
+  deployPostfix: <postfix>                # Optional
+  namespace: <namespace-name>             # Optional
+```
+
+If specifying more than one, separate them as described in [Multiple Values Support](#multiple-values-support).
 
 **Default Value**: None
 
 **Mandatory**: No
 
-**Example Values**:
+**Example**:
 
-- `appdef-generation-job`
+- `solution:0.64.2`
+- `env-1-bss:app-1:1.2.3`
 
-### `APP_DEFS_PATH`
+### `DEPLOY_POSTFIXES_FILTER`
 
-**Description**: Specifies the relative path inside the `definitions.zip` artifact (downloaded from the job specified by `APP_REG_DEFS_JOB`) where Application Definitions are located. The contents from this path will be copied to the root-level /appdefs folder.
+**Description**: Filters the generated deployment plan by `deployPostfix`. Only entries whose `deployPostfix` is
+listed are kept. Prefix a value with `!` to exclude it instead. When empty, no filtering is applied.
 
-**Default Value**: `appdefs`
+Processed only at `PIPELINE_TYPE: GITLAB_DEPLOY`.
 
-**Mandatory**: No
+If specifying more than one, separate them as described in [Multiple Values Support](#multiple-values-support).
 
-**Example Values**: `definitions/applications`
-
-### `REG_DEFS_PATH`
-
-**Description**: Specifies the relative path inside the `definitions.zip` artifact (downloaded from the job specified by `APP_REG_DEFS_JOB`) where Registry Definitions are located. The contents from this path will be copied to the root-level /regdefs folder.
-
-**Default Value**: `regdefs`
+**Default Value**: None
 
 **Mandatory**: No
 
-**Example Values**: `definitions/registries`
+**Example**: `core,bss`
 
-### `SD_SOURCE_TYPE`
+### `NAMESPACE_NAMES_FILTER`
 
-**Description**: Defines the method by which SD is passed in the `SD_DATA` or `SD_VERSION` attributes. Valid values ​​are `artifact` OR `json`.
+**Description**: Filters the generated deployment plan by namespace. Only entries whose namespace is listed are
+kept. Prefix a value with `!` to exclude it instead. When empty, no filtering is applied.
 
-If `artifact`:
-  An SD artifact is expected in `SD_VERSION` in `application:version` notation. The system should download the artifact, transform it into YAML format, and save it to the repository.
+Processed only at `PIPELINE_TYPE: GITLAB_DEPLOY`.
 
-If `json`:
-  SD content is expected in `SD_DATA`. The system should transform it into YAML format, and save it to the repository.
+If specifying more than one, separate them as described in [Multiple Values Support](#multiple-values-support).
 
-See details in [SD processing](/docs/features/sd-processing.md)
-
-**Default Value**: `artifact`
+**Default Value**: None
 
 **Mandatory**: No
 
-**Example**: `artifact`
+**Example**: `env-1-bss,env-1-oss`
+
+### `COMPONENT_NAMES_FILTER`
+
+**Description**: Filters the generated deployment plan by component name, the application name before `:` in the
+version. Only entries whose component is listed are kept. Prefix a value with `!` to exclude it instead. When
+empty, no filtering is applied.
+
+Processed only at `PIPELINE_TYPE: GITLAB_DEPLOY`.
+
+If specifying more than one, separate them as described in [Multiple Values Support](#multiple-values-support).
+
+**Default Value**: None
+
+**Mandatory**: No
+
+**Example**: `MONITORING,postgres`
+
+### `WAVE_NAMES_FILTER`
+
+**Description**: Filters the generated deployment plan by wave number. Only entries whose wave is listed are
+kept. Prefix a value with `!` to exclude it instead. When empty, no filtering is applied.
+
+Processed only at `PIPELINE_TYPE: GITLAB_DEPLOY`.
+
+If specifying more than one, separate them as described in [Multiple Values Support](#multiple-values-support).
+
+**Default Value**: None
+
+**Mandatory**: No
+
+**Example**: `0,1`
 
 ### `SD_VERSION`
 
 **Description**: Specifies one or more SD artifacts in `application:version` notation.
 
-If specifying more than one environment, separate them as described in [Multiple Values Support](#multiple-values-support).
+Processed only at `PIPELINE_TYPE: LEGACY`.
 
-EnvGene downloads and sequentially merges them in the `basic-merge` mode, where subsequent `application:version` takes priority over the previous one. Optionally saves the result to [Delta SD](/docs/features/sd-processing.md#delta-sd), then merges with [Full SD](/docs/features/sd-processing.md#full-sd) using `SD_REPO_MERGE_MODE` merge mode
+If specifying more than one environment, separate them as described in [Multiple Values
+Support](#multiple-values-support).
+
+EnvGene downloads and sequentially merges them in the `basic-merge` mode, where subsequent `application:version` takes
+priority over the previous one. Optionally saves the result to [Delta SD](/docs/features/sd-processing.md#delta-sd),
+then merges with [Full SD](/docs/features/sd-processing.md#full-sd) using `SD_REPO_MERGE_MODE` merge mode
 
 See details in [SD processing](/docs/features/sd-processing.md)
 
@@ -434,21 +672,22 @@ See details in [SD processing](/docs/features/sd-processing.md)
 **Example**:
 
 - Single SD: `MONITORING:0.64.1`
-- Multiple SDs:
-  - `solution-part-1:0.64.2\nsolution-part-2:0.44.1`
-  - `solution-part-1:0.64.2;solution-part-2:0.44.1`
-  - `solution-part-1:0.64.2,solution-part-2:0.44.1`
-  - `solution-part-1:0.64.2 solution-part-2:0.44.1`
+- Multiple SDs: `solution-part-1:0.64.2,solution-part-2:0.44.1`
 
 ### `SD_DATA`
 
 **Description**: Specifies the contents of one or more SD. Can be either a single SD object or a list of SD objects.
 
-If a single SD object is provided, it is processed directly. If a list is provided, EnvGene sequentially merges them in the `basic-merge` mode, where subsequent element takes priority over the previous one. Optionally saves the result to [Delta SD](/docs/features/sd-processing.md#delta-sd), then merges with [Full SD](/docs/features/sd-processing.md#full-sd) using `SD_REPO_MERGE_MODE` merge mode
+Processed only at `PIPELINE_TYPE: LEGACY`.
+
+If a single SD object is provided, it is processed directly. If a list is provided, EnvGene sequentially merges them in
+the `basic-merge` mode, where subsequent element takes priority over the previous one. Optionally saves the result to
+[Delta SD](/docs/features/sd-processing.md#delta-sd), then merges with [Full
+SD](/docs/features/sd-processing.md#full-sd) using `SD_REPO_MERGE_MODE` merge mode
 
 See details in [SD processing](/docs/features/sd-processing.md)
 
-**Format**: A string containing a JSON object (JSON-in-string)
+**Format**: See [Parameter value formats](#parameter-value-formats)
 
 **Default Value**: None
 
@@ -458,25 +697,57 @@ See details in [SD processing](/docs/features/sd-processing.md)
 
 - Single SD (as object):
 
-```text
-'{"version":2.1,"type":"solutionDeploy","deployMode":"composite","applications":[{"version":"MONITORING:0.64.1","deployPostfix":"platform-monitoring"},{"version":"postgres:1.32.6","deployPostfix":"postgresql"}]}'
+```yaml
+version: 2.1
+type: solutionDeploy
+deployMode: composite
+applications:
+- version: MONITORING:0.64.1
+  deployPostfix: platform-monitoring
+- version: postgres:1.32.6
+  deployPostfix: postgresql
 ```
 
 - Single SD (as list with one element):
 
-```text
-'[{"version":2.1,"type":"solutionDeploy","deployMode":"composite","applications":[{"version":"MONITORING:0.64.1","deployPostfix":"platform-monitoring"},{"version":"postgres:1.32.6","deployPostfix":"postgresql"}]}]'
+```yaml
+- version: 2.1
+  type: solutionDeploy
+  deployMode: composite
+  applications:
+  - version: MONITORING:0.64.1
+    deployPostfix: platform-monitoring
+  - version: postgres:1.32.6
+    deployPostfix: postgresql
 ```
 
 - Multiple SD:
 
-```text
-'[{"version":2.1,"type":"solutionDeploy","deployMode":"composite","applications":[{"version":"MONITORING:0.64.1","deployPostfix":"platform-monitoring"},{"version":"postgres:1.32.6","deployPostfix":"postgresql"}]},{"version":2.1,"type":"solutionDeploy","deployMode":"composite","applications":[{"version":"postgres-services:1.32.6","deployPostfix":"postgresql"},{"version":"postgres:1.32.3","deployPostfix":"postgresql-dbaas"}]}]'
+```yaml
+- version: 2.1
+  type: solutionDeploy
+  deployMode: composite
+  applications:
+  - version: MONITORING:0.64.1
+    deployPostfix: platform-monitoring
+  - version: postgres:1.32.6
+    deployPostfix: postgresql
+- version: 2.1
+  type: solutionDeploy
+  deployMode: composite
+  applications:
+  - version: postgres-services:1.32.6
+    deployPostfix: postgresql
+  - version: postgres:1.32.3
+    deployPostfix: postgresql-dbaas
 ```
 
 ### `SD_REPO_MERGE_MODE`
 
-**Description**: Defines SD merge mode between incoming SD and already existed in repository SD. See details in [SD Merge](/docs/features/sd-processing.md#sd-merge)
+**Description**: Defines SD merge mode between incoming SD and already existed in repository SD. See details in [SD
+Merge](/docs/features/sd-processing.md#sd-merge)
+
+Processed only at `PIPELINE_TYPE: LEGACY`.
 
 Available values:
 
@@ -493,24 +764,16 @@ See details in [SD processing](/docs/features/sd-processing.md)
 
 **Example**: `extended-merge`
 
-### `NS_BUILD_FILTER`
-
-**Description**: It allows to generate or update only specific Namespaces without touching the others.
-
-See details in [Namespace Render Filtering](/docs/features/namespace-render-filtering.md)
-
-**Default Value**: None
-
-**Mandatory**: No
-
-**Example**: `${controller}`
-
 ### `DEPLOYMENT_SESSION_ID`
 
 **Description**: Operation identifier in Envgene. Must be a valid [UUID v4](https://www.rfc-editor.org/rfc/rfc4122). This parameter is used in two scenarios:
 
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
+
 1. If this parameter is provided, the resulting pipeline commit will include a [Git trailer](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---trailertokenvalue) in the format: `DEPLOYMENT_SESSION_ID: <value of DEPLOYMENT_SESSION_ID>`.
-2. It will also be part of the deployment context of the Effective Set. The EnvGene passes it to the Calculator command-line tool using the `--extra_params` attribute. In this case it is used together with `GENERATE_EFFECTIVE_SET`.
+2. It will also be part of the deployment context of the Effective Set. The EnvGene passes it to the Calculator
+   command-line tool using the `--extra_params` attribute. In this case it is used together with
+   `GENERATE_EFFECTIVE_SET`.
 
 **Default Value**: None
 
@@ -520,23 +783,23 @@ See details in [Namespace Render Filtering](/docs/features/namespace-render-filt
 
 ### `CRED_ROTATION_PAYLOAD`
 
-**Description**: A parameter used to dynamically update sensitive parameters (those defined via the [cred macro](/docs/template-macros.md#credential-macro-and-credential-reference)). It modifies values across different contexts within a specified namespace and optional application. The value can be provided as plain text or encrypted. **JSON in string** format. See details in [feature description](/docs/features/cred-rotation.md)
+**Description**: A parameter used to dynamically update sensitive parameters (those defined via the [cred
+macro](/docs/template-macros.md#credential-macro-and-credential-reference)). It modifies values across different
+contexts within a specified namespace and optional application. The value can be provided as plain text or encrypted.
+See details in [feature description](/docs/features/cred-rotation.md)
+
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
 
 > [!CAUTION]
 > `CRED_ROTATION_PAYLOAD` cannot be combined with `GET_PASSPORT: true` in one pipeline run.
 
-```json
-{
-  "rotation_items": [
-    {
-      "namespace": "<namespace>",
-      "application": "<application-name>",
-      "context": "enum[`pipeline`,`deployment`, `runtime`]",
-      "parameter_key": "<parameter-key>",
-      "parameter_value": "<new-parameter-value>"
-    }
-  ]
-}
+```yaml
+rotation_items:
+- namespace: <namespace>
+  application: <application-name>
+  context: enum[`pipeline`,`deployment`, `runtime`]
+  parameter_key: <parameter-key>
+  parameter_value: <new-parameter-value>
 ```
 
 | Attribute         | Mandatory | Description                                                                                                                                                                                                                                                                               | Default | Example                             |
@@ -553,61 +816,62 @@ See details in [Namespace Render Filtering](/docs/features/namespace-render-filt
 
 **Example**:
 
-```json
-{
-  "rotation_items": [
-    {
-      "namespace": "env-1-platform-monitoring",
-      "application": "MONITORING",
-      "context": "deployment",
-      "parameter_key": "db_login",
-      "parameter_value": "s3cr3tN3wLogin"
-    },
-    {
-      "namespace": "env-1-platform-monitoring",
-      "application": "MONITORING",
-      "context": "deployment",
-      "parameter_key": "db_password",
-      "parameter_value": "s3cr3tN3wP@ss"
-    },
-    {
-      "namespace": "env-1-platform-monitoring",
-      "context": "deployment",
-      "parameter_key": "db_password",
-      "parameter_value": "s3cr3tN3wP@ss"
-    },
-    {
-      "namespace": "env-1-platform-monitoring",
-      "context": "deployment",
-      "parameter_key": "global.secrets.password",
-      "parameter_value": "user"
-    },
-    {
-      "namespace": "env-1-platform-monitoring",
-      "context": "deployment",
-      "parameter_key": "a.b.c.d",
-      "parameter_value": "somevalue"
-    }
-  ]
-}
+```yaml
+rotation_items:
+- namespace: env-1-platform-monitoring
+  application: MONITORING
+  context: deployment
+  parameter_key: db_login
+  parameter_value: s3cr3tN3wLogin
+- namespace: env-1-platform-monitoring
+  application: MONITORING
+  context: deployment
+  parameter_key: db_password
+  parameter_value: s3cr3tN3wP@ss
+- namespace: env-1-platform-monitoring
+  context: deployment
+  parameter_key: db_password
+  parameter_value: s3cr3tN3wP@ss
+- namespace: env-1-platform-monitoring
+  context: deployment
+  parameter_key: global.secrets.password
+  parameter_value: user
+- namespace: env-1-platform-monitoring
+  context: deployment
+  parameter_key: a.b.c.d
+  parameter_value: somevalue
 ```
 
 #### Affected Parameters and Troubleshooting
 
-When rotating sensitive parameters, EnvGene checks if the Credential is [shared](/docs/features/cred-rotation.md#affected-parameters) (used by multiple parameters or Environments). If shared Credentials are detected and force mode is not enabled, the credential_rotation job will fail to prevent accidental mass updates.
+When rotating sensitive parameters, EnvGene checks if the Credential is
+[shared](/docs/features/cred-rotation.md#affected-parameters) (used by multiple parameters or Environments). If shared
+Credentials are detected and force mode is not enabled, the credential_rotation job will fail to prevent accidental mass
+updates.
 
-- In this case, the job will generate an [`affected-sensitive-parameters.yaml`](/docs/features/cred-rotation.md#affected-parameters-reporting) file as an artifact. This file lists all parameters and locations affected by the Credential change, including those in shared Credentials files and all Environments that reference this credential.
+- In this case, the job will generate an
+  [`affected-sensitive-parameters.yaml`](/docs/features/cred-rotation.md#affected-parameters-reporting) file as an
+  artifact. This file lists all parameters and locations affected by the Credential change, including those in shared
+  Credentials files and all Environments that reference this credential.
 - To resolve:
-  - Review `affected-sensitive-parameters.yaml` to see which parameters and environments are linked by the shared Credential.
+  - Review `affected-sensitive-parameters.yaml` to see which parameters and environments are linked by the shared
+    Credential.
   - Either:
     - Manually split the shared Credential in the repository so each parameter uses its own Credential, **or**
-    - Rerun the Credential rotation job with force mode enabled (`CRED_ROTATION_FORCE=true`) to update all linked parameters.
+    - Rerun the Credential rotation job with force mode enabled (`CRED_ROTATION_FORCE=true`) to update all linked
+      parameters.
 
-> **Note:** When rotating a shared credential, all parameters in all Environments that reference this credential will be updated. This is why force mode is required for such operations to avoid accidental mass changes. The `affected-sensitive-parameters.yaml` file will list all such parameters and environments.
+> **Note:** When rotating a shared credential, all parameters in all Environments that reference this credential will be
+> updated. This is why force mode is required for such operations to avoid accidental mass changes. The
+> `affected-sensitive-parameters.yaml` file will list all such parameters and environments.
 
 ### `CRED_ROTATION_FORCE`
 
-**Description**: Enables force mode for updating sensitive parameter values. In force mode, the sensitive parameter value will be changed even if it affects other sensitive parameters that may be linked through the same credential. See details in [Credential Rotation](/docs/features/cred-rotation.md)
+**Description**: Enables force mode for updating sensitive parameter values. In force mode, the sensitive parameter
+value will be changed even if it affects other sensitive parameters that may be linked through the same credential. See
+details in [Credential Rotation](/docs/features/cred-rotation.md)
+
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
 
 **Default Value**: `false`
 
@@ -617,7 +881,8 @@ When rotating sensitive parameters, EnvGene checks if the Credential is [shared]
 
 ### `GH_ADDITIONAL_PARAMS`
 
-**Description**: A comma-separated string of key-value pairs for GitHub pipeline. Use it to pass all pipeline parameters except these main ones, which must be set directly:
+**Description**: A comma-separated string of key-value pairs for GitHub pipeline. Use it to pass all pipeline parameters
+except these main ones, which must be set directly:
 
 - `ENV_NAMES`
 - `DEPLOYMENT_TICKET_ID`
@@ -632,17 +897,22 @@ The parameters must follow the parameter schema defined in this document.
 This parameter is only available in the [GitHub version](/github_workflows/instance-repo-pipeline/) of the pipeline.
 
 > [!NOTE]
-> GitHub only allows 10 input parameters for the pipeline. To work around this but keep full functionality, the main parameters are provided at the top level, and all additional ones are sent as comma-separated key-value pairs in this field.
+> GitHub only allows 10 input parameters for the pipeline. To work around this but keep full functionality, the main
+> parameters are provided at the top level, and all additional ones are sent as comma-separated key-value pairs in this
+> field.
 
 **Format**: `KEY1=VALUE1,KEY2=VALUE2,KEY3=VALUE3`
 
-If a value contains JSON (e.g., `SD_DATA`, `EFFECTIVE_SET_CONFIG`, `ENV_SPECIFIC_PARAMS`, `CRED_ROTATION_PAYLOAD`, `BG_STATE`), the JSON must be properly escaped within the value part. For example: `SD_DATA=[{\"version\":2.1,...}],EFFECTIVE_SET_CONFIG={\"version\": \"v2.0\"}`
+If a value contains JSON (e.g., `SD_DATA`, `EFFECTIVE_SET_CONFIG`, `CUSTOM_PARAMS`, `CRED_ROTATION_PAYLOAD`,
+`BG_STATE`), the JSON must be properly escaped within the value part. For example:
+`SD_DATA=[{\"version\":2.1,...}],EFFECTIVE_SET_CONFIG={\"version\": \"v2.0\"}`
 
 **Default Value**: None
 
 **Mandatory**: No
 
-**Example**: `SD_SOURCE_TYPE=json,SD_DATA=[{\"version\":2.1,\"type\":\"solutionDeploy\"}],ENV_SPECIFIC_PARAMS={\"tenantName\":\"value\"}`
+**Example**:
+`SD_DATA=[{\"version\":2.1,\"type\":\"solutionDeploy\"}],CUSTOM_PARAMS={\"deployment\":{\"KEY\":\"value\"}}`
 
 Example of calling EnvGene pipeline via GitHub API:
 
@@ -658,32 +928,12 @@ curl -X POST \
             "ENV_BUILDER": "true",
             "GENERATE_EFFECTIVE_SET": "true",
             "DEPLOYMENT_TICKET_ID": "QBSHP-0001",
-            "GH_ADDITIONAL_PARAMS": "SD_SOURCE_TYPE=json,SD_DATA=[{\"version\":2.1,\"type\":\"solutionDeploy\"}],EFFECTIVE_SET_CONFIG={\"version\": \"v2.0\", \"app_chart_validation\": \"false\"}"
+            "GH_ADDITIONAL_PARAMS":
+"SD_DATA=[{\"version\":2.1,\"type\":\"solutionDeploy\"}],EFFECTIVE_SET_CONFIG={\"version\": \"v2.0\",
+\"app_chart_validation\": \"false\"}"
         }
       }'
 ```
-
-### `BG_MANAGE`
-
-**Description**: Enable Blue-Green operation. When set to `true`, the `bg_manage` pipeline job is executed to perform BG operations including state management and validation , Origin/Peer configuration copying for WarmUp operations.
-
-**Default Value**: `false`
-
-**Mandatory**: No
-
-**Example**: `true`
-
-### `BG_STATE`
-
-**Description**: Contains the description of the target state of the Blue-Green namespaces of the Environment. Used together with `BG_MANAGE`.
-
-See details in [Blue-Green Deployment](/docs/features/blue-green-deployment.md)
-
-**Default Value**: None
-
-**Mandatory**: No (Yes, when `BG_MANAGE` is `true`)
-
-**Example**: `{"peerNamespace":{"name":"prod-ns2","state":"IDLE","version":null},"controllerNamespace":"ns-controller","originNamespace":{"name":"prod-ns1","state":"ACTIVE","version":"v5"},"updateTime":"2023-07-07T10:00:54Z"}`
 
 ## Deprecated Parameters
 
@@ -691,7 +941,9 @@ The following parameters are planned for removal
 
 ### `SD_DELTA`
 
-**Description**: Deprecated
+**Description**: Deprecated. Use `SD_REPO_MERGE_MODE` instead.
+
+Processed only at `PIPELINE_TYPE: LEGACY`.
 
 If `true`: behaves identically to `SD_REPO_MERGE_MODE: extended-merge`
 
@@ -705,9 +957,125 @@ See details in [SD processing](/docs/features/sd-processing.md)
 
 **Example**: `true`
 
-## Archived Parameters
+### `ENV_SPECIFIC_PARAMS`
 
-These parameters are no longer in use and are maintained for historical reference
+**Description**: Specifies Environment Inventory and env-specific parameters. Use `ENV_INVENTORY_CONTENT` instead. This
+is can used together with
+`ENV_INVENTORY_INIT`. See details in [Environment Inventory
+Generation](/docs/features/env-inventory-generation.md)
+
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
+
+**Default Value**: None
+
+**Mandatory**: No
+
+**Example**:
+
+```yaml
+clusterParams:
+  clusterEndpoint: <value>
+  clusterToken: <value>
+additionalTemplateVariables:
+  <key>: <value>
+cloudName: <value>
+envSpecificParamsets:
+  <ns-template-name>:
+  - paramsetA
+  cloud:
+  - paramsetB
+paramsets:
+  paramsetA:
+    version: <paramset-version>
+    name: <paramset-name>
+    parameters:
+      <key>: <value>
+    applications:
+    - appName: <app-name>
+      parameters:
+        <key>: <value>
+  paramsetB:
+    version: <paramset-version>
+    name: <paramset-name>
+    parameters:
+      <key>: <value>
+    applications: []
+credentials:
+  credX:
+    type: <credential-type>
+    data:
+      username: <value>
+      password: <value>
+  credY:
+    type: <credential-type>
+    data:
+      secret: <value>
+```
+
+### `ENV_TEMPLATE_NAME`
+
+**Description**: Specifies the template artifact value within the generated Environment Inventory. Use
+`ENV_INVENTORY_CONTENT` instead. This is used together
+with `ENV_INVENTORY_INIT`.
+
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
+
+System overrides `envTemplate.name` at `/environments/<ENV_NAME>/Inventory/env_definition.yml`:
+
+```yaml
+envTemplate:
+    name: <ENV_TEMPLATE_NAME>
+    ...
+...
+```
+
+**Default Value**: None
+
+**Mandatory**: No
+
+**Example**: `env-template:v1.2.3`
+
+### `ENV_INVENTORY_INIT`
+
+**Description**: Use `ENV_INVENTORY_CONTENT` instead.
+
+If `true`:
+  In the pipeline, a job for generating the environment inventory is executed. The new Environment Inventory will be
+generated in the path `/environments/<ENV_NAME>/Inventory/env_definition.yml`. See details in [Environment Inventory
+Generation](/docs/features/env-inventory-generation.md)
+
+Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
+
+**Default Value**: `false`
+
+**Mandatory**: No
+
+**Example**: `true`
+
+## Parameter value formats
+
+A parameter whose value is structured, a map or a list, may be passed as YAML, JSON, or JSON-in-string.
+The pipeline parses each value and normalizes a map or a list into compact JSON before use. A scalar value,
+a plain string, number, or boolean, is passed through unchanged.
+
+The three forms are equivalent:
+
+```yaml
+# YAML
+deployment:
+  MY_OVERRIDE: value
+```
+
+```json
+{"deployment": {"MY_OVERRIDE": "value"}}
+```
+
+```text
+# JSON-in-string
+"{\"deployment\":{\"MY_OVERRIDE\":\"value\"}}"
+```
+
+The structured examples in this document use YAML for readability. Any of the three forms is accepted.
 
 ## Multiple Values Support
 
@@ -719,7 +1087,7 @@ Values can be separated using one of the following delimiters:
 - Comma (`,`)
 - Space (` `)
 
-**Example:**
+**Example**:
 
 ```text
 # Using newline


### PR DESCRIPTION
## Summary

Reworks `docs/instance-pipeline-parameters.md` to match the actual behavior of the instance pipeline,
verified against the orchestrator step gating in `feature/modern-toolset-rc2`.

- States `PIPELINE_TYPE` applicability (`GITLAB_DEPLOY`, `LEGACY`, or both) on every parameter,
  derived from each step's `should_run` condition. `ENV_BUILDER` and `GENERATE_EFFECTIVE_SET` are
  marked effective only at `LEGACY`, since at `GITLAB_DEPLOY` the job runs based on the operation
  regardless of the flag.
- Adds parameters processed at `PIPELINE_TYPE: GITLAB_DEPLOY`: `OPERATION_TYPE`, `BGD_OPERATION`,
  `BG_NS_TARGET`, `NAMESPACE_NAMES`, `APPLICATION_VERSIONS`, `DELTA_DEPLOY`, and the deploy-plan
  filters (`DEPLOY_POSTFIXES_FILTER`, `NAMESPACE_NAMES_FILTER`, `COMPONENT_NAMES_FILTER`,
  `WAVE_NAMES_FILTER`), plus `CLUSTER_NAME`, `ENVIRONMENT_NAME`, `PIPELINE_TYPE`,
  `CMDB_IMPORT_APP_DEFS`, `CMDB_IMPORT_REG_DEFS`.
- Removes parameters not processed by the GitLab pipeline (GitHub-only): `SD_SOURCE_TYPE`,
  `APP_REG_DEFS_JOB`, `APP_DEFS_PATH`, `REG_DEFS_PATH`.
- Moves deprecated parameters to the Deprecated section with a replacement pointer woven into each
  description: `SD_DELTA` (use `SD_REPO_MERGE_MODE`), `ENV_SPECIFIC_PARAMS`, `ENV_TEMPLATE_NAME`,
  `ENV_INVENTORY_INIT` (use `ENV_INVENTORY_CONTENT`).
- Adds a `Parameter value formats` section (YAML / JSON / JSON-in-string are equivalent) and rewrites
  structured examples in YAML for readability.
- Fixes incorrect "JSON in string" format claims that no longer hold now that values are parsed with a
  YAML loader.

Base picks up master's #1603 (deprecation of `ENV_INVENTORY_INIT` / `ENV_TEMPLATE_NAME`); the
`SSL_CERTIFICATES_BUNDLE` addition from this session was dropped as redundant with #1650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)