### PR TITLE
docs: Blue-Green design (from #1671) onto feature/modern-toolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,16 +174,22 @@ After the pipeline finishes, the Environment configuration will be generated and
 - [**Environment Instance Generation**](/docs/features/environment-instance-generation.md) - Generate Environment Instances from templates and inventories
 - [**Credential Rotation**](/docs/features/cred-rotation.md) - Automate [Credential](/docs/envgene-objects.md#credential) rotation
 - [**External Credentials Management**](/docs/features/external-creds.md) - External secret stores, VALS/ESO, and External Credential Context
-- [**Namespace Render Filter**](/docs/features/namespace-render-filtering.md) - Render only selected [Namespaces](/docs/envgene-objects.md#namespace)
+- [**Namespace render filtering**](/docs/features/namespace-render-filtering.md) - Render only [Namespaces](/docs/envgene-objects.md#namespace) selected from the Solution Descriptor via Namespace map
+- [**BG Domain from Composite Structure**](/docs/features/bg-domain-from-composite-structure.md) - Generate standalone `bg_domain.yml` from an inline composite `bgdomain` member
 - [**Namespace Filtering in Template Descriptor**](/docs/features/namespace-filtering-in-template-descriptor.md) - Filter namespaces during Template Descriptor rendering
 - [**System Certificate Configuration**](/docs/features/system-certificate.md) - Auto-config system certs for internal registries or TLS services
 - [**Template Override**](/docs/features/template-override.md) - Use a base Environment template and override parts as needed
 - [**Automatic Environment Name Derivation**](/docs/features/auto-env-name-derivation.md) - Auto-detect Environment name from folder structure
 - [**Template Composition**](/docs/features/template-composition.md) - Advanced Environment template patterns
-- [**Blue-Green Deployment**](/docs/features/blue-green-deployment.md) - BG domains, state management, and `bg_manage` pipeline job
+- [**Blue-Green Deployment**](/docs/features/blue-green-deployment.md) - BG domains, `OPERATION_TYPE` lifecycle, and deploy-side targeting
 - [**Resource Profiles**](/docs/features/resource-profile.md) - Baselines and overrides for performance parameters
 - [**SBOM**](/docs/features/sbom.md) - CycloneDX-based artifact and parameter exchange for EnvGene
 - [**SBOM Retention**](/docs/features/sbom-retention.md) - Automatic cleanup of cached SBOM files to manage repository size
+
+### Technical documentation
+
+- [**Technical documentation hub**](/docs/tech/README.md) - Implementer-facing contracts (algorithms, internal artefacts)
+- [**Namespace map**](/docs/tech/namespace-map.md) - `compute_namespace_map` resolution, validation, and consumers
 
 ### Examples & Samples
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,13 +76,14 @@
 - [**Environment Instance Generation**](/docs/features/environment-instance-generation.md) - Generate Environment Instances from templates and inventories (including BG support)
 - [**Credential Rotation**](/docs/features/cred-rotation.md) - Automate [Credential](/docs/envgene-objects.md#credential) rotation
 - [**External Credentials Management**](/docs/features/external-creds.md) - External secret stores, VALS/ESO in the Effective Set, and External Credential Context
-- [**Namespace Render Filter**](/docs/features/namespace-render-filtering.md) - Render only selected [Namespaces](/docs/envgene-objects.md#namespace)
+- [**Namespace render filtering**](/docs/features/namespace-render-filtering.md) - Render only [Namespaces](/docs/envgene-objects.md#namespace) selected from the Solution Descriptor via Namespace map
+- [**BG Domain from Composite Structure**](/docs/features/bg-domain-from-composite-structure.md) - Generate standalone `bg_domain.yml` from an inline composite `bgdomain` member
 - [**Namespace Filtering in Template Descriptor**](/docs/features/namespace-filtering-in-template-descriptor.md) - Filter namespaces during Template Descriptor rendering
 - [**System Certificate Configuration**](/docs/features/system-certificate.md) - Auto-config system certs for internal registries or TLS services
 - [**Template Override**](/docs/features/template-override.md) - Use a base Environment template and override parts as needed
 - [**Automatic Environment Name Derivation**](/docs/features/auto-env-name-derivation.md) - Auto-detect Environment name from folder structure
 - [**Template Composition**](/docs/features/template-composition.md) - Advanced Environment template patterns
-- [**Blue-Green Deployment**](/docs/features/blue-green-deployment.md) - BG domains, state management, and `bg_manage` pipeline job
+- [**Blue-Green Deployment**](/docs/features/blue-green-deployment.md) - BG domains, `OPERATION_TYPE` lifecycle, and deploy-side targeting
 - [**Resource Profiles**](/docs/features/resource-profile.md) - Baselines and overrides for performance parameters
 - [**SBOM**](/docs/features/sbom.md) - CycloneDX-based artifact and parameter exchange for EnvGene
 - [**SBOM Retention**](/docs/features/sbom-retention.md) - Automatic cleanup of cached SBOM files to manage repository size

--- a/docs/configuration-standard.md
+++ b/docs/configuration-standard.md
@@ -574,7 +574,7 @@ integration-deploy-offsite   # topology suffix where it genuinely varies
 cloud-env-specific           # scope in the name, the file location already says environment
 qa01-bss-deploy              # environment name baked in
 bss-deploy-r23-3             # release baked in
-etbss-51477                  # ticket id, opaque
+project-51477                  # ticket id, opaque
 bss                          # category missing
 ```
 
@@ -601,7 +601,7 @@ prod-oss-override
 dev-core-override-hawk
 # Not OK
 sit-dm-override                # baseline is dev, so the leading token contradicts the field
-telus-dv2-multi-sql-override   # environment name baked in
+project-dv2-multi-sql-override   # environment name baked in
 ```
 
 ### NAME-6 - Name a credential ID by purpose (SHOULD)

--- a/docs/envgene-objects.md
+++ b/docs/envgene-objects.md
@@ -1456,7 +1456,7 @@ This object, which is an empty file, is used to represent the current Blue-Green
 
 The files are maintained by the [`bg_manage`](/docs/envgene-pipelines.md) step.
 
-See details in [Blue-Green Deployment](/docs/features/blue-green-deployment.md#state-storage).
+See details in [Blue-Green Deployment](/docs/features/blue-green-deployment.md#bg-domain-lifecycle).
 
 **Filename patterns:**
 

--- a/docs/envgene-objects.md
+++ b/docs/envgene-objects.md
@@ -25,6 +25,8 @@
       - [Composite Structure](#composite-structure)
       - [BG Domain](#bg-domain)
     - [BG State Files](#bg-state-files)
+    - [Namespace map](#namespace-map)
+    - [Deployment Plan](#deployment-plan)
     - [Solution Descriptor](#solution-descriptor)
     - [Credential](#credential)
       - [`usernamePassword`](#usernamepassword)
@@ -530,10 +532,14 @@ satellites: []
 
 #### BG Domain Template
 
-This is a Jinja template file used to render the standalone [BG Domain](#bg-domain) object for environments that use
-Blue-Green Domain (BGD) support and are not part of a [Composite Structure](#composite-structure). For a BG Domain
-that is part of a composite structure, the [Composite Structure Template](#composite-structure-template) renders the
-inline `bgdomain` member instead.
+This is a Jinja template file used to render the standalone [BG Domain](#bg-domain) object when the
+Environment Template descriptor has a `bg_domain` key. That explicit hook takes precedence over
+generation from a [Composite Structure](#composite-structure). Generation from the composite runs
+only when the descriptor omits `bg_domain`. See
+[BG Domain from Composite Structure](/docs/features/bg-domain-from-composite-structure.md).
+
+For Environments that embed the domain only in the composite, authors may omit this template and
+rely on generation from the composite instead.
 
 **Location:** `/templates/env-templates/{Group name}/bg-domain.yml.j2`
 
@@ -1341,21 +1347,20 @@ satellites:
 
 #### BG Domain
 
-The BG Domain object defines the Blue-Green Domain structure and namespace mappings for environments that use BGD support. This object is used for alias resolution in the `NS_BUILD_FILTER` parameter and BGD lifecycle management.
+The standalone BG Domain object is the file `bg_domain.yml` in the Environment Instance. EnvGene
+produces it from either:
 
-The standalone BG Domain object represents a BG Domain that is not part of a
-[Composite Structure](#composite-structure).
-When a BG Domain is part of a composite structure, it is embedded inline in the composite structure as a `bgdomain`
-member and no standalone BG Domain object is generated.
+- the [BG Domain Template](#bg-domain-template) when the Environment Template descriptor has a
+  `bg_domain` key, or
+- an inline `type: bgdomain` member of the [Composite Structure](#composite-structure), by
+  generation from the composite when the descriptor omits `bg_domain`
 
-The standalone BG Domain object represents a BG Domain that is not part of a
-[Composite Structure](#composite-structure).
-When a BG Domain is part of a composite structure, it is embedded inline in the composite structure as a `bgdomain`
-member and no standalone BG Domain object is generated.
+When both the descriptor key and an inline member exist, EnvGene uses the BG Domain Template and
+warns that the inline member is not used for `bg_domain.yml`. See
+[BG Domain from Composite Structure](/docs/features/bg-domain-from-composite-structure.md).
 
-The BG Domain object is generated during Environment Instance generation based on:
-
-- [BG Domain Template](#bg-domain-template)
+The BG Domain object is used for Blue-Green Domain structure, Namespace map resolution with
+[`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target), and BGD lifecycle management.
 
 **Location:** `/environments/<cluster-name>/<environment-name>/bg_domain.yml`
 
@@ -1438,19 +1443,20 @@ bg_domain:
     url: https://controller-env-1-controller.qubership.org
 ```
 
-**BGD Alias Resolution:** Used by `NS_BUILD_FILTER` parameter to resolve BGD aliases:
+**BG Domain roles:** The object names the origin, peer, and controller Namespaces used by Namespace
+map resolution and BGD lifecycle management:
 
-- `@controller` → controller namespace
-- `@origin` → origin namespaces
-- `@peer` → peer namespaces
+- `originNamespace` - origin Namespace
+- `peerNamespace` - peer Namespace
+- `controllerNamespace` - controller Namespace
 
 ### BG State Files
 
 This object, which is an empty file, is used to represent the current Blue-Green Domain state of the Origin and Peer namespaces via lightweight filesystem markers.
 
-The files are maintained by the [`bg_manage`](/docs/envgene-pipelines.md) job.
+The files are maintained by the [`bg_manage`](/docs/envgene-pipelines.md) step.
 
-See details in [Blue-Green Deployment](/docs/features/blue-green-deployment.md#bg-state-files).
+See details in [Blue-Green Deployment](/docs/features/blue-green-deployment.md#state-storage).
 
 **Filename patterns:**
 
@@ -1480,6 +1486,49 @@ State files are located in the environment root directory:
 ├── .peer-candidate
 ```
 
+### Namespace map
+
+The namespace map is a flat YAML file that maps each
+[`deployPostfix`](/docs/glossary.md#deploy-postfix) to the Namespace `name` in the
+Environment Instance.
+
+**Location:** `/environments/<cluster-name>/<environment-name>/Inventory/namespace-map.yml`
+
+```yaml
+# Mandatory keys are deployPostfix values from the Solution Descriptor (or equivalent application list)
+# Values are Namespace object name fields from Namespaces/<folder>/namespace.yml
+<deployPostfix>: <namespace-name>
+```
+
+**Example (BG Domain, peer selected):**
+
+```yaml
+bss: env-1-bss-peer
+core: env-1-core
+```
+
+EnvGene builds the file in `compute_namespace_map`. For Blue-Green Domains where origin and peer
+share one `deployPostfix`, resolution requires
+[`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target).
+
+### Deployment Plan
+
+The Deployment Plan is an internal Environment Inventory file. EnvGene builds it from the
+application list (Solution Descriptor or equivalent) and the
+[Namespace map](#namespace-map). Downstream steps, including Effective Set generation, consume it.
+Operators do not author it by hand.
+
+**Location:** `/environments/<cluster-name>/<environment-name>/Inventory/deploy-plan.yml`
+
+Each list entry extends an application deploy item with the resolved Namespace `name`:
+
+```yaml
+- wave: <wave>
+  version: <application-name>:<application-version>
+  deployPostfix: <deploy-postfix>
+  namespace: <namespace-name>
+```
+
 ### Solution Descriptor
 
 The Solution Descriptor (SD) defines the application composition of a solution. In EnvGene it serves as the primary input for EnvGene's Effective Set calculations. The SD can also be used for template rendering through the [`current_env.solution_structure`](/docs/template-macros.md#current_envsolution_structure) variable.
@@ -1487,6 +1536,12 @@ The Solution Descriptor (SD) defines the application composition of a solution. 
 Other systems can use it for other reasons, for example as a deployment blueprint for external systems.
 
 Only SD versions 2.1 and 2.2 can be used by EnvGene for the purposes described above, as their `application` list elements contain the `deployPostfix` and `version` attributes.
+
+Application entries use a [`deployPostfix`](/docs/glossary.md#deploy-postfix). In a
+[BG Domain](#bg-domain), origin and peer may share that postfix while their Namespace `name` values
+differ. The SD does not carry [`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target) or
+`originNamespace.name` / `peerNamespace.name`. EnvGene resolves the Namespace `name` through the
+[Namespace map](#namespace-map).
 
 For details on how EnvGene processes SD, refer to the [SD Processing documentation](/docs/features/sd-processing.md).
 

--- a/docs/envgene-pipelines.md
+++ b/docs/envgene-pipelines.md
@@ -52,8 +52,9 @@ flowchart TB
    - **Condition**: Runs if [`CRED_ROTATION_PAYLOAD`](/docs/instance-pipeline-parameters.md#cred_rotation_payload) is provided
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
-4. **bg_manage**
-   - **Condition**: Runs if `BG_MANAGE: true`.
+4. **bg_manage** (step):
+   - **Condition**: Runs if [`OPERATION_TYPE`](/docs/instance-pipeline-parameters.md#operation_type) is one
+     of `BGD_INIT`, `BGD_WARMUP`, `BGD_PROMOTE`, `BGD_ROLLBACK`, or `BGD_COMMIT`.
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
 5. **env_inventory_generation**:
@@ -87,7 +88,8 @@ flowchart TB
        5. Handles template Parameter Set and Resource profiles.
        6. Handles environment-specific Parameter Set and Resource profiles.
        7. Creates Credentials including shared Credentials
-   - **Condition**: Runs if [`ENV_BUILDER: true`](/docs/instance-pipeline-parameters.md#env_builder).
+       8. When a Solution Descriptor is supplied for the run, re-renders only the Namespaces selected via [Namespace map](/docs/tech/namespace-map.md) and [Namespace render filtering](/docs/features/namespace-render-filtering.md). When no SD is supplied and that scenario is supported, renders all Namespaces
+   - **Condition**: Runs if [`ENV_BUILD: true`](/docs/instance-pipeline-parameters.md#env_builder).
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
 9. **generate_effective_set**:

--- a/docs/features/bg-domain-from-composite-structure.md
+++ b/docs/features/bg-domain-from-composite-structure.md
@@ -1,0 +1,209 @@
+# BG Domain from Composite Structure
+
+- [BG Domain from Composite Structure](#bg-domain-from-composite-structure)
+  - [Description](#description)
+  - [Problem](#problem)
+  - [Sources of `bg_domain.yml`](#sources-of-bg_domainyml)
+  - [Generation from the Composite Structure](#generation-from-the-composite-structure)
+  - [Which source EnvGene uses](#which-source-envgene-uses)
+  - [Environment Instance generation order](#environment-instance-generation-order)
+  - [Effect on consumers](#effect-on-consumers)
+  - [Authoring guidance](#authoring-guidance)
+  - [Validation](#validation)
+  - [Related documentation](#related-documentation)
+
+## Description
+
+EnvGene can generate the standalone
+[BG Domain](/docs/envgene-objects.md#bg-domain) file `bg_domain.yml` from an inline
+`type: bgdomain` member of the
+[Composite Structure](/docs/envgene-objects.md#composite-structure).
+
+That keeps one authoring surface for solutions that embed the Blue-Green Domain in the composite
+(for example as a satellite). Steps that already read `bg_domain.yml` keep working without a second
+[BG Domain Template](/docs/envgene-objects.md#bg-domain-template).
+
+The Composite Structure file remains in the Environment Instance. Generation from the composite
+copies the domain into the standalone BG Domain object. It does not remove the inline member.
+
+## Problem
+
+Two objects can describe the same Blue-Green Domain:
+
+- an inline `bgdomain` member inside `composite_structure.yml`
+- a standalone `bg_domain.yml`
+
+Without generation from the composite, authors must keep a Composite Structure Template and a BG
+Domain Template aligned. Some EnvGene steps and Effective Set topology fields read only the
+standalone file. When the domain exists only inline, those consumers see no BG Domain.
+
+## Sources of `bg_domain.yml`
+
+| Source                                                         | Role                                                                         |
+|----------------------------------------------------------------|------------------------------------------------------------------------------|
+| [BG Domain Template](/docs/envgene-objects.md#bg-domain-template) via the `bg_domain` key on the Environment Template descriptor | Explicit generation hook. EnvGene renders `bg_domain.yml` from the template  |
+| Inline `type: bgdomain` in the rendered Composite Structure    | Fallback source when the `bg_domain` descriptor key is absent                |
+
+Generation from the composite is a fallback. It runs only when the Environment Template descriptor
+does not define `bg_domain`.
+
+## Generation from the Composite Structure
+
+1. EnvGene renders `composite_structure.yml` from the
+   [Composite Structure Template](/docs/envgene-objects.md#composite-structure-template).
+2. It searches `baseline` and each `satellites` member for `type: bgdomain`.
+3. When generation from the composite applies, it writes
+   `/environments/<cluster-name>/<environment-name>/bg_domain.yml` from that member.
+4. The written object is a standalone
+   [BG Domain](/docs/envgene-objects.md#bg-domain): `name`, `type: bgdomain`,
+   `originNamespace`, `peerNamespace`, and `controllerNamespace`.
+5. Fields present on the inline member are copied into `bg_domain.yml`.
+6. The inline member stays in `composite_structure.yml`.
+
+> [!NOTE]
+> The [Composite Structure schema](/schemas/composite-structure.schema.json) currently allows
+> `type: bgdomain` on `baseline` only. `satellites` items are limited to `type: namespace`, and the
+> inline `controllerNamespace` object does not declare `credentials` or `url`. The object reference
+> and this feature describe a satellite BG Domain and copy of those controller fields because
+> standalone [BG Domain](/docs/envgene-objects.md#bg-domain) consumers require them. Extending the
+> schema is part of implementing this feature.
+
+### Example
+
+Rendered Composite Structure (BG Domain as `baseline`; the same field copy applies when a satellite
+`bgdomain` is supported by the schema):
+
+```yaml
+name: "clusterA-env-1-composite-structure"
+baseline:
+  type: bgdomain
+  name: env-1-bss-bg-domain
+  originNamespace:
+    type: namespace
+    name: env-1-bss-origin
+  peerNamespace:
+    type: namespace
+    name: env-1-bss-peer
+  controllerNamespace:
+    type: namespace
+    name: env-1-bss-controller
+satellites:
+  - name: env-1-api
+    type: namespace
+```
+
+Generated `bg_domain.yml` (shape of the standalone object; `credentials` and `url` appear only when
+present on the inline member after the schema allows them):
+
+```yaml
+name: env-1-bss-bg-domain
+type: bgdomain
+originNamespace:
+  type: namespace
+  name: env-1-bss-origin
+peerNamespace:
+  type: namespace
+  name: env-1-bss-peer
+controllerNamespace:
+  type: namespace
+  name: env-1-bss-controller
+```
+
+## Which source EnvGene uses
+
+Decision order:
+
+1. If the Environment Template descriptor has `bg_domain`, EnvGene renders `bg_domain.yml` from the
+   BG Domain Template.
+2. Else if the Composite Structure has exactly one inline `type: bgdomain` member, EnvGene generates
+   `bg_domain.yml` from that member.
+3. Else EnvGene does not write `bg_domain.yml`.
+
+| Descriptor has `bg_domain` | Inline `bgdomain` in composite | `bg_domain.yml`                         | Extra behaviour                                      |
+|----------------------------|--------------------------------|-----------------------------------------|------------------------------------------------------|
+| Yes                        | No                             | From BG Domain Template                 | -                                                    |
+| Yes                        | Yes                            | From BG Domain Template                 | Warning: inline domain is not used for this file     |
+| No                         | Yes                            | Generated from the Composite Structure  | -                                                    |
+| No                         | No                             | Not written                             | -                                                    |
+
+Why this order:
+
+- The `bg_domain` descriptor key is the existing explicit generation hook. Environments that already
+  use a BG Domain Template keep the same result.
+- Generation from the composite is only for Environments that omit that key and embed the domain in
+  the composite (one authoring surface).
+- When both are present, EnvGene does not silently overwrite the template result with the composite
+  fallback. It keeps the template output and warns that the inline member is ignored for
+  `bg_domain.yml`.
+
+## Environment Instance generation order
+
+Relative order for this feature:
+
+1. Render Namespace, Cloud, and Tenant objects as today.
+2. Render `composite_structure.yml`.
+3. If the descriptor has no `bg_domain`, generate `bg_domain.yml` from the composite when an inline
+   `bgdomain` member is present.
+4. If the descriptor has `bg_domain`, render `bg_domain.yml` from the BG Domain Template. If an
+   inline `bgdomain` member also exists, emit the warning from the table above.
+5. Run BG Domain validation and downstream steps that read `bg_domain.yml` (for example credentials
+   creation and namespace role resolution).
+
+Exact job names differ between pipeline layouts. The observable rule is the decision order in
+[Which source EnvGene uses](#which-source-envgene-uses).
+
+## Effect on consumers
+
+After EnvGene generates or renders standalone `bg_domain.yml`, consumers that read that file behave
+as for any Environment with a BG Domain, including:
+
+- [Blue-Green Deployment](/docs/features/blue-green-deployment.md) lifecycle (`bg_manage`)
+- Namespace map resolution for shared `deployPostfix` values with
+  [`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target)
+- Effective Set Topology Context `bg_domain` (see
+  [calculator-cli](/docs/features/calculator-cli.md#version-20topology-context-bg_domain-example))
+
+`composite_structure` in the Topology Context still carries the full composite, including the
+inline `bgdomain` member when it is present.
+
+## Authoring guidance
+
+- Prefer a single authoring path: either embed the domain in the Composite Structure Template and
+  omit the `bg_domain` descriptor key, or use a BG Domain Template and do not rely on generation
+  from the composite for `bg_domain.yml`.
+- Do not set both paths unless you accept that only the BG Domain Template feeds `bg_domain.yml`
+  and EnvGene warns about the unused inline member.
+- When you rely on generation from the composite, put every field required by standalone BG Domain
+  consumers on the inline `bgdomain` member. Namespace names are always required. Controller
+  credentials and URL are required when lifecycle or Effective Set need them, after the Composite
+  Structure schema allows those fields.
+- Do not expect generation from the composite to invent credentials or controller URL. Missing
+  fields on the inline member stay missing on `bg_domain.yml`.
+
+## Validation
+
+EnvGene fails Environment Instance generation when:
+
+- generation from the composite is selected and more than one `type: bgdomain` member exists in the
+  composite (baseline and satellites together)
+- generation from the composite is selected and the chosen member is missing required BG Domain
+  fields for a standalone object (`name`, `type`, origin, peer, and controller names)
+- the written `bg_domain.yml` fails existing BG Domain validation (for example referenced
+  Namespaces are missing)
+
+When the descriptor has `bg_domain` and the composite also has an inline `bgdomain` member, EnvGene
+does not fail for that combination alone. It renders from the template and warns that the inline
+member is not used for `bg_domain.yml`.
+
+When the BG Domain Template path is selected, existing template-render validation applies
+unchanged.
+
+## Related documentation
+
+- [Composite Structure](/docs/envgene-objects.md#composite-structure)
+- [Composite Structure Template](/docs/envgene-objects.md#composite-structure-template)
+- [BG Domain](/docs/envgene-objects.md#bg-domain)
+- [BG Domain Template](/docs/envgene-objects.md#bg-domain-template)
+- [Blue-Green Deployment](/docs/features/blue-green-deployment.md)
+- [Environment Instance generation](/docs/features/environment-instance-generation.md)
+- [`bg_domain` Topology Context](/docs/features/calculator-cli.md#version-20topology-context-bg_domain-example)

--- a/docs/features/blue-green-deployment.md
+++ b/docs/features/blue-green-deployment.md
@@ -2,13 +2,14 @@
 
 - [Blue-Green Deployment](#blue-green-deployment)
   - [Description](#description)
+  - [Conceptual model](#conceptual-model)
+  - [Operation-driven control](#operation-driven-control)
+  - [Responsibility boundaries](#responsibility-boundaries)
   - [Operation flows](#operation-flows)
-  - [BG-related EnvGene objects](#bg-related-envgene-objects)
-  - [`bg_manage` job](#bg_manage-job)
-  - [BG-related Instance pipeline parameters](#bg-related-instance-pipeline-parameters)
-  - [BG state files](#bg-state-files)
-    - [State transition validation](#state-transition-validation)
-  - [Warmup operation](#warmup-operation)
+  - [Deploy-side namespace targeting](#deploy-side-namespace-targeting)
+  - [`bg_manage` step](#bg_manage-step)
+  - [BG Domain lifecycle](#bg-domain-lifecycle)
+  - [Warmup behaviour](#warmup-behaviour)
   - [CMDB import](#cmdb-import)
   - [BG-related parameters in Effective Set](#bg-related-parameters-in-effective-set)
   - [BG-related macros](#bg-related-macros)
@@ -24,247 +25,245 @@ For BGD, EnvGene:
 
 - generates the BG Domain object from a
   [BG Domain Template](/docs/envgene-objects.md#bg-domain-template) during Environment Instance
-  generation and validates that every namespace the object references exists in the Environment
-  (otherwise generation fails)
-- regenerates selected namespaces only, by name or BG Domain role alias, using the
-  [Namespace Render Filter](/docs/features/namespace-render-filtering.md)
-- creates, updates, and validates [BG state files](#bg-state-files) on BG Plugin calls
-- copies namespace contents between origin and peer during the [warmup operation](#warmup-operation)
+  generation and validates that every referenced namespace exists in the Environment
+- resolves a shared Solution Descriptor `deployPostfix` to the origin or peer Namespace `name`
+  through [`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target) and the
+  [Namespace map](/docs/tech/namespace-map.md)
+- re-renders only the Namespaces selected from the Solution Descriptor via the Namespace map
+  ([Namespace render filtering](/docs/features/namespace-render-filtering.md))
+- creates and updates [BG state files](#bg-domain-lifecycle) for lifecycle operations
+- copies namespace contents during [warmup](#warmup-behaviour)
 - adds BG Domain parameters to the
   [Effective Set](#bg-related-parameters-in-effective-set)
 - [imports](#cmdb-import) the BG Domain object into CMDB
 
-To prepare an Environment for BGD, see
-[Migrate to Blue-Green Deployment](/docs/how-to/blue-green-deployment-migration.md). To select
-parameters for a deploy operation, see
+To prepare an Environment, see
+[Migrate to Blue-Green Deployment](/docs/how-to/blue-green-deployment-migration.md).
+For deploy parameters, see
 [Blue-Green Deployment deploy operations](/docs/how-to/blue-green-deployment-deploy-operations.md).
 
-## Operation flows
+## Conceptual model
 
-The BG Operator initiates lifecycle operations through the BG Plugin, which triggers the Instance
-pipeline with `BG_MANAGE` and `BG_STATE`.
+Origin and peer are fixed positions in a BG Domain. They do not decide which side serves traffic.
+
+State files decide the purpose of each side at a point in time (for example origin `ACTIVE`, peer
+`IDLE`). After a full cycle the states swap. EnvGene resolves active, idle, candidate, or legacy
+from state files. That supports both forward and reverse cycles.
+
+## Operation-driven control
+
+Lifecycle control uses
+[`OPERATION_TYPE`](/docs/instance-pipeline-parameters.md#operation_type).
+
+EnvGene reads the current origin and peer states from the state files, derives the next states from
+`OPERATION_TYPE`, and writes the new state files.
+
+Application deploy into a BG Domain side is not a lifecycle operation. It uses a Solution Descriptor
+for the applications to deploy and
+[`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target) when origin and peer share a
+`deployPostfix`, not a BGD `OPERATION_TYPE` value. See
+[Deploy-side namespace targeting](#deploy-side-namespace-targeting) and
+[Blue-Green Deployment deploy operations](/docs/how-to/blue-green-deployment-deploy-operations.md).
+
+## Responsibility boundaries
+
+| Actor                       | Responsibility                                                           |
+|-----------------------------|--------------------------------------------------------------------------|
+| BG Operator / BG Controller | Decide whether a lifecycle operation is allowed before the pipeline runs |
+| BG Plugin                   | Start the Instance pipeline with `ENV_NAMES` and `OPERATION_TYPE`        |
+| EnvGene                     | Read BG Domain and state files, run repository actions, write next state |
+| External deployment system  | Deploy apps, check candidate readiness, switch traffic, clean up legacy  |
+
+> [!NOTE]
+> The BG Plugin, BG Operator, deployment system, and CMDB are not part of EnvGene Core.
+
+## Operation flows
 
 ```mermaid
 sequenceDiagram
     participant BGO as BG Operator
     participant BGP as BG Plugin
-    participant EGP as EnvGene Pipeline
-    participant EGR as EnvGene Repo
+    participant EGP as Instance pipeline
+    participant EGR as Instance Repository
 
     BGO->>BGP: POST /api/bluegreen/v1/operation/<operation>
-    Note over BGO,BGP: BGState with namespace states and versions
+    BGP->>BGP: Validate the BGD operation request
+    BGP->>EGP: Start the Instance pipeline
+    Note over BGP,EGP: ENV_NAMES and OPERATION_TYPE
 
-    BGP->>BGP: Validate BG operation request
-    BGP->>EGP: Trigger Instance Pipeline
-    Note over BGP,EGP: Parameters: BG_MANAGE=true, BG_STATE=<...>, ENV_NAMES=<...>
-    EGP-->>BGP: Operation result (200 OK or error)
-    BGP-->>BGO: Operation result (200 OK or error)
-
-    EGP->>EGP: Execute bg_manage job
-
-    EGP->>EGP: Validate state transition
-
-    EGP->>EGR: Create/update BG state files
-
-    alt If the operation is `warmup`
-        EGP->>EGR: Copy namespace and child objects
+    EGP->>EGR: Read the BG Domain and state files
+    opt BGD_WARMUP
+        EGP->>EGR: Copy namespace content and synchronise bgNsArtifacts
     end
+    EGP->>EGR: Update BG state files
+    EGP-->>BGP: Success or error
+    BGP-->>BGO: Result
 ```
 
-The deploy orchestrator triggers the Instance pipeline with `NS_BUILD_FILTER` for selective
-namespace processing.
+## Deploy-side namespace targeting
+
+Application deploy into a BG Domain side is not a lifecycle operation. Deploy-side targeting uses
+[`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target) (`origin` or `peer`).
+
+Two effects, with one shared `BG_NS_TARGET` input to Namespace map:
+
+1. **Namespace map** - when origin and peer share a Solution Descriptor `deployPostfix`,
+   `compute_namespace_map` requires `BG_NS_TARGET` and writes the matching Namespace `name` into
+   [`namespace-map.yml`](/docs/envgene-objects.md#namespace-map).
+2. **Render filtering** - `env_build` re-renders only the Namespace `name` values selected from the
+   SD through that map. See
+   [Namespace render filtering](/docs/features/namespace-render-filtering.md).
 
 ```mermaid
 sequenceDiagram
     participant DP as Deploy Orchestrator
-    participant EGP as EnvGene Pipeline
+    participant EGP as Instance pipeline
     participant CMDB as CMDB
 
     DP->>EGP: Trigger Instance Pipeline
-    Note over DP,EGP: with NS_BUILD_FILTER
-    EGP->>EGP: Generate Environment Instance
-    Note over EGP,EGP: Only those namespaces that passed NS_BUILD_FILTER
+    Note over DP,EGP: Solution Descriptor and BG_NS_TARGET
+    EGP->>EGP: Build namespace-map and render selected Namespaces
+    Note over EGP,EGP: Map resolves deployPostfix. env_build uses selected Namespace.name values
 
     alt CMDB import
         EGP->>CMDB: Import Environment Instance to CMDB
     else Effective Set generation
-        EGP->>EGP: Generate Effective Set
+        EGP->>EGP: Generate Effective Set from the resolved Deployment Plan scope
     end
 ```
 
-> [!NOTE]
-> BG Operator, BG Plugin, Deploy Orchestrator, and CMDB are not components of EnvGene. They are
-> external systems that interact with EnvGene during BGD operations.
+## `bg_manage` step
 
-## BG-related EnvGene objects
+The Instance pipeline step that applies a BGD
+[`OPERATION_TYPE`](/docs/instance-pipeline-parameters.md#operation_type).
 
-- [BG Domain](/docs/envgene-objects.md#bg-domain): defines the domain structure - origin, peer, and
-  controller namespaces
-- [BG Domain Template](/docs/envgene-objects.md#bg-domain-template): generates the BG Domain object
-  during Environment Instance generation
-- [BG State Files](/docs/envgene-objects.md#bg-state-files): track the states of the origin and peer
-  namespaces
+- Resolves origin, peer, and controller names from the
+  [BG Domain](/docs/envgene-objects.md#bg-domain).
+- Applies [Operation-driven control](#operation-driven-control) and the
+  [lifecycle transition table](#bg-domain-lifecycle).
+- For every BGD `OPERATION_TYPE`, updates BG state files.
+- For `BGD_WARMUP`, also runs [Warmup behaviour](#warmup-behaviour).
 
-## `bg_manage` job
-
-The job is part of the Instance pipeline. It:
-
-- validates namespace names in `BG_STATE` against the [BG Domain](/docs/envgene-objects.md#bg-domain)
-  object in the Environment Instance
-- validates the requested state change against the BG state files (see
-  [State transition validation](#state-transition-validation))
-- creates and updates [BG state files](/docs/envgene-objects.md#bg-state-files)
-- during warmup, copies the [Namespace](/docs/envgene-objects.md#namespace) and the
-  [Applications](/docs/envgene-objects.md#application) under it
-
-The criteria for running the job and its order relative to other jobs are described in
+When the step runs and how it orders relative to other steps is described in
 [EnvGene pipelines](/docs/envgene-pipelines.md).
 
-## BG-related Instance pipeline parameters
+Related pipeline parameters:
 
 - [`ENV_NAMES`](/docs/instance-pipeline-parameters.md#env_names)
-- `BG_MANAGE`
-- `BG_STATE`
+- [`OPERATION_TYPE`](/docs/instance-pipeline-parameters.md#operation_type)
+- [`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target)
+- [`ENV_TEMPLATE_VERSION`](/docs/instance-pipeline-parameters.md#env_template_version)
 - [`GH_ADDITIONAL_PARAMS`](/docs/instance-pipeline-parameters.md#gh_additional_params)
 
-The parameter set differs between the GitLab and GitHub pipelines.
+## BG Domain lifecycle
 
-**GitLab CI example:**
+Each side carries a runtime state: `ACTIVE`, `IDLE`, `CANDIDATE`, or `LEGACY`. The diagram shows
+state pairs as `(origin, peer)`. The table below lists the same pairs with the corresponding state
+files before and after each `OPERATION_TYPE`.
 
-```yaml
-variables:
-  ENV_NAMES: "sdp-dev/env-1"
-  BG_MANAGE: "true"
-  BG_STATE: "{\"controllerNamespace\":\"bss-controller\",\"originNamespace\":{\"name\":\"bss-origin\",\"state\":\"active\",\"version\":\"v2.1.0\"},\"peerNamespace\":{\"name\":\"bss-peer\",\"state\":\"candidate\",\"version\":\"v2.2.0\"},\"updateTime\":\"2024-01-15T10:30:00Z\"}"
+```mermaid
+stateDiagram-v2
+    direction TB
+    state "ACTIVE + NONE" as Initial
+    state "ACTIVE + IDLE" as Stable
+    state "ACTIVE + CANDIDATE" as Candidate
+    state "LEGACY + ACTIVE" as Promoted
+    state "IDLE + ACTIVE" as Committed
+
+    Initial --> Stable: BGD_INIT
+    Stable --> Candidate: BGD_WARMUP
+    Candidate --> Promoted: BGD_PROMOTE
+    Promoted --> Committed: BGD_COMMIT or BGD_ROLLBACK
 ```
 
-**GitHub Actions example:**
+After `LEGACY + ACTIVE` → `IDLE + ACTIVE`, the former candidate stays active and the former active
+side becomes idle. The next `BGD_WARMUP` uses the mirrored rows in the table.
 
-```yaml
-ENV_NAMES: "sdp-dev/env-1"
-GH_ADDITIONAL_PARAMS: "BG_MANAGE=true,BG_STATE={\"controllerNamespace\":\"bss-controller\",\"originNamespace\":{\"name\":\"bss-origin\",\"state\":\"active\",\"version\":\"v2.1.0\"},\"peerNamespace\":{\"name\":\"bss-peer\",\"state\":\"candidate\",\"version\":\"v2.2.0\"},\"updateTime\":\"2024-01-15T10:30:00Z\"}"
-```
-
-The BG Plugin is expected to merge the pipeline parameters from `INSTANCE_PIPELINE_PARAMETERS` - a
-deployment parameter of the solution, consumed by the BG Plugin outside EnvGene - into the trigger
-call. For example, when `INSTANCE_PIPELINE_PARAMETERS` holds
-`ENV_NAMES: sdp-dev/env-1`, `CMDB_IMPORT: "true"`, and `DEPLOYMENT_TICKET_ID: "FAKE-000"`, the plugin
-triggers the pipeline with:
-
-```yaml
-variables:
-  ENV_NAMES: "sdp-dev/env-1"
-  BG_MANAGE: "true"
-  BG_STATE: "{\"controllerNamespace\":\"bss-controller\",\"originNamespace\":{\"name\":\"bss-origin\",\"state\":\"active\",\"version\":\"v2.1.0\"},\"peerNamespace\":{\"name\":\"bss-peer\",\"state\":\"candidate\",\"version\":\"v2.2.0\"},\"updateTime\":\"2024-01-15T10:30:00Z\"}"
-  CMDB_IMPORT: "true"
-  DEPLOYMENT_TICKET_ID: "FAKE-000"
-```
-
-## BG state files
-
-BG state files track which lifecycle state each of the origin and peer namespaces of a BG Domain is
-in. BG state files are empty marker files created and updated by the `bg_manage` job. When a state
-changes, the job removes the old state file and creates a new one with the updated state.
-
-The file location and naming pattern (`.<role>-<state>` in the environment root) are defined in
+**State files** are empty markers in `/environments/<cluster>/<env>/`. The file body has no
+content. Each role has at most one marker named `.<role>-<state>` (for example `.origin-active`,
+`.peer-idle`). On change, EnvGene removes the old marker and creates the new one. Who is origin
+and who is peer comes from `bg_domain.yml`. See
 [BG State Files](/docs/envgene-objects.md#bg-state-files).
 
-**Examples**:
+When no state files exist, the current pair is `(ACTIVE, NONE)` - the state before `BGD_INIT`.
+`BGD_INIT` is not mirrored.
 
-- `.origin-active` - the origin namespace is serving traffic
-- `.peer-candidate` - the peer namespace is prepared for promotion
-- `.origin-legacy` - the origin namespace was demoted after promotion
-- `.peer-idle` - the peer namespace is not in use
-- `.peer-failedw` - the peer namespace warmup operation failed
-- `.origin-failedc` - the origin namespace commit or promote operation failed
+| Operation                     | Cycle    | State files before                    | `(origin, peer)` before | `(origin, peer)` after | State files after                     | EnvGene actions              |
+|-------------------------------|----------|---------------------------------------|-------------------------|------------------------|---------------------------------------|------------------------------|
+| `BGD_INIT`                    | forward  | (none)                                | `(ACTIVE, NONE)`        | `(ACTIVE, IDLE)`       | `.origin-active`, `.peer-idle`        | State files only             |
+| `BGD_WARMUP`                  | forward  | `.origin-active`, `.peer-idle`        | `(ACTIVE, IDLE)`        | `(ACTIVE, CANDIDATE)`  | `.origin-active`, `.peer-candidate`   | State files + warmup actions |
+| `BGD_PROMOTE`                 | forward  | `.origin-active`, `.peer-candidate`   | `(ACTIVE, CANDIDATE)`   | `(LEGACY, ACTIVE)`     | `.origin-legacy`, `.peer-active`      | State files only             |
+| `BGD_COMMIT` / `BGD_ROLLBACK` | forward  | `.origin-legacy`, `.peer-active`      | `(LEGACY, ACTIVE)`      | `(IDLE, ACTIVE)`       | `.origin-idle`, `.peer-active`        | State files only             |
+| `BGD_WARMUP`                  | mirrored | `.origin-idle`, `.peer-active`        | `(IDLE, ACTIVE)`        | `(CANDIDATE, ACTIVE)`  | `.origin-candidate`, `.peer-active`   | State files + warmup actions |
+| `BGD_PROMOTE`                 | mirrored | `.origin-candidate`, `.peer-active`   | `(CANDIDATE, ACTIVE)`   | `(ACTIVE, LEGACY)`     | `.origin-active`, `.peer-legacy`      | State files only             |
+| `BGD_COMMIT` / `BGD_ROLLBACK` | mirrored | `.origin-active`, `.peer-legacy`       | `(ACTIVE, LEGACY)`      | `(ACTIVE, IDLE)`       | `.origin-active`, `.peer-idle`        | State files only             |
 
-### State transition validation
+The **State files before** column is the required input. EnvGene looks up the row for
+`OPERATION_TYPE` and the current markers. If no row matches, the step fails and leaves state files
+unchanged.
 
-The `bg_manage` job accepts a requested state change only when all of the following hold. On the
-first violated check, the job fails with an error describing the violation.
+`BGD_ROLLBACK` produces the same state files as `BGD_COMMIT`. The difference between a successful
+cycle and a revert is outside EnvGene.
 
-- **Namespace names.** `BG_STATE.originNamespace.name` and `BG_STATE.peerNamespace.name` equal the
-  matching names in the BG Domain object, and `BG_STATE.controllerNamespace` equals
-  `bg_domain.controllerNamespace.name`.
-- **Single state file per role.** At most one `.origin-<state>` and one `.peer-<state>` file exists
-  in the environment root.
-- **Known current state.** The `.origin-<state>` and `.peer-<state>` files form a state pair listed
-  in the transition table. When no state files exist, the job treats the current state as
-  `(ACTIVE, NONE)`.
-- **Allowed transition.** The state pair requested in `BG_STATE` is an allowed next state for the
-  current pair.
+## Warmup behaviour
 
-The table lists the allowed transitions as `(origin, peer)` state pairs. `NONE` means no state file
-exists for that namespace - the initial state before the Init domain operation.
+`BGD_WARMUP` is the only lifecycle operation that changes the Instance Repository beyond state
+files. See the [lifecycle transition table](#bg-domain-lifecycle) for required state files before
+and after.
 
-| Current state         | Next state            | Operation                  |
-|-----------------------|-----------------------|----------------------------|
-| `(ACTIVE, NONE)`      | `(ACTIVE, IDLE)`      | Init domain                |
-| `(ACTIVE, IDLE)`      | `(ACTIVE, CANDIDATE)` | Warmup                     |
-| `(ACTIVE, IDLE)`      | `(ACTIVE, FAILEDW)`   | Warmup failure             |
-| `(ACTIVE, IDLE)`      | `(ACTIVE, IDLE)`      | -                          |
-| `(ACTIVE, CANDIDATE)` | `(LEGACY, ACTIVE)`    | Promote                    |
-| `(ACTIVE, CANDIDATE)` | `(ACTIVE, FAILEDC)`   | Promote failure            |
-| `(ACTIVE, CANDIDATE)` | `(ACTIVE, IDLE)`      | -                          |
-| `(LEGACY, ACTIVE)`    | `(IDLE, ACTIVE)`      | Commit or rollback         |
-| `(LEGACY, ACTIVE)`    | `(FAILEDC, ACTIVE)`   | Commit or rollback failure |
-| `(ACTIVE, FAILEDW)`   | `(ACTIVE, CANDIDATE)` | Warmup retry               |
-| `(ACTIVE, FAILEDW)`   | `(ACTIVE, FAILEDW)`   | Warmup failure             |
-| `(ACTIVE, FAILEDC)`   | `(IDLE, ACTIVE)`      | -                          |
-| `(ACTIVE, FAILEDC)`   | `(ACTIVE, FAILEDC)`   | -                          |
+EnvGene:
 
-Every current state except `(ACTIVE, NONE)` also allows the mirrored transitions, with the origin
-and peer states swapped. The mirrored transitions cover the reverse flow: reverse warmup, reverse
-promote, and reverse commit.
+1. Copies the active namespace folder to the idle side that becomes candidate, including nested
+   [Application](/docs/envgene-objects.md#application) objects, and keeps the candidate Namespace
+   `name`.
+2. Sets `envTemplate.bgNsArtifacts.<candidate> := envTemplate.bgNsArtifacts.<active>` in
+   `Inventory/env_definition.yml` (preparing peer: `peer := origin`; preparing origin:
+   `origin := peer`).
+3. Updates state files as in the table.
 
-## Warmup operation
+`envTemplate.artifact` does not change. It renders the controller, plugin, and non-BG namespaces.
 
-Unlike other BG operations, `warmup` (forward flow) and `reverse warmup` (reverse flow) copy
-namespace contents.
+**Example** - forward `BGD_WARMUP`, mid-rollout (required state files before:
+`.origin-active`, `.peer-idle`):
 
-The `bg_manage` job syncs the namespace folders in the repository: it replaces the content of the
-candidate namespace folder with the content from the active namespace folder, including all nested
-`Application` objects and their files, but keeps the `name` attribute of the candidate namespace. As
-a result, the active and candidate namespace folders become identical except for the `name`
-attribute.
+```yaml
+# Before
+envTemplate:
+  artifact: "my-env-templates:2.0.0"
+  bgNsArtifacts:
+    origin: "my-env-templates:2.1.0"
+    peer: "my-env-templates:2.0.0"
 
-The copy runs only for the transition `(ACTIVE, IDLE)` to `(ACTIVE, CANDIDATE)` and its mirror. A
-warmup retried from the `FAILEDW` state updates state files only.
+# After - state files: .origin-active, .peer-candidate
+envTemplate:
+  artifact: "my-env-templates:2.0.0"
+  bgNsArtifacts:
+    origin: "my-env-templates:2.1.0"
+    peer: "my-env-templates:2.1.0"
+```
 
-During warmup the `bg_manage` job also updates the Environment Inventory (`env_definition.yml`):
-
-- Forward flow (warmup): copies `envTemplate.bgNsArtifacts.origin` to `envTemplate.bgNsArtifacts.peer`
-- Reverse flow (reverse warmup): copies `envTemplate.bgNsArtifacts.peer` to
-  `envTemplate.bgNsArtifacts.origin`
-
-The candidate namespace then uses the same template artifact version as the active namespace when it
-becomes active.
+Peer namespace folder content matches origin, except the peer Namespace `name`. For the mirrored row,
+origin is the candidate and the same rules apply with origin and peer swapped.
 
 ## CMDB import
 
-The CMDB import creates the [BG Domain](/docs/envgene-objects.md#bg-domain) in the CMDB, among other
-entities such as Cloud or Namespace. The import runs when the Instance pipeline is started with
-[`CMDB_IMPORT: true`](/docs/instance-pipeline-parameters.md#cmdb_import).
-
-> [!NOTE]
-> Integration with a CMDB system is not part of EnvGene Core.
+When [`CMDB_IMPORT: true`](/docs/instance-pipeline-parameters.md#cmdb_import), the Instance pipeline
+imports the [BG Domain](/docs/envgene-objects.md#bg-domain) into the CMDB with other entities such as
+Cloud and Namespace.
 
 ## BG-related parameters in Effective Set
 
-When a BG Domain object is part of an Environment Instance, EnvGene adds BG-specific parameters to
-the Effective Set Topology Context: the domain structure goes to `parameters.yaml`, and the resolved
-controller credentials go to `credentials.yaml`. EnvGene replaces the credentials reference with the
-actual credentials value and removes the `credentials` attribute. The credentials must be of type
-`usernamePassword`.
+When the Environment has a BG Domain, EnvGene adds its structure to the Effective Set Topology
+Context `parameters.yaml` and resolved controller credentials to `credentials.yaml`. EnvGene
+replaces the credentials reference with the value and removes the `credentials` attribute.
+Credentials must be `usernamePassword`.
 
 See the
-[Effective Set](/docs/features/calculator-cli.md#version-20topology-context-bg_domain-example)
-documentation for the `bg_domain` context example.
+[`bg_domain` Topology Context example](/docs/features/calculator-cli.md#version-20topology-context-bg_domain-example).
 
 ## BG-related macros
 
-Calculator command-line tool macros that read the BG Domain object when one exists in the
-Environment:
+Macros that read the BG Domain when it exists:
 
 - [`ORIGIN_NAMESPACE`](/docs/template-macros.md#origin_namespace)
 - [`PEER_NAMESPACE`](/docs/template-macros.md#peer_namespace)
@@ -283,6 +282,11 @@ Environment:
 - [Migrate to Blue-Green Deployment](/docs/how-to/blue-green-deployment-migration.md)
 - [Blue-Green Deployment deploy operations](/docs/how-to/blue-green-deployment-deploy-operations.md)
 - [Blue-Green Deployment Use Cases](/docs/use-cases/blue-green-deployment.md)
-- [Namespace Render Filter](/docs/features/namespace-render-filtering.md)
+- [Namespace map](/docs/tech/namespace-map.md)
+- [Namespace render filtering](/docs/features/namespace-render-filtering.md)
 - [BG Domain object](/docs/envgene-objects.md#bg-domain)
+- [BG Domain Template](/docs/envgene-objects.md#bg-domain-template)
+- [BG Domain from Composite Structure](/docs/features/bg-domain-from-composite-structure.md)
+- [BG State Files](/docs/envgene-objects.md#bg-state-files)
+- [Namespace map object](/docs/envgene-objects.md#namespace-map)
 - [BGD samples](/docs/samples/blue-green-deployment/)

--- a/docs/features/calculator-cli.md
+++ b/docs/features/calculator-cli.md
@@ -18,7 +18,7 @@
       - [\[Version 2.0\] Effective Set Structure](#version-20-effective-set-structure)
       - [\[Version 2.0\] Parameter type conversion](#version-20-parameter-type-conversion)
       - [\[Version 2.0\] Service Inclusion Criteria and Naming Convention](#version-20-service-inclusion-criteria-and-naming-convention)
-      - [\[Version 2.0\] deployPostfix Matching Logic](#version-20-deploypostfix-matching-logic)
+      - [\[Version 2.0\] Deployment Plan namespace matching](#version-20-deployment-plan-namespace-matching)
       - [\[Version 2.0\] Handling Missing Attributes in SBOM](#version-20-handling-missing-attributes-in-sbom)
       - [\[Version 2.0\] App chart validation](#version-20-app-chart-validation)
       - [\[Version 2.0\] Sensitive parameter processing](#version-20-sensitive-parameter-processing)
@@ -367,18 +367,25 @@ It includes components from the Application SBOM with these `mime-type`:
 
 The service name is derived from the `name` attribute of the Application SBOM component.
 
-#### [Version 2.0] deployPostfix Matching Logic
+#### [Version 2.0] Deployment Plan namespace matching
 
-When processing the Solution Descriptor (SD), the Calculator matches the `deployPostfix` value from each `application` element in the SD to the corresponding Namespace folder in the Environment Instance. This matching logic applies to all contexts that use SD data (Deployment, Runtime, etc.).
+When the Calculator processes a
+[Deployment Plan](/docs/envgene-objects.md#deployment-plan), it matches each plan entry to a
+Namespace in the Environment Instance by equality:
 
-The matching logic is as follows:
+```text
+deploy-plan[].namespace == Namespace.name
+```
 
-- First, attempts an exact match: finds a Namespace folder whose name exactly matches the `deployPostfix` value from the SD.
-- If no exact match is found, attempts to find a Namespace folder that is part of a BG Domain:
-  - Checks for a match with `deployPostfix` + `-origin` suffix **only** for namespaces that are part of a BG Domain with role `origin`
-  - Checks for a match with `deployPostfix` + `-peer` suffix **only** for namespaces that are part of a BG Domain with role `peer`
+This rule applies to every Namespace. For non-BG environments it is equivalent to the previous
+matching by `deployPostfix`. For [BG Domain](/docs/envgene-objects.md#bg-domain) Namespaces it
+removes ambiguity when origin and peer share one `deployPostfix`: the plan already carries the
+chosen Namespace `name` from the [Namespace map resolver](/docs/tech/namespace-map.md).
 
-This allows matching `deployPostfix` values from SD with Namespace folder names that include suffixes for BG Domain namespaces, as described in [Namespace Folder Name Generation](/docs/features/environment-instance-generation.md#namespace-folder-name-generation).
+After a match:
+
+- the Effective Set path segment is the Namespace folder name under `Namespaces/` (for example
+  `bss-origin` or `bss-peer`), taken from the matched Environment Instance folder
 
 #### [Version 2.0] Handling Missing Attributes in SBOM
 

--- a/docs/features/environment-instance-generation.md
+++ b/docs/features/environment-instance-generation.md
@@ -119,7 +119,7 @@ In this example:
 
 ## Related Features
 
-- [Namespace Render Filter](/docs/features/namespace-render-filtering.md) - Select which Namespaces to render in a specific pipeline run
+- [Namespace render filtering](/docs/features/namespace-render-filtering.md) - Render only Namespaces selected from the Solution Descriptor via Namespace map
 - [Namespace Filtering in Template Descriptor](/docs/features/namespace-filtering-in-template-descriptor.md) - Filter which Namespaces are included in Environment structure during Template Descriptor rendering
 - [Blue-Green Deployment](/docs/features/blue-green-deployment.md) - BG domains and state management
 - [Effective Set Calculator](/docs/features/calculator-cli.md) - Uses folder names for effective set structure

--- a/docs/features/namespace-filtering-in-template-descriptor.md
+++ b/docs/features/namespace-filtering-in-template-descriptor.md
@@ -81,12 +81,15 @@ If a namespace is disabled by a condition:
 - The namespace does **not** appear in the Effective Set
 
 > [!NOTE]
-> If you are using `NS_BUILD_FILTER`, keep in mind that this parameter only limits which namespaces are processed during a specific pipeline run — it does not add namespaces to the Environment structure.
+> [Namespace render filtering](/docs/features/namespace-render-filtering.md) only limits which
+> Namespaces `env_build` re-renders in a specific pipeline run. It does not add Namespaces to the
+> Environment structure.
 >
-> If a namespace is excluded during Template Descriptor rendering (Jinja condition = `false`), it will not be generated and will not appear in the Instance Repository or Effective Set.
+> If a Namespace is excluded during Template Descriptor rendering (Jinja condition = `false`), it is
+> not generated and does not appear in the Instance Repository or Effective Set.
 >
-> Therefore, such a namespace cannot be processed via `NS_BUILD_FILTER`, because it does not exist in the Environment model.
-> For details about `NS_BUILD_FILTER` syntax and usage, see: [Namespace Render Filter](../features/namespace-render-filtering.md)
+> Therefore such a Namespace cannot be selected through the Solution Descriptor and Namespace map,
+> because it does not exist in the Environment model.
 
 ## How-To
 

--- a/docs/features/namespace-render-filtering.md
+++ b/docs/features/namespace-render-filtering.md
@@ -1,82 +1,115 @@
-# Namespace Render Filter
+# Namespace render filtering
+
+- [Namespace render filtering](#namespace-render-filtering)
+  - [Description](#description)
+  - [Flow](#flow)
+  - [Behaviour](#behaviour)
+  - [Role of `BG_NS_TARGET`](#role-of-bg_ns_target)
+  - [Examples](#examples)
+    - [One ordinary Namespace](#one-ordinary-namespace)
+    - [Several applications](#several-applications)
+    - [Template Namespaces outside the SD](#template-namespaces-outside-the-sd)
+    - [BG Domain origin or peer](#bg-domain-origin-or-peer)
+    - [No Solution Descriptor](#no-solution-descriptor)
+  - [Error handling](#error-handling)
+  - [Related documentation](#related-documentation)
 
 ## Description
 
-Namespace render filter feature lets select which Environment [Namespaces](/docs/envgene-objects.md#namespace) will be rendered. It does not affect rendering of other objects like cloud or tenant.
+When a pipeline run supplies a [Solution Descriptor](/docs/envgene-objects.md#solution-descriptor)
+(SD), EnvGene limits which Environment [Namespaces](/docs/envgene-objects.md#namespace) `env_build`
+re-renders. Cloud, Tenant, and other non-Namespace objects are still rendered.
 
-This feature uses the [`NS_BUILD_FILTER`](/docs/instance-pipeline-parameters.md#parameters) Instance pipeline parameter. This parameter is used during the Environment Instance generation in the `env_build` job.
+Selection is automatic. EnvGene does not accept a manual Namespace render filter parameter.
 
-It allows to generate or update only specific Namespaces without touching the others. This is useful, for example, in Blue-Green deployment scenarios.
+The selection answers which Namespaces `env_build` may rewrite. Resolution of SD
+[`deployPostfix`](/docs/glossary.md#deploy-postfix) values to Namespace `name` values belongs to
+[Namespace map](/docs/tech/namespace-map.md).
 
-## Syntax
+## Flow
 
-You can set the value of `NS_BUILD_FILTER` in two ways:
-
-### BG Domain role aliases
-
-You can use BG Domain role aliases as namespace selectors:
-
-- `@controller` - controller namespace
-- `@origin` - origin namespace  
-- `@peer` - peer namespace
-
-EnvGene resolves these aliases using the [BG Domain](/docs/envgene-objects.md#bg-domain) object. To use aliases, the BG Domain object must exist in the Environment.
-
-### Direct namespace names
-
-You can specify the namespace name directly, as defined in the `name` attribute of the Namespace object:
-
-- `env-name-api` - full namespace name
-
-### Operators
-
-The following operators are available:
-
-- `!` - exclusion operator. When used at the beginning, it excludes the specified namespaces from processing. **Important**: The `!` operator applies to the entire expression, not to individual namespaces within a comma-separated list.
-- `,` - multiple selection operator. Separates multiple namespace selectors
-
-## Usage examples
-
-### Update all except the peer NS
-
-```yaml
-NS_BUILD_FILTER: "! @peer"
-# or
-NS_BUILD_FILTER: "! env-name-peer"
+```text
+Solution Descriptor
+    → Namespace map
+    → list of selected Namespace.name values
+    → env_build
+    → render only the selected Namespaces
 ```
 
-### Update only the peer NS
+1. The run supplies an SD (applications and their `deployPostfix` values).
+2. `compute_namespace_map` builds [`namespace-map.yml`](/docs/envgene-objects.md#namespace-map) and
+   resolves each relevant `deployPostfix` to a Namespace `name`. For a
+   [BG Domain](/docs/envgene-objects.md#bg-domain),
+   [`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target) selects origin or peer at
+   map-build time.
+3. EnvGene passes the resulting list of Namespace `name` values into `env_build`.
+4. `env_build` re-renders only those Namespaces. It does not re-derive `deployPostfix` →
+   Namespace `name`, and it does not convert `BG_NS_TARGET` into a render filter expression.
+
+## Behaviour
+
+| Situation                                                         | Result                                              |
+|-------------------------------------------------------------------|-----------------------------------------------------|
+| SD has one ordinary Namespace                                     | Only that Namespace is rendered                     |
+| SD has several applications                                       | Every Namespace mapped from those apps is rendered  |
+| Environment Template has Namespaces not referenced by the SD      | Those Namespaces are not rendered                   |
+| BG Domain and `BG_NS_TARGET=origin`                                | Namespace map selects origin; only origin is rendered |
+| BG Domain and `BG_NS_TARGET=peer`                                  | Namespace map selects peer; only peer is rendered   |
+| No SD for the run, and the process supports that scenario         | All Namespaces are rendered (unchanged default)     |
+
+## Role of `BG_NS_TARGET`
+
+[`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target) is an input to Namespace map
+resolution when origin and peer share a `deployPostfix`. It is not a render filter and is not
+translated into `@origin` or `@peer` selectors for `env_build`.
+
+After the map contains concrete Namespace `name` values, `env_build` uses only that list.
+
+## Examples
+
+### One ordinary Namespace
+
+SD applications use `deployPostfix: core`. The map contains `core: env-1-core`. `env_build`
+renders only `env-1-core`.
+
+### Several applications
+
+SD applications use `deployPostfix` values `core` and `bss`. The map resolves both. `env_build`
+renders the corresponding Namespace `name` values.
+
+### Template Namespaces outside the SD
+
+The Environment Template also defines a Namespace that no SD application maps to. That Namespace is
+not rendered in this run.
+
+### BG Domain origin or peer
+
+Pipeline:
 
 ```yaml
-NS_BUILD_FILTER: "@peer"
-# or
-NS_BUILD_FILTER: "env-name-peer"
+BG_NS_TARGET: peer
 ```
 
-### Update all
+SD applications use `deployPostfix: bss`. The map writes `bss: env-1-bss-peer`. `env_build`
+renders only `env-1-bss-peer`. The origin Namespace is left unchanged.
 
-```yaml
-NS_BUILD_FILTER: ""
-# or
-NS_BUILD_FILTER is not provided
-```
+With `BG_NS_TARGET: origin`, the map writes `bss: env-1-bss-origin` and `env_build` renders only
+that Namespace.
 
-### Multiple selection
+### No Solution Descriptor
 
-```yaml
-# Update controller and origin
-NS_BUILD_FILTER: "@peer,@origin"
+When the run does not supply an SD and that scenario is supported, EnvGene renders all Namespaces.
 
-# Update all except peer and controller
-NS_BUILD_FILTER: "! @peer,@controller"
+## Error handling
 
-# Update specific namespaces by name
-NS_BUILD_FILTER: "env-name-api,env-name-frontend"
-```
+Unmapped or BG-ambiguous `deployPostfix` values follow the
+[Namespace map validation](/docs/tech/namespace-map.md#validation) policy. `env_build` does not add
+a separate duplicate error path for the same cases.
 
-Mixed use of aliases and names is not allowed
+## Related documentation
 
-## Error Handling
-
-- Invalid/non-existent namespace names: Pipeline fails
-- Missing BG Domain: Pipeline fails when using aliases without BG Domain
+- [`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target)
+- [Namespace map](/docs/tech/namespace-map.md)
+- [Solution Descriptor](/docs/envgene-objects.md#solution-descriptor)
+- [Blue-Green Deployment](/docs/features/blue-green-deployment.md)
+- [Blue-Green Deployment deploy operations](/docs/how-to/blue-green-deployment-deploy-operations.md)

--- a/docs/how-to/blue-green-deployment-deploy-operations.md
+++ b/docs/how-to/blue-green-deployment-deploy-operations.md
@@ -15,12 +15,19 @@
 
 An Instance pipeline run is part of a
 [Blue-Green Deployment (BGD)](/docs/features/blue-green-deployment.md) deploy operation: it
-regenerates the configuration of the selected namespaces so a new application version can be deployed
-there. Three inputs control the run:
+regenerates the configuration of the Namespaces that belong to the applications in the current
+[Solution Descriptor](/docs/envgene-objects.md#solution-descriptor) (SD) so a new application version
+can be deployed there. Three inputs control the run:
 
-- which namespaces are regenerated (`NS_BUILD_FILTER`)
+- which Namespaces are regenerated (automatic selection from the SD via
+  [Namespace map](/docs/tech/namespace-map.md) and
+  [Namespace render filtering](/docs/features/namespace-render-filtering.md))
 - which template artifact version renders them
 - what the run produces: the Effective Set (`GENERATE_EFFECTIVE_SET`) or a CMDB import (`CMDB_IMPORT`)
+
+For a BG Domain side, also set
+[`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target) so the Namespace map binds each
+shared `deployPostfix` to origin or peer. `BG_NS_TARGET` is not a render filter.
 
 The right combination depends on the target - the origin/peer pair, the controller namespace, or a
 non-BG namespace. The deploy orchestrator passes these parameters when it triggers the pipeline. Set
@@ -35,49 +42,48 @@ Working examples are in [`/docs/samples/blue-green-deployment/`](/docs/samples/b
 
 ## Deploy operations
 
-[`NS_BUILD_FILTER`](/docs/features/namespace-render-filtering.md) selects the namespaces to
-regenerate, by name or by BG Domain role alias:
-
-- `@origin` - origin namespace
-- `@peer` - peer namespace
-- `@controller` - controller namespace
+When the run supplies an SD, EnvGene resolves application
+[`deployPostfix`](/docs/glossary.md#deploy-postfix) values through the Namespace map and
+`env_build` re-renders only the resulting Namespace `name` values. See
+[Namespace render filtering](/docs/features/namespace-render-filtering.md).
 
 The examples below show the Effective Set flow. For the CMDB import flow, replace
 `GENERATE_EFFECTIVE_SET` with `CMDB_IMPORT: "true"`.
 
 > [!NOTE]
-> On the GitHub pipeline, `NS_BUILD_FILTER`, `ENV_TEMPLATE_VERSION_ORIGIN`, and
-> `ENV_TEMPLATE_VERSION_PEER` have no dedicated workflow inputs. Pass them through
+> On the GitHub pipeline, `BG_NS_TARGET` and related template-version overrides have no dedicated
+> workflow inputs. Pass them through
 > [`GH_ADDITIONAL_PARAMS`](/docs/instance-pipeline-parameters.md#gh_additional_params).
 
 ### Deploy in origin or peer namespace
 
-EnvGene regenerates the selected BG-role namespace from a template artifact version and recalculates
-its parameters. The other role's namespace is untouched. Either namespace can be the deploy target:
-origin and peer swap the `active` and `candidate`
-[BG states](/docs/features/blue-green-deployment.md#bg-state-files) from release to release.
+EnvGene regenerates the BG-role Namespace selected by the Namespace map from a template artifact
+version and recalculates its parameters. The other role's Namespace is untouched. Either Namespace
+can be the deploy target: origin and peer swap the `active` and `candidate`
+[BG states](/docs/features/blue-green-deployment.md#state-storage) from release to release.
 
 1. Choose the template artifact version that renders the namespace, one of:
 
    - Persist it in the Environment Inventory: `envTemplate.bgNsArtifacts.origin` or
      `envTemplate.bgNsArtifacts.peer`.
-   - Set the pipeline parameter
-     `ENV_TEMPLATE_VERSION_ORIGIN`
-     or `ENV_TEMPLATE_VERSION_PEER`
-     for this run. EnvGene writes the value into the matching `bgNsArtifacts` field.
+   - Set [`ENV_TEMPLATE_VERSION`](/docs/instance-pipeline-parameters.md#env_template_version) together
+     with [`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target) `origin` or `peer` for
+     this run. EnvGene writes the value into the matching `bgNsArtifacts` field.
 
    When neither is set, the namespace renders from the common `envTemplate.artifact`.
 
-2. Run the Instance pipeline with the role alias:
+2. Run the Instance pipeline with the SD for the applications to deploy and the BG side:
 
    ```yaml
    ENV_NAMES: "<cluster-name>/<environment-name>"
    ENV_BUILDER: "true"
-   NS_BUILD_FILTER: "@peer"
+   SD_SOURCE_TYPE: artifact
+   SD_VERSION: "<application>:<version>"
+   BG_NS_TARGET: peer
    GENERATE_EFFECTIVE_SET: "true"
    ```
 
-   For the origin namespace, set `NS_BUILD_FILTER: "@origin"`.
+   For the origin namespace, set `BG_NS_TARGET: origin`.
 
 3. Confirm that only the target namespace folder changed (for example `Namespaces/bss-peer/`). The
    other role's folder stays as it was.
@@ -90,23 +96,17 @@ The descriptor layout behind the origin/peer pair is set up once during migratio
 Namespaces outside the BG Domain (no origin/peer pair, no BG state files) always render from
 `envTemplate.artifact`.
 
-1. Run the Instance pipeline selecting the namespace by name:
+1. Run the Instance pipeline with an SD whose applications map to that Namespace:
 
    ```yaml
    ENV_NAMES: "<cluster-name>/<environment-name>"
    ENV_BUILDER: "true"
-   NS_BUILD_FILTER: "<namespace-name>"
+   SD_SOURCE_TYPE: artifact
+   SD_VERSION: "<application>:<version>"
    GENERATE_EFFECTIVE_SET: "true"
    ```
 
-   Or regenerate everything except the BG roles with
-   `NS_BUILD_FILTER: "! @peer,@origin,@controller"`.
-
-2. Confirm that only the selected namespace folders changed.
-
-> [!NOTE]
-> Mixed alias and direct name selectors in one `NS_BUILD_FILTER` expression are not allowed. See
-> [Namespace Render Filter](/docs/features/namespace-render-filtering.md#multiple-selection).
+2. Confirm that only the Namespace folders selected through the Namespace map changed.
 
 ### Deploy in controller namespace
 
@@ -114,34 +114,35 @@ The controller namespace always renders from `envTemplate.artifact`, not from `b
 mapping in `bg_domain.yml` is set up once during migration - see
 [Migrate to Blue-Green Deployment, Step 2](/docs/how-to/blue-green-deployment-migration.md#step-2-add-the-bg-domain-template).
 
-1. Run the Instance pipeline with the role alias:
+1. Run the Instance pipeline with an SD whose applications map to the controller Namespace through
+   the Namespace map:
 
    ```yaml
    ENV_NAMES: "<cluster-name>/<environment-name>"
    ENV_BUILDER: "true"
-   NS_BUILD_FILTER: "@controller"
+   SD_SOURCE_TYPE: artifact
+   SD_VERSION: "<application>:<version>"
    GENERATE_EFFECTIVE_SET: "true"
    ```
 
-2. Confirm that only the `Namespaces/bg-controller/` folder changed, and that
+2. Confirm that only the controller Namespace folder changed, and that
    `bg_domain.controllerNamespace.credentials` exists in the generated Credentials file (EnvGene
    creates it during generation).
 
 > [!NOTE]
-> `bg-plugin` is not part of the BG Domain, so `@controller` does not select it. Regenerate it by
-> namespace name, as for any non-BG namespace.
+> `bg-plugin` is not part of the BG Domain. Regenerate it the same way as any non-BG Namespace:
+> supply an SD whose applications map to that Namespace.
 
 ## Deploy operation summary
 
-| Deploy operation     | Namespace role        | Rendered from          | Typical `NS_BUILD_FILTER` |
-|----------------------|-----------------------|------------------------|---------------------------|
-| Deploy in peer       | `peerNamespace`       | `bgNsArtifacts.peer`   | `@peer`                   |
-| Deploy in origin     | `originNamespace`     | `bgNsArtifacts.origin` | `@origin`                 |
-| Deploy non-BG        | Not in BG Domain      | `artifact`             | `<namespace-name>`        |
-| Deploy in controller | `controllerNamespace` | `artifact`             | `@controller`             |
+| Deploy operation     | Namespace role        | Rendered from          | Side / selection input                          |
+|----------------------|-----------------------|------------------------|-------------------------------------------------|
+| Deploy in peer       | `peerNamespace`       | `bgNsArtifacts.peer`   | SD apps + `BG_NS_TARGET: peer`                  |
+| Deploy in origin     | `originNamespace`     | `bgNsArtifacts.origin` | SD apps + `BG_NS_TARGET: origin`                |
+| Deploy non-BG        | Not in BG Domain      | `artifact`             | SD apps via Namespace map                       |
+| Deploy in controller | `controllerNamespace` | `artifact`             | SD apps via Namespace map                       |
 
-When `bgNsArtifacts` is not set, origin and peer render from `artifact`. Non-BG namespaces can also
-be selected by exclusion: `! @peer,@origin,@controller`.
+When `bgNsArtifacts` is not set, origin and peer render from `artifact`.
 
 ## Pipeline parameters by deploy operation
 
@@ -168,6 +169,7 @@ For BG lifecycle operations (warmup, promote, commit), see
 - [Blue-Green Deployment (feature)](/docs/features/blue-green-deployment.md)
 - [Blue-Green Deployment Use Cases](/docs/use-cases/blue-green-deployment.md)
 - [Environment Instance Generation](/docs/features/environment-instance-generation.md)
-- [Namespace Render Filter](/docs/features/namespace-render-filtering.md)
+- [Namespace render filtering](/docs/features/namespace-render-filtering.md)
+- [Namespace map](/docs/tech/namespace-map.md)
 - [BG Domain object](/docs/envgene-objects.md#bg-domain)
 - [BGD samples](/docs/samples/blue-green-deployment/)

--- a/docs/how-to/blue-green-deployment-deploy-operations.md
+++ b/docs/how-to/blue-green-deployment-deploy-operations.md
@@ -60,7 +60,7 @@ The examples below show the Effective Set flow. For the CMDB import flow, replac
 EnvGene regenerates the BG-role Namespace selected by the Namespace map from a template artifact
 version and recalculates its parameters. The other role's Namespace is untouched. Either Namespace
 can be the deploy target: origin and peer swap the `active` and `candidate`
-[BG states](/docs/features/blue-green-deployment.md#state-storage) from release to release.
+[BG states](/docs/features/blue-green-deployment.md#bg-domain-lifecycle) from release to release.
 
 1. Choose the template artifact version that renders the namespace, one of:
 

--- a/docs/tech/README.md
+++ b/docs/tech/README.md
@@ -1,0 +1,14 @@
+# Technical documentation
+
+This directory holds implementer-facing technical contracts for EnvGene: resolution algorithms,
+internal pipeline artefacts, and validation rules that do not belong in user-facing feature
+explanations.
+
+Use a feature document under `/docs/features/` for the problem statement and product behaviour.
+Use an object entry under `/docs/envgene-objects.md` for the authored or generated file shape.
+Put the detailed algorithm here and link both ways.
+
+## Documents
+
+- [Namespace map](/docs/tech/namespace-map.md) - How `compute_namespace_map` resolves
+  `deployPostfix` to a Namespace `name`, including Blue-Green Domain sides

--- a/docs/tech/namespace-map.md
+++ b/docs/tech/namespace-map.md
@@ -1,0 +1,155 @@
+# Namespace map
+
+- [Namespace map](#namespace-map)
+  - [Description](#description)
+  - [Namespace map file](#namespace-map-file)
+  - [Resolution without a BG Domain](#resolution-without-a-bg-domain)
+  - [Resolution with a BG Domain](#resolution-with-a-bg-domain)
+  - [Role of `BG_NS_TARGET`](#role-of-bg_ns_target)
+  - [Consumers](#consumers)
+  - [Validation](#validation)
+
+## Description
+
+This document is the technical contract for `compute_namespace_map`. For the file shape, see
+[Namespace map object](/docs/envgene-objects.md#namespace-map).
+
+The namespace map resolves a
+[`deployPostfix`](/docs/glossary.md#deploy-postfix) from a
+[Solution Descriptor](/docs/envgene-objects.md#solution-descriptor) (or an equivalent application
+list) to the [Namespace](/docs/envgene-objects.md#namespace) `name` in the Environment Instance.
+
+EnvGene builds the map in `compute_namespace_map` and writes
+[`namespace-map.yml`](/docs/envgene-objects.md#namespace-map). Downstream components consume the file.
+They do not re-derive Blue-Green (BG) roles from pipeline parameters.
+
+In a [BG Domain](/docs/envgene-objects.md#bg-domain), origin and peer Namespaces often share one
+`deployPostfix` while their Namespace `name` values differ. The map uses
+[`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target) to choose which side to bind.
+
+`BG_NS_TARGET` names the static BG Domain role (`origin` or `peer`). It is not a lifecycle state such
+as `ACTIVE`, `IDLE`, or `CANDIDATE`. Namespace-map resolution does not read BG state files.
+
+## Namespace map file
+
+**Location:** `/environments/<cluster-name>/<environment-name>/Inventory/namespace-map.yml`
+
+Flat map:
+
+```yaml
+<deployPostfix>: <namespace-name>
+```
+
+Example without a BG Domain:
+
+```yaml
+core: env-1-core
+bss: env-1-bss
+```
+
+Example with a BG Domain and [`BG_NS_TARGET: peer`](/docs/instance-pipeline-parameters.md#bg_ns_target):
+
+```yaml
+bss: env-1-bss-peer
+```
+
+The map value is the `name` field from `Namespaces/<folder>/namespace.yml`, not the folder name
+alone. For BG origin and peer folders the folder name is typically
+`<deployPostfix>-origin` or `<deployPostfix>-peer`. See
+[Namespace Folder Name Generation](/docs/features/environment-instance-generation.md#namespace-folder-name-generation).
+
+## Resolution without a BG Domain
+
+Each `deployPostfix` maps to exactly one Namespace `name`.
+[`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target) is not required.
+
+## Resolution with a BG Domain
+
+1. EnvGene lists Environment Namespaces and reads the BG Domain object.
+2. For each Namespace it derives the `deployPostfix` (folder name without a trailing
+   `-origin` or `-peer` suffix when the Namespace is an origin or peer member).
+3. It compares the Namespace `name` to `originNamespace.name` and `peerNamespace.name` in
+   the BG Domain.
+4. When a `deployPostfix` matches both origin and peer members:
+   - [`BG_NS_TARGET`](/docs/instance-pipeline-parameters.md#bg_ns_target) must be `origin` or `peer`
+   - the map entry uses `originNamespace.name` or `peerNamespace.name` for that role
+5. Namespaces that are not origin or peer members (including the controller) keep a one-to-one
+   mapping and do not require `BG_NS_TARGET`.
+
+### Peer example
+
+Pipeline:
+
+```yaml
+BG_NS_TARGET: peer
+```
+
+Solution Descriptor applications use:
+
+```yaml
+deployPostfix: bss
+```
+
+BG Domain:
+
+```yaml
+originNamespace:
+  name: env-1-bss-origin
+peerNamespace:
+  name: env-1-bss-peer
+```
+
+Resulting map entry:
+
+```yaml
+bss: env-1-bss-peer
+```
+
+### Origin example
+
+With the same BG Domain and `BG_NS_TARGET: origin`:
+
+```yaml
+bss: env-1-bss-origin
+```
+
+## Role of `BG_NS_TARGET`
+
+| Situation                                       | `BG_NS_TARGET`                 |
+|-------------------------------------------------|--------------------------------|
+| No BG Domain                                    | Not required                   |
+| `deployPostfix` not shared by origin/peer     | Not required for that postfix  |
+| One `deployPostfix` shared by origin and peer | Mandatory (`origin` or `peer`) |
+| Invalid value                                   | Pipeline fails                 |
+
+The Solution Descriptor keeps the `deployPostfix` only. It does not store `BG_NS_TARGET` and does
+not name `originNamespace.name` or `peerNamespace.name`.
+
+## Consumers
+
+- **Deployment Plan Generator** reads `namespace-map.yml` and sets the `namespace` field on each
+  Deployment Plan entry from `deployPostfix`. It does not interpret `BG_NS_TARGET` again.
+- **Effective Set Calculator** matches each Deployment Plan entry to a Namespace by
+  `deploy-plan[].namespace == Namespace.name`. See
+  [Deployment Plan namespace matching](/docs/features/calculator-cli.md#version-20-deployment-plan-namespace-matching).
+  It does not read `BG_NS_TARGET`.
+- **`env_build`** receives the selected Namespace `name` values from the map when a Solution
+  Descriptor is supplied for the run, and re-renders only those Namespaces. See
+  [Namespace render filtering](/docs/features/namespace-render-filtering.md).
+- Other modern-pipeline steps that need `deployPostfix` → Namespace `name` use the same map.
+
+## Validation
+
+EnvGene fails `compute_namespace_map` when:
+
+- a `deployPostfix` matches both BG origin and peer and `BG_NS_TARGET` is missing
+- `BG_NS_TARGET` is set to a value other than `origin` or `peer`
+- the selected BG Domain role has no matching Namespace in the Environment Instance
+- the BG Domain configuration is incomplete or ambiguous for the Namespaces being mapped
+
+Example error intent:
+
+```text
+BG_NS_TARGET is required to resolve deployPostfix 'bss': both origin and peer Namespaces
+belong to the BG Domain.
+```

--- a/docs/use-cases/calculator-cli.md
+++ b/docs/use-cases/calculator-cli.md
@@ -34,7 +34,7 @@ This document covers use cases for [Calculator CLI](/docs/features/calculator-cl
 
 ## deployPostfix Matching Logic
 
-This section covers use cases for [deployPostfix Matching Logic](/docs/features/calculator-cli.md#version-20-deploypostfix-matching-logic). The matching logic matches `deployPostfix` values from Solution Descriptor(SD) to Namespace folders in Environment Instance.
+This section covers use cases for [deployPostfix Matching Logic](/docs/features/calculator-cli.md#version-20-deployment-plan-namespace-matching). The matching logic matches `deployPostfix` values from Solution Descriptor(SD) to Namespace folders in Environment Instance.
 
 ### UC-CC-DP-1: Exact Match
 


### PR DESCRIPTION
## Summary

Re-homes the Blue-Green design docs from **#1671** onto `feature/modern-toolset`. #1671 was branched off `main`
and diverged too much for a base swap (a simple retarget inflated the diff to 300+ files), so the doc changes were
brought over onto a fresh branch off `feature/modern-toolset`.

Brings the BGD design: `OPERATION_TYPE` `BGD_*` lifecycle, shared `BG_NS_TARGET`, namespace map contract
(`/docs/tech/namespace-map.md`), namespace render filtering, standalone `bg_domain.yml` from Composite Structure,
and calculator DP-match-by-`Namespace.name`.

## Conflict resolution

- Shared docs (`envgene-objects`, `envgene-pipelines`, `blue-green-deployment`, `blue-green-deployment-deploy-operations`)
  resolved to #1671's newer design.
- **`instance-pipeline-parameters.md` kept as `feature/modern-toolset`'s version** (its BGD params, including the
  live `BG_STATE` section). #1671's rewrite of this file was not brought - the merge was too divergent and #1671
  marks `BG_STATE` deprecated, which conflicts with the current code. All anchors referenced by the brought docs
  exist in the kept version (verified, no broken links).

## Related

- Supersedes the base of #1671 for the modern-toolset line. **#1671 stays open** (still targets `main`).
- Related issues: #1656, #1662, #1673, #1674, #1678, #1679.

## Breaking Change?

- [ ] Yes
- [x] No (documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)