### PR TITLE
docs: cloud passport single-file auto-association fallback (from #1665)

### DIFF
--- a/docs/features/cloud-passport-processing.md
+++ b/docs/features/cloud-passport-processing.md
@@ -155,9 +155,14 @@ The system looks for a default passport in the env's parent (cluster) directory,
 
 1. `cloud-passport/<cluster-name>.{yml|yaml}` (a file named after the cluster directory)
 2. `cloud-passport/passport.{yml|yaml}` (the recommended default name)
+3. The single passport file in `cloud-passport/`. When the directory holds exactly one passport file
+   (any `<name>.{yml|yaml}` that is not a `-creds` file), that file is used regardless of its name.
 
 Name the default passport `passport.yml` so it auto-associates regardless of the cluster directory name.
-If neither file exists, no passport is applied and generation continues without one.
+If `cloud-passport/` holds more than one passport file and none matched by name in steps 1 and 2,
+generation fails with an ambiguous-passport error that lists the candidates. Set
+`inventory.cloudPassport` to select one. If `cloud-passport/` holds no passport file, no passport is
+applied and generation continues without one.
 
 ### Resolution summary
 
@@ -166,8 +171,12 @@ Decision flow:
 1. `cloudPassport` set → bottom-up search for `<name>.{yml|yaml}`. Resolved on exactly one match.
    Generation fails on zero matches (not-found) or multiple matches (duplicate).
 2. `cloudPassport` absent → try `cloud-passport/<cluster-name>.{yml|yaml}`, then
-   `cloud-passport/passport.{yml|yaml}`. Generation fails on multiple matches (duplicate).
-3. Nothing matched → no passport applied, generation continues.
+   `cloud-passport/passport.{yml|yaml}`, then the single passport file in `cloud-passport/` when
+   exactly one exists.
+3. `cloudPassport` absent and `cloud-passport/` holds more than one unmatched passport file →
+   generation fails with an ambiguous-passport error listing the candidates.
+4. `cloudPassport` absent and `cloud-passport/` holds no passport file → no passport applied,
+   generation continues.
 
 ## Merge into Cloud
 


### PR DESCRIPTION
## Summary

Re-homes the docs from **#1665** onto `feature/modern-toolset`. #1665 was branched off `main`, so instead of a
base swap the doc change was brought onto a fresh branch off `feature/modern-toolset`.

Documents the Cloud Passport auto-association relaxation:

- Single-file fallback: when `cloudPassport` is not set and neither the cluster-name nor the `passport` default
  matches, the sole passport file in `cloud-passport/` is used regardless of its name.
- Ambiguous-passport error when more than one unmatched passport file is present.
- Scopes the "no passport file, generation continues" outcome to the `cloudPassport`-absent path.

## Conflict resolution

The `cloud-passport/` resolution section had diverged on `feature/modern-toolset` (via #1702, `1dbfd1a0`,
2026-08-17): item 2 reworded to "the recommended default name" and a "Name the default passport `passport.yml`"
sentence added. That newer wording was **kept**; #1665's new content (item 3, ambiguous-passport paragraph,
Resolution summary items 3-4) was layered on top. The `#1665` base wording ("a generic fallback name") was not
brought. The two are complementary, not conflicting.

## Related

- Supersedes #1665 for the modern-toolset line. #1665 is being retired and closed.
- Implementation tracked in #1666.

## Breaking Change?

- [ ] Yes
- [x] No (documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)