### PR TITLE
docs: add use_committed_sd config for No-SD Mode without incoming SD (from #1630)

### DIFF
--- a/docs/envgene-configs.md
+++ b/docs/envgene-configs.md
@@ -402,6 +402,15 @@ sbom_retention:
 # and [Full Generation](/docs/features/effective-set-generation.md#full-generation)
 # for generation mode behavior
 effective_set_generation_strategy: enum [`full`, `partial`]
+# Optional. Default value - `true`
+# Controls whether the committed Full SD is used when a pipeline run provides no incoming SD
+# `true` - the committed Full SD is used, so Full Generation or Partial Generation runs
+# `false` - the committed Full SD is ignored when no SD is passed, so No-SD Mode runs and only
+# `topology` and `pipeline` contexts are produced
+# Set to `false` to avoid failures when the committed Full SD references application versions that can no
+# longer be downloaded from the registry
+# See [No-SD Mode](/docs/features/effective-set-generation.md#no-sd-mode)
+use_committed_sd: boolean
 ```
 
 ## `integration.yml`

--- a/docs/features/effective-set-generation.md
+++ b/docs/features/effective-set-generation.md
@@ -75,7 +75,8 @@ The generation path is chosen automatically based on the outcome of SD processin
 The entire ES is rebuilt from the current Full SD and environment instance data. All five contexts (`topology`, `pipeline`, `deployment`, `runtime`, `cleanup`) are produced. Applied when:
 
 - `SD_REPO_MERGE_MODE=replace`, or
-- The pipeline runs without an incoming SD and a Full SD already exists in the repository, or
+- The pipeline runs without an incoming SD, a Full SD already exists in the repository, and
+  `use_committed_sd` is `true` (the default), or
 - An incoming SD is supplied with a merge mode but no Full SD exists yet — the incoming SD becomes the Full SD, there is nothing to merge against.
 
 Application and Registry Definitions for every application in the Full SD must be available.
@@ -112,9 +113,21 @@ Under partial generation, the `generate_effective_set` stage follows the Delta S
 
 ### No-SD Mode
 
-Applied when the pipeline runs without an incoming SD and no Full SD exists in the repository. Only `topology` and `pipeline` contexts are produced; `deployment`, `runtime`, and `cleanup` require application data from a Solution Descriptor and cannot be generated without one. SBOMs are not required and are not requested.
+Applied when the pipeline runs without an incoming SD and one of the following holds:
 
-See [Generate Without a Solution Descriptor](/docs/how-to/generate-effective-set.md#generate-without-a-solution-descriptor) in the how-to guide.
+- No Full SD exists in the repository, or
+- A Full SD exists but `use_committed_sd` is `false` in
+  [`config.yml`](/docs/envgene-configs.md#configyml).
+
+Only `topology` and `pipeline` contexts are produced. `deployment`, `runtime`, and `cleanup` require
+application data from a Solution Descriptor and cannot be generated without one. SBOMs are not required
+so are not generated.
+
+By default (`use_committed_sd: true`) a run with no incoming SD uses the committed Full SD and Full
+Generation runs.
+
+See [Generate Without a Solution Descriptor](/docs/how-to/generate-effective-set.md#generate-without-a-solution-descriptor)
+in the how-to guide.
 
 ## Configuration
 

--- a/docs/how-to/generate-effective-set.md
+++ b/docs/how-to/generate-effective-set.md
@@ -165,7 +165,7 @@ The `git_commit` job commits these files to the Instance Repository automaticall
 
 ### Generate Without a Solution Descriptor
 
-When no Solution Descriptor is provided - for example when setting up infrastructure-only namespaces or preparing an environment before any applications are defined - the Effective Set is generated in a partial mode.
+When no Solution Descriptor is provided - for example when setting up infrastructure-only namespaces or preparing an environment before any applications are defined - the Effective Set is generated in No-SD Mode.
 
 Without an SD, EnvGene does not know which applications belong to which namespaces, so the application-specific contexts cannot be produced. The following contexts are generated normally:
 
@@ -178,7 +178,13 @@ The following contexts are **not generated**:
 - `runtime` - requires application definitions from the SD
 - `cleanup` - requires application definitions from the SD
 
-To use this mode, simply omit `SD_VERSION` and `SD_SOURCE_TYPE` from the pipeline variables. If no SD artifact is passed and no `sd.yaml` exists in the repository, EnvGene skips all application-level processing automatically.
+To use this mode, omit `SD_VERSION` and `SD_SOURCE_TYPE` from the pipeline variables. If no SD artifact is
+passed and no `sd.yaml` exists in the repository, EnvGene enters No-SD Mode automatically.
+
+If a `sd.yaml` is committed but you still want No-SD Mode - for example when the committed SD references
+application versions that can no longer be downloaded from the registry - set `use_committed_sd: false` in
+[`config.yml`](/docs/envgene-configs.md#configyml). With `use_committed_sd` set to `false`, a run with no
+incoming SD stays in No-SD Mode instead of using the committed SD.
 
 ---
 


### PR DESCRIPTION
## Summary

Re-homes the docs from **#1630** onto `feature/modern-toolset`. #1630 was branched off `main`, so the change was
brought onto a fresh branch off `feature/modern-toolset`.

Documents a new `config.yml` attribute `use_committed_sd` (boolean, default `true`) that controls whether the
committed Full SD is used when a `generate_effective_set` run provides no incoming SD. With `use_committed_sd:
false`, such a run enters No-SD Mode (`topology` and `pipeline` contexts only) instead of failing when the
committed Full SD references versions that can no longer be downloaded. The default `true` preserves current
behavior.

Touches `docs/envgene-configs.md`, `docs/features/effective-set-generation.md`, and
`docs/how-to/generate-effective-set.md`.

## Notes

Pure diff transplant from #1630 - no style/content edits. The diff applied cleanly against the modern-toolset
versions of all three files (context matched, no conflicts). Net `+33/-5`, identical to #1630.

## Related

- Supersedes #1630 for the modern-toolset line. #1630 is being retired and closed.
- Documents behavior ahead of implementation. The implementation change request is a follow-up.

## Breaking Change?

- [ ] Yes
- [x] No (documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)