### PR TITLE
docs: use ENV_INVENTORY_CONTENT in the create-environment-inventory how-to

### DIFF
--- a/docs/how-to/create-environment-inventory.md
+++ b/docs/how-to/create-environment-inventory.md
@@ -111,8 +111,7 @@ This guide provides instructions for creating a Environment Inventory in the Ins
 
     ```yaml
     ENV_NAMES: "<cluster-name>/<env-name>"
-    ENV_INVENTORY_INIT: "true"
-    ENV_SPECIFIC_PARAMS: <...> # Optional. Used to define environment-specific parameters, or credentials
+    ENV_INVENTORY_CONTENT: <...> # JSON in string with the Environment Inventory content
     ```
 
     See details about pipeline parameter options in the [documentation](/docs/instance-pipeline-parameters.md)


### PR DESCRIPTION
## Summary

Switches the pipeline snippet in the `create-environment-inventory` how-to from the legacy
`ENV_INVENTORY_INIT` / `ENV_SPECIFIC_PARAMS` to `ENV_INVENTORY_CONTENT`. The existing deprecation note is kept.

Extracted from **#1606** (its how-to part only). The legacy-parameter removal itself is intentionally not part
of this PR - the parameters stay documented as deprecated. The full removal is tracked separately and gated on
the implementation in #1609.

## Breaking Change?

- [ ] Yes
- [x] No (documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)