### PR TITLE
docs: remove the legacy inventory flow (from #1606)

### DIFF
--- a/docs/envgene-pipelines.md
+++ b/docs/envgene-pipelines.md
@@ -57,11 +57,7 @@ flowchart TB
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
 5. **env_inventory_generation**:
-   - **Condition**: Runs if [`ENV_TEMPLATE_TEST: false`](/docs/envgene-repository-variables.md#env_template_test) AND any of the following holds:
-     - [`ENV_INVENTORY_CONTENT`](/docs/instance-pipeline-parameters.md#env_inventory_content) is set, or
-     - [`ENV_INVENTORY_INIT`](/docs/instance-pipeline-parameters.md#env_inventory_init) is `true`, or
-     - [`ENV_SPECIFIC_PARAMS`](/docs/instance-pipeline-parameters.md#env_specific_params) is set (non-empty), or
-     - [`ENV_TEMPLATE_NAME`](/docs/instance-pipeline-parameters.md#env_template_name) is set (non-empty)
+   - **Condition**: Runs if [`ENV_TEMPLATE_TEST: false`](/docs/envgene-repository-variables.md#env_template_test) AND [`ENV_INVENTORY_CONTENT`](/docs/instance-pipeline-parameters.md#env_inventory_content) is set
    - **Docker image**: [`qubership-envgene`](https://github.com/Netcracker/qubership-envgene/pkgs/container/qubership-envgene)
 
 6. **app_reg_def_process**:

--- a/docs/features/env-inventory-generation.md
+++ b/docs/features/env-inventory-generation.md
@@ -15,8 +15,6 @@
         - [Validations](#validations)
         - [Full `ENV_INVENTORY_CONTENT` Example](#full-env_inventory_content-example)
         - [ENV\_INVENTORY\_CONTENT in JSON-in-string format](#env_inventory_content-in-json-in-string-format)
-      - [`ENV_SPECIFIC_PARAMS`](#env_specific_params)
-        - [`ENV_SPECIFIC_PARAMS` Example](#env_specific_params-example)
     - [Example of Generated Result with `ENV_INVENTORY_CONTENT`](#example-of-generated-result-with-env_inventory_content)
       - [Generated Result with `ENV_INVENTORY_CONTENT` (new files)](#generated-result-with-env_inventory_content-new-files)
         - [Environment Inventory (`env_definition.yml`)](#environment-inventory-env_definitionyml)
@@ -33,9 +31,6 @@
           - [Existing Parameter Set file](#existing-parameter-set-file)
           - [Input request (paramSets)](#input-request-paramsets)
           - [Result Parameter Sets](#result-parameter-sets)
-    - [Example of Generated Result with `ENV_SPECIFIC_PARAMS`](#example-of-generated-result-with-env_specific_params)
-      - [Minimal Environment Inventory](#minimal-environment-inventory)
-      - [Environment Inventory with env-specific parameters](#environment-inventory-with-env-specific-parameters)
 
 ## Problem Statements
 
@@ -67,15 +62,11 @@ The generated Environment Inventory must be reused by other jobs in the same pip
 > **Note**
 > If `ENV_TEMPLATE_VERSION` is provided in the instance pipeline, it has higher priority than the template version specified in `env_definition.yml`
 
-`ENV_SPECIFIC_PARAMS` and `ENV_INVENTORY_INIT` are legacy parameters and are deprecated. They do not cover the full set of Inventory management scenarios, therefore new integrations should use `ENV_INVENTORY_CONTENT`.
-
 ### Instance Repository Pipeline Parameters
 
 | Parameter | Type | Mandatory | Description | Example |
 | ----------- | ------------- | ------ | --------- | ---------- |
 | `ENV_INVENTORY_CONTENT` | JSON in string | no | Allows to create/ replace, delete `env_definition.yml` and related Inventory objects. Must be valid according to [JSON schema](/schemas/env-inventory-content.schema.json). See details in [ENV_INVENTORY_CONTENT](#env_inventory_content) | See [example below](#full-env_inventory_content-example) |
-| `ENV_INVENTORY_INIT` | string | no | **Deprecated**. If `true`, the new Environment Inventory will be generated in the path `/environments/<cluster-name>/<env-name>/Inventory/env_definition.yml`. If `false` can be updated only | `true` OR `false` |
-| `ENV_SPECIFIC_PARAMS` | JSON in string | no | **Deprecated**. If specified, Environment Inventory is updated. See details in [ENV_SPECIFIC_PARAMS](#env_specific_params) | See [example below](#env_specific_params-example) |
 
 #### `ENV_INVENTORY_CONTENT`
 
@@ -136,11 +127,6 @@ The order in which different object types are processed is not guaranteed and ma
 ##### Validations
 
 Before processing any files, the system performs the following validations:
-
-**Parameter exclusivity validation:**
-
-If both `ENV_INVENTORY_CONTENT` and any of `ENV_INVENTORY_INIT`, `ENV_SPECIFIC_PARAMS` or `ENV_TEMPLATE_NAME`
-are provided, validation fails
 
 **JSON schema validation:**
 
@@ -306,86 +292,6 @@ This example shows how to generate a new Environment Inventory (`env_definition.
 
 ```json
 "{\"envDefinition\":{\"action\":\"create_or_replace\",\"content\":{\"inventory\":{\"environmentName\":\"env-1\",\"tenantName\":\"Applications\",\"cloudName\":\"cluster-1\",\"description\":\"Fullsample\",\"owners\":\"Qubershipteam\",\"config\":{\"updateRPOverrideNameWithEnvName\":false,\"updateCredIdsWithEnvName\":true}},\"envTemplate\":{\"name\":\"composite-prod\",\"artifact\":\"project-env-template:master_20231024-080204\",\"additionalTemplateVariables\":{\"ci\":{\"CI_PARAM_1\":\"ci-param-val-1\",\"CI_PARAM_2\":\"ci-param-val-2\"},\"e2eParameters\":{\"E2E_PARAM_1\":\"e2e-param-val-1\",\"E2E_PARAM_2\":\"e2e-param-val-2\"}},\"sharedTemplateVariables\":[\"prod-template-variables\",\"sample-cloud-template-variables\"],\"envSpecificParamsets\":{\"bss\":[\"env-specific-bss\"]},\"envSpecificTechnicalParamsets\":{\"bss\":[\"env-specific-tech\"]},\"envSpecificE2EParamsets\":{\"cloud\":[\"cloud-level-params\"]},\"sharedMasterCredentialFiles\":[\"prod-integration-creds\"],\"envSpecificResourceProfiles\":{\"cloud\":[\"cloud-specific-profile\"]}}}},\"paramSets\":[{\"action\":\"create_or_replace\",\"place\":\"env\",\"content\":{\"version\":\"<paramset-version>\",\"name\":\"env-specific-bss\",\"parameters\":{\"key\":\"value\"},\"applications\":[]}}],\"credentials\":[{\"action\":\"create_or_replace\",\"place\":\"site\",\"name\":\"prod-integration-creds\",\"content\":{\"prod-integration-creds\":{\"type\":\"<credential-type>\",\"data\":{\"username\":\"<value>\",\"password\":\"<value>\"}}}}],\"resourceProfiles\":[{\"action\":\"create_or_replace\",\"place\":\"cluster\",\"content\":{\"name\":\"cloud-specific-profile\",\"baseline\":\"dev\",\"description\":\"\",\"applications\":[{\"name\":\"core\",\"version\":\"release-20241103.225817\",\"sd\":\"\",\"services\":[{\"name\":\"operator\",\"parameters\":[{\"name\":\"GATEWAY_MEMORY_LIMIT\",\"value\":\"96Mi\"},{\"name\":\"GATEWAY_CPU_REQUEST\",\"value\":\"50m\"}]}]}],\"version\":0}}],\"sharedTemplateVariables\":[{\"action\":\"create_or_replace\",\"place\":\"site\",\"name\":\"prod-template-variables\",\"content\":{\"TEMPLATE_VAR_1\":\"prod-value-1\",\"TEMPLATE_VAR_2\":\"prod-value-2\",\"nested\":{\"key1\":\"nested-prod-value-1\",\"key2\":\"nested-prod-value-2\"}}},{\"action\":\"create_or_replace\",\"place\":\"cluster\",\"name\":\"sample-cloud-template-variables\",\"content\":{\"CLOUD_VAR_1\":\"cloud-value-1\",\"CLOUD_VAR_2\":\"cloud-value-2\"}}]}"
-```
-
-#### `ENV_SPECIFIC_PARAMS`
-
-| Field | Type | Mandatory | Description | Example |
-| ------- | ------------- | ------ | --------- | ---------- |
-| `clusterParams` | hashmap | no | Cluster connection parameters | None |
-| `clusterParams.clusterEndpoint` | string | no | System **overrides** the value of `inventory.clusterUrl` in corresponding Environment Inventory | `https://api.cluster.example.com:6443` |
-| `clusterParams.clusterToken` | string | no | System **adds** Credential in the `/environments/<cluster-name>/<env-name>/Inventory/credentials/inventory_generation_creds.yml`. If Credential already exists, the value will **not be overridden**. System also creates an association with the credential file in corresponding Environment Inventory via `envTemplate.sharedMasterCredentialFiles` | None |
-| `additionalTemplateVariables` | hashmap | no | System **merges** the value into `envTemplate.additionalTemplateVariables` in corresponding Environment Inventory | `{"keyA": "valueA", "keyB": "valueB"}` |
-| `cloudName` | string | no | System **overrides** the value of `inventory.cloudName` in corresponding Environment Inventory | `cloud01` |
-| `tenantName` | string | no | System **overrides** the value of `inventory.tenantName` in corresponding Environment Inventory | `Application` |
-| `deployer` | string | no | System **overrides** the value of `inventory.deployer` in corresponding Environment Inventory | `abstract-CMDB-1` |
-| `envSpecificParamsets` | hashmap | no | System **merges** the value into `envTemplate.envSpecificParamsets` in corresponding Environment Inventory | See [example](#env_specific_params-example) |
-| `paramsets` | hashmap | no | System creates Parameter Set file for each first level key in the path `/environments/<cluster-name>/<env-name>/Inventory/parameters/KEY-NAME.yml`. If Parameter Set already exists, the value will be **overridden** | See [example](#env_specific_params-example) |
-| `credentials` | hashmap | no | System **adds** Credential object for each first level key in the `/environments/<cluster-name>/<env-name>/Inventory/credentials/inventory_generation_creds.yml`. If Credential already exists, the value will be **overridden**. System also creates an association with the credential file in corresponding Environment Inventory via `envTemplate.sharedMasterCredentialFiles` | See [example](#env_specific_params-example) |
-
-##### `ENV_SPECIFIC_PARAMS` Example
-
-```json
-  {
-    "clusterParams": {
-      "clusterEndpoint": "<value>",
-      "clusterToken": "<value>"
-    },
-    "additionalTemplateVariables": {
-      "<key>": "<value>"
-    },
-    "cloudName": "<value>",
-    "tenantName": "<value>",
-    "deployer": "<value>",
-    "envSpecificParamsets": {
-      "<ns-template-name>": [
-        "paramsetA"
-      ],
-      "cloud": [
-        "paramsetB"
-      ]
-    },
-    "paramsets": {
-      "paramsetA": {
-        "version": "<paramset-version>",
-        "name": "<paramset-name>",
-        "parameters": {
-          "<key>": "<value>"
-        },
-        "applications": [
-          {
-            "appName": "<app-name>",
-            "parameters": {
-              "<key>": "<value>"
-            }
-          }
-        ]
-      },
-      "paramsetB": {
-        "version": "<paramset-version>",
-        "name": "<paramset-name>",
-        "parameters": {
-          "<key>": "<value>"
-        },
-        "applications": []
-      }
-    },
-    "credentials": {
-      "credX": {
-        "type": "<credential-type>",
-        "data": {
-          "username": "<value>",
-          "password": "<value>"
-        }
-      },
-      "credY": {
-        "type": "<credential-type>",
-        "data": {
-          "secret": "<value>"
-        }
-      }
-    }
-  }
 ```
 
 ### Example of Generated Result with `ENV_INVENTORY_CONTENT`
@@ -635,80 +541,4 @@ name: "env-specific-bss"
 parameters:
   featureFlag: "true"
 applications: []
-```
-
-### Example of Generated Result with `ENV_SPECIFIC_PARAMS`
-
-#### Minimal Environment Inventory
-
-```yaml
-# /environments/<cluster-name>/<env-name>/Inventory/env_definition.yml
-inventory:
-  environmentName: <env-name>
-  clusterUrl: <cloud>
-envTemplate:
-  name: <env-template-name>
-  artifact: <app:ver>
-```
-
-#### Environment Inventory with env-specific parameters
-
-```yaml
-# /environments/<cluster-name>/<env-name>/Inventory/env_definition.yml
-inventory:
-  environmentName: <env-name>
-  clusterUrl: <cloud>
-envTemplate:
-  additionalTemplateVariables:
-    <key>: <value>
-  envSpecificParamsets:
-    cloud: [ "paramsetA" ]
-    <ns-template-name>: [ "paramsetB" ]
-  sharedMasterCredentialFiles: [ "inventory_generation_creds" ]
-  name: <env-template-name>
-  artifact: <app:ver>
-```
-
-```yaml
-# /environments/<cluster-name>/<env-name>/Credentials/credentials.yml
-cloud-admin-token:
-  type: "secret"
-  data:
-    secret: <cloud-token>
-```
-
-```yaml
-# /environments/<cluster-name>/<env-name>/Inventory/parameters/paramsetA.yml
-paramsetA:
-  version: <paramset-ver>
-  name: <paramset-name>
-  parameters:
-    <key>: <value>
-  applications:
-    - appName: <app-name>
-      parameters:
-        <key>: <value>
-```
-
-```yaml
-# /environments/<cluster-name>/<env-name>/Inventory/parameters/paramsetB.yml
-paramsetB:
-  version: <paramset-ver>
-  name: <paramset-name>
-  parameters:
-    <key>: <value>
-  applications: []
-```
-
-```yaml
-# /environments/<cluster-name>/<env-name>/Inventory/credentials/inventory_generation_creds.yml
-credX:
-  type: <credential-type>
-  data:
-    username: <value>
-    password: <value>
-credY:
-  type: <credential-type>
-  data:
-    secret: <value>
 ```

--- a/docs/instance-pipeline-parameters.md
+++ b/docs/instance-pipeline-parameters.md
@@ -40,6 +40,7 @@
     - [`GH_ADDITIONAL_PARAMS`](#gh_additional_params)
   - [Deprecated Parameters](#deprecated-parameters)
     - [`SD_DELTA`](#sd_delta)
+  - [Archived Parameters](#archived-parameters)
     - [`ENV_SPECIFIC_PARAMS`](#env_specific_params)
     - [`ENV_TEMPLATE_NAME`](#env_template_name)
     - [`ENV_INVENTORY_INIT`](#env_inventory_init)
@@ -988,100 +989,21 @@ See details in [SD processing](/docs/features/sd-processing.md)
 
 **Example**: `true`
 
+## Archived Parameters
+
+The following parameters have been removed. Use [`ENV_INVENTORY_CONTENT`](#env_inventory_content) instead.
+
 ### `ENV_SPECIFIC_PARAMS`
 
-**Description**: Specifies Environment Inventory and env-specific parameters. Use `ENV_INVENTORY_CONTENT` instead. This
-is can used together with
-`ENV_INVENTORY_INIT`. See details in [Environment Inventory
-Generation](/docs/features/env-inventory-generation.md)
-
-Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
-
-**Default Value**: None
-
-**Mandatory**: No
-
-**Example**:
-
-```yaml
-clusterParams:
-  clusterEndpoint: <value>
-  clusterToken: <value>
-additionalTemplateVariables:
-  <key>: <value>
-cloudName: <value>
-envSpecificParamsets:
-  <ns-template-name>:
-  - paramsetA
-  cloud:
-  - paramsetB
-paramsets:
-  paramsetA:
-    version: <paramset-version>
-    name: <paramset-name>
-    parameters:
-      <key>: <value>
-    applications:
-    - appName: <app-name>
-      parameters:
-        <key>: <value>
-  paramsetB:
-    version: <paramset-version>
-    name: <paramset-name>
-    parameters:
-      <key>: <value>
-    applications: []
-credentials:
-  credX:
-    type: <credential-type>
-    data:
-      username: <value>
-      password: <value>
-  credY:
-    type: <credential-type>
-    data:
-      secret: <value>
-```
+**Removed.** Use [`ENV_INVENTORY_CONTENT`](#env_inventory_content) instead.
 
 ### `ENV_TEMPLATE_NAME`
 
-**Description**: Specifies the template artifact value within the generated Environment Inventory. Use
-`ENV_INVENTORY_CONTENT` instead. This is used together
-with `ENV_INVENTORY_INIT`.
-
-Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
-
-System overrides `envTemplate.name` at `/environments/<ENV_NAME>/Inventory/env_definition.yml`:
-
-```yaml
-envTemplate:
-    name: <ENV_TEMPLATE_NAME>
-    ...
-...
-```
-
-**Default Value**: None
-
-**Mandatory**: No
-
-**Example**: `env-template:v1.2.3`
+**Removed.** Use [`ENV_INVENTORY_CONTENT`](#env_inventory_content) instead.
 
 ### `ENV_INVENTORY_INIT`
 
-**Description**: Use `ENV_INVENTORY_CONTENT` instead.
-
-If `true`:
-  In the pipeline, a job for generating the environment inventory is executed. The new Environment Inventory will be
-generated in the path `/environments/<ENV_NAME>/Inventory/env_definition.yml`. See details in [Environment Inventory
-Generation](/docs/features/env-inventory-generation.md)
-
-Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
-
-**Default Value**: `false`
-
-**Mandatory**: No
-
-**Example**: `true`
+**Removed.** Use [`ENV_INVENTORY_CONTENT`](#env_inventory_content) instead.
 
 ## Parameter value formats
 


### PR DESCRIPTION
## Summary

Re-homes the legacy-inventory removal from **#1606** onto `feature/modern-toolset`. Target-state documentation for
the legacy inventory flow removal.

- `ENV_SPECIFIC_PARAMS`, `ENV_TEMPLATE_NAME` and `ENV_INVENTORY_INIT` are marked as removed.
- Their detailed docs, examples and the parameter-exclusivity rule are dropped from
  `docs/features/env-inventory-generation.md`.
- The `env_inventory_generation` job condition in `docs/envgene-pipelines.md` lists `ENV_INVENTORY_CONTENT` only.

> [!IMPORTANT]
> Draft on purpose. Merge together with the implementation of #1609, not before - the legacy parameters are still
> processed by the code today.

## Deviation from #1606

The removed parameters are moved into a new `## Archived Parameters` section in
`docs/instance-pipeline-parameters.md` (modern-toolset has no Archived section yet), leaving only `SD_DELTA` under
`## Deprecated Parameters`. The how-to snippet switch was split into a separate, mergeable-now PR (#1713).

## Related

- Documentation half of #1609. Supersedes #1606 for the modern-toolset line.

## Breaking Change?

- [x] Yes
- [ ] No

Removes the deprecated `ENV_INVENTORY_INIT`, `ENV_SPECIFIC_PARAMS` and `ENV_TEMPLATE_NAME` from the documented
contract. Integrations must use `ENV_INVENTORY_CONTENT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)