### PR TITLE
feat: Computed current_env.composite_topology environment variable

### DIFF
--- a/schemas/composite-structure.schema.json
+++ b/schemas/composite-structure.schema.json
@@ -47,80 +47,11 @@
               "enum": [
                 "bgdomain"
               ]
-            },
-            "originNamespace": {
-              "type": "object",
-              "description": "The currently active namespace in the BG Domain",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Name of the origin namespace"
-                },
-                "type": {
-                  "type": "string",
-                  "description": "Type of the namespace reference",
-                  "enum": [
-                    "namespace"
-                  ]
-                }
-              },
-              "required": [
-                "name",
-                "type"
-              ],
-              "additionalProperties": false
-            },
-            "peerNamespace": {
-              "type": "object",
-              "description": "The standby namespace in the BG Domain",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Name of the peer namespace"
-                },
-                "type": {
-                  "type": "string",
-                  "description": "Type of the namespace reference",
-                  "enum": [
-                    "namespace"
-                  ]
-                }
-              },
-              "required": [
-                "name",
-                "type"
-              ],
-              "additionalProperties": false
-            },
-            "controllerNamespace": {
-              "type": "object",
-              "description": "The namespace that manages BG Domain lifecycle operations",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Name of the controller namespace"
-                },
-                "type": {
-                  "type": "string",
-                  "description": "Type of the namespace reference",
-                  "enum": [
-                    "namespace"
-                  ]
-                }
-              },
-              "required": [
-                "name",
-                "type"
-              ],
-              "additionalProperties": false
             }
           },
           "required": [
             "name",
-            "type",
-            "originNamespace",
-            "peerNamespace",
-            "controllerNamespace"
+            "type"
           ],
           "additionalProperties": false
         }
@@ -129,27 +60,55 @@
     "satellites": {
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Name of the satellite component"
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "Namespace Satellite",
+            "description": "Satellite defined as a simple namespace",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the satellite component"
+              },
+              "type": {
+                "type": "string",
+                "description": "Type of the satellite component",
+                "enum": [
+                  "namespace"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "type"
+            ],
+            "additionalProperties": false
           },
-          "type": {
-            "type": "string",
-            "description": "Type of the satellite component",
-            "enum": [
-              "namespace"
-            ]
+          {
+            "type": "object",
+            "title": "BG Domain Satellite",
+            "description": "Satellite defined as a Blue-Green Domain",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the BG Domain"
+              },
+              "type": {
+                "type": "string",
+                "description": "Type of the satellite component",
+                "enum": [
+                  "bgdomain"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "type"
+            ],
+            "additionalProperties": false
           }
-        },
-        "required": [
-          "name",
-          "type"
-        ],
-        "additionalProperties": false
+        ]
       },
-      "minItems": 1,
       "description": "List of satellite components"
     }
   },

--- a/schemas/composite-structure.schema.json
+++ b/schemas/composite-structure.schema.json
@@ -114,8 +114,7 @@
   },
   "required": [
     "name",
-    "baseline",
-    "satellites"
+    "baseline"
   ],
   "additionalProperties": false
 }

--- a/scripts/build_env/render_config_env.py
+++ b/scripts/build_env/render_config_env.py
@@ -725,7 +725,7 @@ class EnvGenerator:
 
             self.generate_bgd_file()
             self.generate_composite_structure()
-            self.compute_composite_topology ()
+            self.compute_composite_topology()
             self.generate_solution_structure()
             self.generate_tenant_file()
             self.generate_cloud_file()

--- a/scripts/build_env/render_config_env.py
+++ b/scripts/build_env/render_config_env.py
@@ -434,7 +434,7 @@ class EnvGenerator:
             cs_file.parent.mkdir(parents=True, exist_ok=True)
             self.render_from_file_to_file(Template(composite_structure).render(self.ctx.as_dict()), str(cs_file))
             validate_yaml_by_scheme_or_fail(cs_file, COMPOSITE_SCHEMA)
-    
+
     def generate_external_cred(self):
         #render external creds
         external_credential_template = self.ctx.current_env_template.get("external_credential_template")
@@ -618,6 +618,90 @@ class EnvGenerator:
             self.render_reg_defs()
 
             self.validate_appregdefs()
+    def _resolve_composite_member(self, member: dict, bgd: dict | None = None) -> dict:
+        member_type = member.get("type")
+
+        if member_type == "namespace":
+            return {
+                "originNamespace": member["name"]
+            }
+
+        if member_type == "bgdomain":
+            if bgd is None:
+                raise ValueError(
+                    f"BG Domain '{member.get('name')}' cannot be resolved "
+                    "because bg_domain.yml is missing or empty"
+                )
+
+            bgd_name = member.get("name")
+
+            if bgd.get("name") != bgd_name:
+                raise ValueError(
+                    f"Composite Structure references BG Domain '{bgd_name}', "
+                    f"but bg_domain.yml contains '{bgd.get('name')}'"
+                )
+
+            return {
+                "originNamespace": bgd["originNamespace"]["name"],
+                "peerNamespace": bgd["peerNamespace"]["name"],
+                "controllerNamespace": bgd["controllerNamespace"]["name"],
+            }
+
+        raise ValueError(f"Unknown composite member type: {member_type}")
+
+    def _load_bg_domain(self) -> dict:
+        bgd_file = Path(self.ctx.current_env_dir) / "bg_domain.yml"
+
+        if not bgd_file.exists():
+            raise ValueError(
+                f"Composite Structure references a BG Domain, "
+                f"but BG Domain file was not generated: {bgd_file}"
+            )
+        bgd = openYaml(bgd_file)
+        if not bgd:
+            raise ValueError(f"BG Domain file is empty: {bgd_file}")
+        return bgd
+
+    def compute_composite_topology(self):
+        cs_file = Path(self.ctx.current_env_dir) / "composite_structure.yml"
+
+        if not cs_file.exists():
+            logger.info("Composite Structure not found. composite_topology={}")
+            self.ctx.current_env["composite_topology"] = {}
+            return
+
+        composite = openYaml(cs_file)
+
+        baseline = composite.get("baseline")
+        if not baseline:
+            raise ValueError("Composite Structure is missing required 'baseline'")
+
+        # Load BGD only when the Composite Structure actually references one.
+        members = [baseline] + composite.get("satellites", [])
+        has_bgd = any(member.get("type") == "bgdomain" for member in members)
+
+        bgd = None
+        if has_bgd:
+            bgd = self._load_bg_domain()
+
+        topology = {
+            "baseline": self._resolve_composite_member(baseline, bgd)
+        }
+
+        satellites = [
+            self._resolve_composite_member(member, bgd)
+            for member in composite.get("satellites", [])
+        ]
+
+        if satellites:
+            topology["satellites"] = satellites
+
+        self.ctx.current_env["composite_topology"] = topology
+
+        logger.info(
+            f"Resolved composite_topology:\n"
+            f"{dump_as_yaml_format(topology)}"
+        )
 
     def render_config_env(self, env_name: str, extra_env: dict):
         logger.info(f"Starting rendering environment {env_name}. Input params are:\n{dump_as_yaml_format(extra_env)}")

--- a/scripts/build_env/render_config_env.py
+++ b/scripts/build_env/render_config_env.py
@@ -618,6 +618,7 @@ class EnvGenerator:
             self.render_reg_defs()
 
             self.validate_appregdefs()
+
     def _resolve_composite_member(self, member: dict, bgd: dict | None = None) -> dict:
         member_type = member.get("type")
 
@@ -737,11 +738,12 @@ class EnvGenerator:
             self.set_env_templates()
 
             self.generate_bgd_file()
+            self.generate_composite_structure()
+            self.compute_composite_topology ()
             self.generate_solution_structure()
             self.generate_tenant_file()
             self.generate_cloud_file()
             self.generate_namespace_files()
-            self.generate_composite_structure()
             self.generate_external_cred()
 
             env_specific_schema = self.ctx.current_env_template.get("envSpecificSchema")

--- a/scripts/build_env/render_config_env.py
+++ b/scripts/build_env/render_config_env.py
@@ -650,19 +650,6 @@ class EnvGenerator:
 
         raise ValueError(f"Unknown composite member type: {member_type}")
 
-    def _load_bg_domain(self) -> dict:
-        bgd_file = Path(self.ctx.current_env_dir) / "bg_domain.yml"
-
-        if not bgd_file.exists():
-            raise ValueError(
-                f"Composite Structure references a BG Domain, "
-                f"but BG Domain file was not generated: {bgd_file}"
-            )
-        bgd = openYaml(bgd_file)
-        if not bgd:
-            raise ValueError(f"BG Domain file is empty: {bgd_file}")
-        return bgd
-
     def compute_composite_topology(self):
         cs_file = Path(self.ctx.current_env_dir) / "composite_structure.yml"
 
@@ -677,13 +664,12 @@ class EnvGenerator:
         if not baseline:
             raise ValueError("Composite Structure is missing required 'baseline'")
 
-        # Load BGD only when the Composite Structure actually references one.
         members = [baseline] + composite.get("satellites", [])
         has_bgd = any(member.get("type") == "bgdomain" for member in members)
 
         bgd = None
         if has_bgd:
-            bgd = self._load_bg_domain()
+            bgd = get_bgd_object(Path(self.ctx.current_env_dir))
 
         topology = {
             "baseline": self._resolve_composite_member(baseline, bgd)

--- a/scripts/build_env/tests/env-build/test_composite_topology.py
+++ b/scripts/build_env/tests/env-build/test_composite_topology.py
@@ -26,15 +26,18 @@ class TestCompositeTopology:
 
         assert generator.ctx.current_env["composite_topology"] == {}
 
-    def test_baseline_only(self):
-        test_dir = TEST_DATA_DIR / "baseline-only"
+    def test_baseline_only(self, tmp_path):
+        composite_structure = tmp_path / "composite_structure.yml"
+        composite_structure.write_text(
+            """
+    baseline:
+      type: namespace
+      name: env-1-core
+    """,
+            encoding="utf-8",
+        )
 
-        generator = self._create_generator(test_dir)
-
-        # Debug: Check if file exists
-        cs_file = Path(generator.ctx.current_env_dir) / "composite_structure.yml"
-        print(f"Looking for file at: {cs_file}")
-        print(f"File exists: {cs_file.exists()}")
+        generator = self._create_generator(tmp_path)
 
         generator.compute_composite_topology()
 

--- a/scripts/build_env/tests/env-build/test_composite_topology.py
+++ b/scripts/build_env/tests/env-build/test_composite_topology.py
@@ -31,6 +31,11 @@ class TestCompositeTopology:
 
         generator = self._create_generator(test_dir)
 
+        # Debug: Check if file exists
+        cs_file = Path(generator.ctx.current_env_dir) / "composite_structure.yml"
+        print(f"Looking for file at: {cs_file}")
+        print(f"File exists: {cs_file.exists()}")
+
         generator.compute_composite_topology()
 
         assert generator.ctx.current_env["composite_topology"] == {

--- a/scripts/build_env/tests/env-build/test_composite_topology.py
+++ b/scripts/build_env/tests/env-build/test_composite_topology.py
@@ -21,18 +21,13 @@ class TestCompositeTopology:
 
     def test_no_composite_structure(self, tmp_path):
         generator = self._create_generator(tmp_path)
-
         generator.compute_composite_topology()
-
         assert generator.ctx.current_env["composite_topology"] == {}
 
     def test_baseline_only(self):
         test_dir = TEST_DATA_DIR / "baseline-only"
-
         generator = self._create_generator(test_dir)
-
         generator.compute_composite_topology()
-
         assert generator.ctx.current_env["composite_topology"] == {
             "baseline": {
                 "originNamespace": "env-1-core",
@@ -41,11 +36,8 @@ class TestCompositeTopology:
 
     def test_namespace_baseline_and_satellites(self):
         test_dir = TEST_DATA_DIR / "namespace-baseline-satellites"
-
         generator = self._create_generator(test_dir)
-
         generator.compute_composite_topology()
-
         assert generator.ctx.current_env["composite_topology"] == {
             "baseline": {
                 "originNamespace": "env-1-core",
@@ -62,11 +54,8 @@ class TestCompositeTopology:
 
     def test_bgdomain_baseline(self):
         test_dir = TEST_DATA_DIR / "bgdomain-baseline"
-
         generator = self._create_generator(test_dir)
-
         generator.compute_composite_topology()
-
         assert generator.ctx.current_env["composite_topology"] == {
             "baseline": {
                 "originNamespace": "env-1-bss-origin",
@@ -82,11 +71,8 @@ class TestCompositeTopology:
 
     def test_bgdomain_satellite(self):
         test_dir = TEST_DATA_DIR / "bgdomain-satellite"
-
         generator = self._create_generator(test_dir)
-
         generator.compute_composite_topology()
-
         assert generator.ctx.current_env["composite_topology"] == {
             "baseline": {
                 "originNamespace": "env-1-core",
@@ -102,11 +88,8 @@ class TestCompositeTopology:
 
     def test_bgdomain_baseline_and_satellites(self):
         test_dir = TEST_DATA_DIR / "bgdomain-baseline-satellites"
-
         generator = self._create_generator(test_dir)
-
         generator.compute_composite_topology()
-
         assert generator.ctx.current_env["composite_topology"] == {
             "baseline": {
                 "originNamespace": "env-1-bss-origin",

--- a/scripts/build_env/tests/env-build/test_composite_topology.py
+++ b/scripts/build_env/tests/env-build/test_composite_topology.py
@@ -60,7 +60,7 @@ class TestCompositeTopology:
             ],
         }
 
-    @patch("build_env.render_config_env.get_bgd_object")
+    @patch("scripts.build_env.render_config_env.get_bgd_object")
     def test_bgdomain_baseline(self, mock_get_bgd_object):
         test_dir = TEST_DATA_DIR / "bgdomain-baseline"
 
@@ -89,7 +89,7 @@ class TestCompositeTopology:
             }
         }
 
-    @patch("build_env.render_config_env.get_bgd_object")
+    @patch("scripts.build_env.render_config_env.get_bgd_object")
     def test_bgdomain_satellite(self, mock_get_bgd_object):
         test_dir = TEST_DATA_DIR / "bgdomain-satellite"
 
@@ -123,7 +123,7 @@ class TestCompositeTopology:
             ],
         }
 
-    @patch("build_env.render_config_env.get_bgd_object")
+    @patch("scripts.build_env.render_config_env.get_bgd_object")
     def test_bgdomain_baseline_and_satellites(self, mock_get_bgd_object):
         test_dir = TEST_DATA_DIR / "bgdomain-baseline-satellites"
 

--- a/scripts/build_env/tests/env-build/test_composite_topology.py
+++ b/scripts/build_env/tests/env-build/test_composite_topology.py
@@ -1,7 +1,7 @@
 from pathlib import Path
-from unittest.mock import patch
 
 from scripts.build_env.render_config_env import EnvGenerator
+
 
 TEST_DATA_DIR = (
     Path(__file__).resolve().parents[4]
@@ -60,24 +60,10 @@ class TestCompositeTopology:
             ],
         }
 
-    @patch("scripts.build_env.render_config_env.get_bgd_object")
-    def test_bgdomain_baseline(self, mock_get_bgd_object):
+    def test_bgdomain_baseline(self):
         test_dir = TEST_DATA_DIR / "bgdomain-baseline"
 
         generator = self._create_generator(test_dir)
-
-        mock_get_bgd_object.return_value = {
-            "name": "bss",
-            "originNamespace": {
-                "name": "env-1-bss-origin",
-            },
-            "peerNamespace": {
-                "name": "env-1-bss-peer",
-            },
-            "controllerNamespace": {
-                "name": "env-1-controller",
-            },
-        }
 
         generator.compute_composite_topology()
 
@@ -89,24 +75,10 @@ class TestCompositeTopology:
             }
         }
 
-    @patch("scripts.build_env.render_config_env.get_bgd_object")
-    def test_bgdomain_satellite(self, mock_get_bgd_object):
+    def test_bgdomain_satellite(self):
         test_dir = TEST_DATA_DIR / "bgdomain-satellite"
 
         generator = self._create_generator(test_dir)
-
-        mock_get_bgd_object.return_value = {
-            "name": "bss",
-            "originNamespace": {
-                "name": "env-1-bss-origin",
-            },
-            "peerNamespace": {
-                "name": "env-1-bss-peer",
-            },
-            "controllerNamespace": {
-                "name": "env-1-controller",
-            },
-        }
 
         generator.compute_composite_topology()
 
@@ -123,24 +95,10 @@ class TestCompositeTopology:
             ],
         }
 
-    @patch("scripts.build_env.render_config_env.get_bgd_object")
-    def test_bgdomain_baseline_and_satellites(self, mock_get_bgd_object):
+    def test_bgdomain_baseline_and_satellites(self):
         test_dir = TEST_DATA_DIR / "bgdomain-baseline-satellites"
 
         generator = self._create_generator(test_dir)
-
-        mock_get_bgd_object.return_value = {
-            "name": "bss",
-            "originNamespace": {
-                "name": "env-1-bss-origin",
-            },
-            "peerNamespace": {
-                "name": "env-1-bss-peer",
-            },
-            "controllerNamespace": {
-                "name": "env-1-controller",
-            },
-        }
 
         generator.compute_composite_topology()
 

--- a/scripts/build_env/tests/env-build/test_composite_topology.py
+++ b/scripts/build_env/tests/env-build/test_composite_topology.py
@@ -77,7 +77,12 @@ class TestCompositeTopology:
                 "originNamespace": "env-1-bss-origin",
                 "peerNamespace": "env-1-bss-peer",
                 "controllerNamespace": "env-1-controller",
-            }
+            },
+             "satellites": [
+                            {
+                                "originNamespace": "env-1-data-management",
+                            }
+                        ],
         }
 
     def test_bgdomain_satellite(self):

--- a/scripts/build_env/tests/env-build/test_composite_topology.py
+++ b/scripts/build_env/tests/env-build/test_composite_topology.py
@@ -26,18 +26,10 @@ class TestCompositeTopology:
 
         assert generator.ctx.current_env["composite_topology"] == {}
 
-    def test_baseline_only(self, tmp_path):
-        composite_structure = tmp_path / "composite_structure.yml"
-        composite_structure.write_text(
-            """
-    baseline:
-      type: namespace
-      name: env-1-core
-    """,
-            encoding="utf-8",
-        )
+    def test_baseline_only(self):
+        test_dir = TEST_DATA_DIR / "baseline-only"
 
-        generator = self._create_generator(tmp_path)
+        generator = self._create_generator(test_dir)
 
         generator.compute_composite_topology()
 

--- a/scripts/build_env/tests/env-build/test_composite_topology.py
+++ b/scripts/build_env/tests/env-build/test_composite_topology.py
@@ -1,0 +1,161 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from build_env.render_config_env import EnvGenerator
+
+
+TEST_DATA_DIR = (
+    Path(__file__).resolve().parents[4]
+    / "test_data"
+    / "test_environments"
+    / "composite-topology"
+)
+
+
+class TestCompositeTopology:
+
+    def _create_generator(self, test_dir):
+        generator = EnvGenerator()
+        generator.ctx.current_env_dir = str(test_dir)
+        generator.ctx.current_env = {}
+        return generator
+
+    def test_no_composite_structure(self, tmp_path):
+        generator = self._create_generator(tmp_path)
+
+        generator.compute_composite_topology()
+
+        assert generator.ctx.current_env["composite_topology"] == {}
+
+    def test_baseline_only(self):
+        test_dir = TEST_DATA_DIR / "baseline-only"
+
+        generator = self._create_generator(test_dir)
+
+        generator.compute_composite_topology()
+
+        assert generator.ctx.current_env["composite_topology"] == {
+            "baseline": {
+                "originNamespace": "env-1-core",
+            }
+        }
+
+    def test_namespace_baseline_and_satellites(self):
+        test_dir = TEST_DATA_DIR / "namespace-baseline-satellites"
+
+        generator = self._create_generator(test_dir)
+
+        generator.compute_composite_topology()
+
+        assert generator.ctx.current_env["composite_topology"] == {
+            "baseline": {
+                "originNamespace": "env-1-core",
+            },
+            "satellites": [
+                {
+                    "originNamespace": "env-1-oss",
+                },
+                {
+                    "originNamespace": "env-1-bss",
+                },
+            ],
+        }
+
+    @patch("build_env.render_config_env.get_bgd_object")
+    def test_bgdomain_baseline(self, mock_get_bgd_object):
+        test_dir = TEST_DATA_DIR / "bgdomain-baseline"
+
+        generator = self._create_generator(test_dir)
+
+        mock_get_bgd_object.return_value = {
+            "name": "bss",
+            "originNamespace": {
+                "name": "env-1-bss-origin",
+            },
+            "peerNamespace": {
+                "name": "env-1-bss-peer",
+            },
+            "controllerNamespace": {
+                "name": "env-1-controller",
+            },
+        }
+
+        generator.compute_composite_topology()
+
+        assert generator.ctx.current_env["composite_topology"] == {
+            "baseline": {
+                "originNamespace": "env-1-bss-origin",
+                "peerNamespace": "env-1-bss-peer",
+                "controllerNamespace": "env-1-controller",
+            }
+        }
+
+    @patch("build_env.render_config_env.get_bgd_object")
+    def test_bgdomain_satellite(self, mock_get_bgd_object):
+        test_dir = TEST_DATA_DIR / "bgdomain-satellite"
+
+        generator = self._create_generator(test_dir)
+
+        mock_get_bgd_object.return_value = {
+            "name": "bss",
+            "originNamespace": {
+                "name": "env-1-bss-origin",
+            },
+            "peerNamespace": {
+                "name": "env-1-bss-peer",
+            },
+            "controllerNamespace": {
+                "name": "env-1-controller",
+            },
+        }
+
+        generator.compute_composite_topology()
+
+        assert generator.ctx.current_env["composite_topology"] == {
+            "baseline": {
+                "originNamespace": "env-1-core",
+            },
+            "satellites": [
+                {
+                    "originNamespace": "env-1-bss-origin",
+                    "peerNamespace": "env-1-bss-peer",
+                    "controllerNamespace": "env-1-controller",
+                }
+            ],
+        }
+
+    @patch("build_env.render_config_env.get_bgd_object")
+    def test_bgdomain_baseline_and_satellites(self, mock_get_bgd_object):
+        test_dir = TEST_DATA_DIR / "bgdomain-baseline-satellites"
+
+        generator = self._create_generator(test_dir)
+
+        mock_get_bgd_object.return_value = {
+            "name": "bss",
+            "originNamespace": {
+                "name": "env-1-bss-origin",
+            },
+            "peerNamespace": {
+                "name": "env-1-bss-peer",
+            },
+            "controllerNamespace": {
+                "name": "env-1-controller",
+            },
+        }
+
+        generator.compute_composite_topology()
+
+        assert generator.ctx.current_env["composite_topology"] == {
+            "baseline": {
+                "originNamespace": "env-1-bss-origin",
+                "peerNamespace": "env-1-bss-peer",
+                "controllerNamespace": "env-1-controller",
+            },
+            "satellites": [
+                {
+                    "originNamespace": "env-1-bss-origin",
+                    "peerNamespace": "env-1-bss-peer",
+                    "controllerNamespace": "env-1-controller",
+                }
+            ],
+        }

--- a/scripts/build_env/tests/env-build/test_composite_topology.py
+++ b/scripts/build_env/tests/env-build/test_composite_topology.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from build_env.render_config_env import EnvGenerator
-
+from scripts.build_env.render_config_env import EnvGenerator
 
 TEST_DATA_DIR = (
     Path(__file__).resolve().parents[4]

--- a/test_data/test_environments/composite-topology/baseline-only/ composite_structure.yml
+++ b/test_data/test_environments/composite-topology/baseline-only/ composite_structure.yml
@@ -1,3 +1,0 @@
-baseline:
-  type: namespace
-  name: env-1-core

--- a/test_data/test_environments/composite-topology/baseline-only/ composite_structure.yml
+++ b/test_data/test_environments/composite-topology/baseline-only/ composite_structure.yml
@@ -1,0 +1,3 @@
+baseline:
+  type: namespace
+  name: env-1-core

--- a/test_data/test_environments/composite-topology/baseline-only/composite_structure.yml
+++ b/test_data/test_environments/composite-topology/baseline-only/composite_structure.yml
@@ -1,0 +1,3 @@
+baseline:
+  type: namespace
+  name: env-1-core

--- a/test_data/test_environments/composite-topology/bgdomain-baseline-satellites/bg_domain.yml
+++ b/test_data/test_environments/composite-topology/bgdomain-baseline-satellites/bg_domain.yml
@@ -1,0 +1,7 @@
+name: bss
+originNamespace:
+  name: env-1-bss-origin
+peerNamespace:
+  name: env-1-bss-peer
+controllerNamespace:
+  name: env-1-controller

--- a/test_data/test_environments/composite-topology/bgdomain-baseline-satellites/composite_structure.yml
+++ b/test_data/test_environments/composite-topology/bgdomain-baseline-satellites/composite_structure.yml
@@ -1,0 +1,7 @@
+baseline:
+  type: bgdomain
+  name: bss
+
+satellites:
+  - type: bgdomain
+    name: bss

--- a/test_data/test_environments/composite-topology/bgdomain-baseline/bg_domain.yml
+++ b/test_data/test_environments/composite-topology/bgdomain-baseline/bg_domain.yml
@@ -1,0 +1,7 @@
+name: bss
+originNamespace:
+  name: env-1-bss-origin
+peerNamespace:
+  name: env-1-bss-peer
+controllerNamespace:
+  name: env-1-controller

--- a/test_data/test_environments/composite-topology/bgdomain-baseline/composite_structure.yml
+++ b/test_data/test_environments/composite-topology/bgdomain-baseline/composite_structure.yml
@@ -1,0 +1,7 @@
+baseline:
+  type: bgdomain
+  name: bss
+
+satellites:
+  - type: namespace
+    name: env-1-data-management

--- a/test_data/test_environments/composite-topology/bgdomain-satellite/bg_domain.yml
+++ b/test_data/test_environments/composite-topology/bgdomain-satellite/bg_domain.yml
@@ -1,0 +1,7 @@
+name: bss
+originNamespace:
+  name: env-1-bss-origin
+peerNamespace:
+  name: env-1-bss-peer
+controllerNamespace:
+  name: env-1-controller

--- a/test_data/test_environments/composite-topology/bgdomain-satellite/composite_structure.yml
+++ b/test_data/test_environments/composite-topology/bgdomain-satellite/composite_structure.yml
@@ -1,0 +1,7 @@
+baseline:
+  type: namespace
+  name: env-1-core
+
+satellites:
+  - type: bgdomain
+    name: bss

--- a/test_data/test_environments/composite-topology/namespace-baseline-satellites/composite_structure.yml
+++ b/test_data/test_environments/composite-topology/namespace-baseline-satellites/composite_structure.yml
@@ -1,0 +1,9 @@
+baseline:
+  type: namespace
+  name: env-1-core
+
+satellites:
+  - type: namespace
+    name: env-1-oss
+  - type: namespace
+    name: env-1-bss


### PR DESCRIPTION
# Pull Request

## Summary

EnvGene resolves an environment's composite topology, its baseline plus satellites including Blue-Green domains, but
does not expose that topology to templates. This ticket adds a computed current_env.composite_topology variable that
carries the rendered Kubernetes namespace names of every member. A namespace-CR application and a cluster-wide
operator consume it to create secrets per namespace.

## Issue
https://github.com/Netcracker/qubership-envgene/issues/1545

## Breaking Change?

- [ ] Yes
- [X] No

If yes, describe the breaking change and its impact (e.g., API changes, behavior changes, or required updates for users).

## Scope / Project

Specify the component, module, or project area affected by this change (e.g., `docs`, `actions`, `workflows`).

## Implementation Notes

1.Add the [current_env.composite_topology](https://github.com/docs/template-macros.md#current_envcomposite_topology) Jinja macro,
resolved at [Environment Instance](https://github.com/docs/envgene-objects.md#environment-instance-objects) generation.
Type HashMap, default {}.
2.Populate the value only for composite environments, including composite environments that contain Blue-Green
domains. Resolve to {} for environments without a [Composite Structure](https://github.com/docs/envgene-objects.md#composite-structure).
3.Build the value from the [Composite Structure](https://github.com/docs/envgene-objects.md#composite-structure) object, which embeds
any inline Blue-Green domain. Copy the baseline and satellites tree, and resolve each member's namespace
template to its rendered namespace name as originNamespace.
4.Expand a bgdomain member into originNamespace, peerNamespace, and controllerNamespace. Keep a namespace
member with only originNamespace.
5.Widen the [Composite Structure](https://github.com/docs/envgene-objects.md#composite-structure) schema
(schemas/composite-structure.schema.json) so the cases below are representable in the source object. Allow a
bgdomain satellite member, mirroring the bgdomain baseline (Case D and Case E). Remove the minItems: 1
constraint on satellites so a baseline-only composite is valid (Case A). The full target schema is attached
under [Target schema](https://github.com/Netcracker/qubership-envgene/issues/1545#target-schema).

## Tests / Evidence

Describe how the changes were verified, including:

- Tests added or updated (e.g., unit, integration, end-to-end)
- Manual testing steps or results
- Screenshots, logs, or other evidence (if applicable)

## Additional Notes

Include any extra information, such as:

- Dependencies introduced
- Future work or follow-up tasks
- Reviewer instructions or context
- References to related PRs or discussions

Leave blank if not applicable.
