### PR TITLE
docs: Add ADR-0001 and registry_auth_adapter flow step

### DIFF
--- a/docs/adr/0001-adapt-registry-auth-from-e2e-parameters.md
+++ b/docs/adr/0001-adapt-registry-auth-from-e2e-parameters.md
@@ -1,0 +1,51 @@
+# ADR-0001: Generate RegDef v2 on the fly from RegDef v1 and pub_reg parameters
+
+Status: Proposed
+Date: 2026-08-20
+
+## Context
+
+EnvGene supports the new RegDef v2, but the rest of the DevOps toolset (deployer, ArgoCD, builder) does not
+yet. Those components read registry auth from the legacy pub_reg parameters in the pipeline context. Until
+they support v2, requiring both a RegDef v2 `authConfig` for EnvGene and the pub_reg parameters for everyone
+else would force operators to author the same auth twice.
+
+## Decision
+
+We add a temporary adapter step after `appregdef_render` that assembles a runtime `RegistryInfo` object in
+memory, the resolved form of a RegDef v2 and not a RegDef v2 file: the committed RegDef v1 coordinates plus
+an `authConfig` synthesized from the resolved pub_reg parameters (`PUB_REG_*`). It
+renders the Cloud object, folds paramsets into parameters, reads the whole `e2eParameters` section,
+expands its credential macros to resolve secret values, and takes the pub_reg parameters it needs. The whole
+object stays in memory and is never saved in the repository. The Java calculator is not a consumer, because
+it reads committed coordinates and needs no auth. The per-step consumer map is below.
+
+The transform is gated in two levels. A `configuration/config.yml` feature flag is the master switch, default
+off. When on, a per-registry pub_reg discriminator triggers it. A committed RegDef already at
+`version: "2.0"` is passed through. We remove the adapter once the rest of the toolset supports RegDef v2.
+
+Consumers of the synthesized object:
+
+- `process_sd`, `run_generate_deployment_plan`, and `get_sboms` read the synthesized `RegistryInfo` through
+  the shared dpg download path.
+- `process_env_template` (env template) is out of scope and authenticates through its Artifact Definition v2.
+- `generate_argocd_repo` performs no download and reads the local DD cache from `dd_downloading`.
+
+Rejected:
+
+- Teach the rest of the toolset to read RegDef v2 now, because that is a large multi-team change outside
+  EnvGene and is the end state this adapter bridges toward, not something available during the transition.
+- Keep operators authoring both the pub_reg parameters and a RegDef v2, because removing that double
+  authoring is the point of this decision.
+- Produce only an in-memory `authConfig` overlay on the v1 RegDef, because a full v2 object lets every
+  downloader read one uniform shape.
+
+## Consequences
+
+- Operators author registry auth once, as pub_reg parameters, during the transition, and RegDef v2 works for
+  EnvGene with no duplicate entry.
+- The adapter is flag-gated and disposable. It carries throwaway code until the toolset supports v2, at which
+  point it and the flag are removed.
+- The adapter must expand credential macros itself, because `create_credentials` runs later. This adds a
+  dependency on credentials being decrypted at that point.
+- Auth values cannot depend on `solution_structure`, because the early Cloud render precedes SD processing.

--- a/docs/adr/0001-adapt-registry-auth-from-e2e-parameters.md
+++ b/docs/adr/0001-adapt-registry-auth-from-e2e-parameters.md
@@ -24,7 +24,8 @@ The transform is gated in two levels. A `configuration/config.yml` feature flag 
 off. When on, a per-registry pub_reg discriminator triggers it. A committed RegDef already at
 `version: "2.0"` is passed through. We remove the adapter once the rest of the toolset supports RegDef v2.
 
-Consumers of the synthesized object:
+Consumers do not choose between the RegDef and `ctx`. They all resolve through the single `get_registry_info`
+seam, which returns the synthesized `RegistryInfo` for the run in place of the on-disk stub:
 
 - `process_sd`, `run_generate_deployment_plan`, and `get_sboms` read the synthesized `RegistryInfo` through
   the shared dpg download path.
@@ -49,3 +50,5 @@ Rejected:
 - The adapter must expand credential macros itself, because `create_credentials` runs later. This adds a
   dependency on credentials being decrypted at that point.
 - Auth values cannot depend on `solution_structure`, because the early Cloud render precedes SD processing.
+- The resolver seam does not exist yet. `get_registry_info` currently reads the on-disk RegDef and stubs
+  the auth, and its cache is per-name memoization, not an injection point, so the adapter must add it.

--- a/docs/adr/0001-adapt-registry-auth-from-e2e-parameters.md
+++ b/docs/adr/0001-adapt-registry-auth-from-e2e-parameters.md
@@ -50,5 +50,3 @@ Rejected:
 - The adapter must expand credential macros itself, because `create_credentials` runs later. This adds a
   dependency on credentials being decrypted at that point.
 - Auth values cannot depend on `solution_structure`, because the early Cloud render precedes SD processing.
-- The resolver seam does not exist yet. `get_registry_info` currently reads the on-disk RegDef and stubs
-  the auth, and its cache is per-name memoization, not an injection point, so the adapter must add it.

--- a/docs/technical-design/instance-pipeline/flow.md
+++ b/docs/technical-design/instance-pipeline/flow.md
@@ -12,16 +12,17 @@
       - [1.8 step `set_template_version`](#18-step-set_template_version)
       - [1.9 step `process_env_template` TO BE IMPLEMENTED. NOT IMPLEMENTED YET](#19-step-process_env_template-to-be-implemented-not-implemented-yet)
       - [1.10 step `appregdef_render`](#110-step-appregdef_render)
-      - [1.11 step `deploy_postfix_namespace_map`](#111-step-deploy_postfix_namespace_map)
-      - [1.12 step `process_sd`](#112-step-process_sd)
-      - [1.13 step `generate_deployment_plan`](#113-step-generate_deployment_plan)
-      - [1.14 step `env_build`](#114-step-env_build)
-      - [1.15 step `generate_effective_set`](#115-step-generate_effective_set)
-      - [1.16 step `git_commit`](#116-step-git_commit)
-      - [1.17 step `generate_argocd_repo` TO BE IMPLEMENTED. NOT IMPLEMENTED YET](#117-step-generate_argocd_repo-to-be-implemented-not-implemented-yet)
-      - [1.18 step `es_pusher`](#118-step-es_pusher)
-      - [1.19 step `cmdb_import`](#119-step-cmdb_import)
-      - [1.20 step `postprocess`](#120-step-postprocess)
+      - [1.11 step `registry_auth_adapter`](#111-step-registry_auth_adapter)
+      - [1.12 step `deploy_postfix_namespace_map`](#112-step-deploy_postfix_namespace_map)
+      - [1.13 step `process_sd`](#113-step-process_sd)
+      - [1.14 step `generate_deployment_plan`](#114-step-generate_deployment_plan)
+      - [1.15 step `env_build`](#115-step-env_build)
+      - [1.16 step `generate_effective_set`](#116-step-generate_effective_set)
+      - [1.17 step `git_commit`](#117-step-git_commit)
+      - [1.18 step `generate_argocd_repo` TO BE IMPLEMENTED. NOT IMPLEMENTED YET](#118-step-generate_argocd_repo-to-be-implemented-not-implemented-yet)
+      - [1.19 step `es_pusher`](#119-step-es_pusher)
+      - [1.20 step `cmdb_import`](#120-step-cmdb_import)
+      - [1.21 step `postprocess`](#121-step-postprocess)
     - [2 job `sync`](#2-job-sync)
       - [2.1 step `preprocess` TO BE IMPLEMENTED. NOT IMPLEMENTED YET](#21-step-preprocess-to-be-implemented-not-implemented-yet)
       - [2.2 step `sync` TO BE IMPLEMENTED. NOT IMPLEMENTED YET](#22-step-sync-to-be-implemented-not-implemented-yet)
@@ -287,7 +288,30 @@ Functions:
     - AI[techDebt-PERF]: renders only required appregdef
     - AI[techDebt-PERF]: implement create_if_not_exist | replace strategies
 
-#### 1.11 step `deploy_postfix_namespace_map`
+#### 1.11 step `registry_auth_adapter`
+
+Triggers:
+
+TBD
+
+Functions:
+
+1. `registry_auth_adapter`
+    - input:
+      - downloaded template files
+      - credentials
+      - `PUB_REG_*`, `NON_PUB_REG_*` parameters
+      - RegDefs v1
+      - `config.yaml`
+    - output:
+      - in-memory `RegistryInfo` per registry in `ctx`
+    - actions:
+      - render the Cloud object , fold paramsets into parameters, read the whole `e2eParameters`
+        section, expand credential macros to resolve secret values
+      - assemble a `RegistryInfo` from the committed RegDef v1 coordinates plus the pub_reg parameters.
+        The in-process Python downloaders (SD, DD, SBOM) consume it, and the Java calculator does not
+
+#### 1.12 step `deploy_postfix_namespace_map`
 
 Design: [`deploy_postfix_namespace_map`](/docs/technical-design/instance-pipeline/steps/deploy-postfix-namespace-map.md)
 
@@ -309,7 +333,7 @@ Functions:
       - build the map keyed by deployPostfix: non-BG postfix -> namespace name, BG postfix -> per-side entry with
         both `origin` and `peer` namespace names (side from the rendered BG domain)
 
-#### 1.12 step `process_sd`
+#### 1.13 step `process_sd`
 
 Triggers:
 
@@ -325,7 +349,7 @@ Functions:
       - `SD_SOURCE_TYPE`
       - `SD_REPO_MERGE_MODE`
       - `sd.yaml`
-      - appreg defs
+      - appreg defs v1 or synthesized `ctx.RegistryInfo` from `registry_auth_adapter`
     - output:
       - updated `sd.yaml`
     - actions:
@@ -347,7 +371,7 @@ Functions:
       - non-BG only
     - [phase1] add the function
 
-#### 1.13 step `generate_deployment_plan`
+#### 1.14 step `generate_deployment_plan`
 
 Design: [`process_deployment_plan`](/docs/technical-design/instance-pipeline/steps/process-deployment-plan.md)
 
@@ -363,10 +387,11 @@ Functions:
       - `OPERATION_TYPE: DEPLOY`
     - input:
       - `APPLICATION_VERSIONS`
-      - params.environment_id -> `build.env.FULL_ENV_NAME`
+      - `FULL_ENV_NAME`
       - app defs
       - `namespace-map.yml`
       - `BG_NS_TARGET`
+      - synthesized `RegistryInfo` from `ctx`
       - filters:
         - `DEPLOY_POSTFIXES_FILTER`
         - `NAMESPACE_NAMES_FILTER`
@@ -423,7 +448,7 @@ Functions:
       - writes the repository plan minus the cleaned namespaces (no delta, no plan passed to the calculator)
     - AI[bgd]: Add the functions
 
-#### 1.14 step `env_build`
+#### 1.15 step `env_build`
 
 Design: [`env_build`](/docs/technical-design/instance-pipeline/steps/env-build.md)
 
@@ -507,7 +532,7 @@ Functions:
       - set `cleaned: true` on `NAMESPACE_NAMES` namespaces (all if empty. error if a namespace is not found)
     - AI[techDebt-LOGS]: extract from `run_build_environment`
 
-#### 1.15 step `generate_effective_set`
+#### 1.16 step `generate_effective_set`
 
 Design: [`generate_effective_set`](/docs/technical-design/instance-pipeline/steps/generate-effective-set.md)
 
@@ -531,8 +556,8 @@ Functions:
       - delete sboms beyond the retention policy
 3. `get_sboms`
     - input:
-      - appreg defs
-      - `delta-deploy-plan.yml` for `DEPLOY` and warmup (produced in 1.13); no plan for `CLEAN` (marker-driven)
+      - appreg defs v1 or synthesized `ctx.RegistryInfo` from `registry_auth_adapter`
+      - `delta-deploy-plan.yml` for `DEPLOY` and warmup (produced in 1.14); no plan for `CLEAN` (marker-driven)
       - `APP_ARTIFACTS_DIR`
     - output:
       - DD and ZIP at `${APP_ARTIFACTS_DIR}`, sboms
@@ -547,7 +572,7 @@ Functions:
 4. `effective_set_entrypoint`
     - input:
       - env instance
-      - `delta-deploy-plan.yml` for `DEPLOY` and warmup (produced in 1.13); no plan for `CLEAN` (marker-driven)
+      - `delta-deploy-plan.yml` for `DEPLOY` and warmup (produced in 1.14); no plan for `CLEAN` (marker-driven)
       - sboms
       - `OPERATION_TYPE`
       - `BGD_OPERATION`
@@ -570,7 +595,7 @@ Functions:
       - if it does not, no-op
     - AI[phase2]: merge external creds feature
 
-#### 1.16 step `git_commit`
+#### 1.17 step `git_commit`
 
 Triggers:
 
@@ -588,7 +613,7 @@ Functions:
     - AI[phase2]: depending on `SAVE_ARTIFACTS_STRATEGY`, save env_instance/ES/deploy-plan.yaml to artifacts or not
     - AI[phase2]: unify with `es-pusher`
 
-#### 1.17 step `generate_argocd_repo` TO BE IMPLEMENTED. NOT IMPLEMENTED YET
+#### 1.18 step `generate_argocd_repo` TO BE IMPLEMENTED. NOT IMPLEMENTED YET
 
 Triggers:
 
@@ -613,7 +638,7 @@ Functions:
     - AI[phase2]: move into the orchestrator as a PipelineStep
     - AI[phase3]: move to GitHub
 
-#### 1.18 step `es_pusher`
+#### 1.19 step `es_pusher`
 
 Triggers:
 
@@ -647,7 +672,7 @@ Functions:
     - AI[phase3]: move to GitHub
     - AI[phase3]: unify with `git_commit`
 
-#### 1.19 step `cmdb_import`
+#### 1.20 step `cmdb_import`
 
 Triggers:
 
@@ -665,7 +690,7 @@ Functions:
     - AI[phase1]: remove envgene dot env file
     - AI[phase2]: move into the orchestrator as a PipelineStep
 
-#### 1.20 step `postprocess`
+#### 1.21 step `postprocess`
 
 Triggers:
 

--- a/docs/technical-design/instance-pipeline/steps/generate-effective-set.md
+++ b/docs/technical-design/instance-pipeline/steps/generate-effective-set.md
@@ -84,12 +84,12 @@ The `generate_effective_set` step writes the Effective Set under
 
 5. **Invoke Calculator CLI**
 
-   1. On `OPERATION_TYPE: DEPLOY` or BGD warmup, the step invokes Calculator CLI with environment id
+   1. On `OPERATION_TYPE: DEPLOY` or BGD warmup, the step invokes Calculator CLI with environment ID
       `<cluster-name>/<env-name>`, output path `effective-set/`, registry file
       `configuration/registry.yml`, SBOM path `sboms/`, and deploy-plan path
       `Inventory/delta-deploy-plan.yml`.
 
-   2. On `OPERATION_TYPE: CLEAN`, the step invokes Calculator CLI with environment id
+   2. On `OPERATION_TYPE: CLEAN`, the step invokes Calculator CLI with environment ID
       `<cluster-name>/<env-name>` and output path `effective-set/` without deploy-plan file path.
 
    3. When pipeline parameter `EFFECTIVE_SET_CONFIG` is set, the step appends configured extra CLI


### PR DESCRIPTION
Records the temporary RegDef v2 registry-auth adapter and adds it to the instance-pipeline flow.

- `docs/adr/0001-adapt-registry-auth-from-e2e-parameters.md` - the decision (transitional, flag-gated adapter that synthesizes a runtime `RegistryInfo` from RegDef v1 plus the pub_reg parameters, in memory only, removed once the toolset supports RegDef v2).
- `docs/technical-design/instance-pipeline/flow.md` - new `1.11 registry_auth_adapter` step, with the following steps renumbered. Consumers (`process_sd`, `run_generate_deployment_plan`, `get_sboms`) read the synthesized `RegistryInfo`.

An analyst issue with the open questions and deliverables will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)