### PR TITLE
test: add BDD tests for deploy sub-flows with scenarios, step definitions, and test data

### DIFF
--- a/.github/workflows/perform_e2e_tests.yml
+++ b/.github/workflows/perform_e2e_tests.yml
@@ -65,6 +65,17 @@ jobs:
                --junitxml=reports/bgd_sub_flows.xml \
                | tee -a /workspace/e2e_tests.log"
 
+      - name: Run Deploy Sub-flows BDD tests
+        run: |
+          docker compose -f devtools/docker-compose.yml exec -T cucumber bash -c \
+            "set -o pipefail && \
+             export PYTHONPATH=/workspace && \
+             cd /workspace && \
+             pytest cucumber_tests/step_defs/test_deploy_sub_flows.py \
+               -v -s \
+               --junitxml=reports/deploy_sub_flows.xml \
+               | tee -a /workspace/e2e_tests.log"
+
       - name: Run Calculator CLI BDD tests
         run: |
           docker compose -f devtools/docker-compose.yml exec -T cucumber bash -c \

--- a/cucumber_tests/features/deploy-sub-flows.feature
+++ b/cucumber_tests/features/deploy-sub-flows.feature
@@ -1,0 +1,58 @@
+Feature: Deploy sub-flows - deploy.md
+  As an EnvGene pipeline orchestrator
+  I want to run the correct subset of pipeline steps for each deploy architecture
+  So that No-CMDB v2 computes the deploy plan from APPLICATION_VERSIONS end to end and
+  No-CMDB v1 builds the env instance and effective set from a Solution Descriptor
+
+  # ── No-CMDB v2 - Deploy ──────────────────────────────────────────────────────
+  # PIPELINE_TYPE: GITLAB_DEPLOY, OPERATION_TYPE: DEPLOY. Build the env instance, compute the
+  # deploy plan from APPLICATION_VERSIONS, generate the effective set, commit. A deploy scoped
+  # to a Blue-Green side (BG_NS_TARGET) is covered separately in bgd-sub-flows.feature
+  # (Sub-flow 3 / Sub-flow 3 SD path), since that scenario's assertions center on
+  # namespace-map.yml resolution rather than the plain deploy step chain.
+
+  Scenario: No-CMDB v2 - deploy computes the deploy plan from APPLICATION_VERSIONS and commits the effective set
+    Given the workspace is initialized with test data from "e2e/uc_deploy"
+    And the pipeline parameter "PIPELINE_TYPE" is set to "GITLAB_DEPLOY"
+    And the pipeline parameter "OPERATION_TYPE" is set to "DEPLOY"
+    And the pipeline parameter "APPLICATION_VERSIONS" is set to a Solution Descriptor with deployPostfix "core" for "app1:1.0"
+    And the environment AppDefs and RegDefs paths are resolved for the deploy
+    When the unified pipeline orchestrator runs
+    Then the orchestrator completes successfully
+    And the pipeline step "appregdef_render" has status "SUCCESS"
+    And the pipeline step "deploy_postfix_namespace_map" has status "SUCCESS"
+    And the pipeline step "process_deployment_plan" has status "SUCCESS"
+    And the pipeline step "env_build" has status "SUCCESS"
+    And the pipeline step "generate_effective_set" has status "SUCCESS"
+    And the pipeline step "git_commit" has status "SUCCESS"
+    And the pipeline step "warmup" has status "SKIPPED"
+    And the pipeline step "change_bg_state" has status "SKIPPED"
+    And the pipeline step "process_sd" has status "SKIPPED"
+    And the deploy plan contains an entry for namespace "dummy-namespace" with version "app1:1.0"
+
+  # ── No-CMDB v1 ───────────────────────────────────────────────────────────────
+  # PIPELINE_TYPE defaults to LEGACY. ENV_BUILDER + GENERATE_EFFECTIVE_SET select an
+  # a-la-carte run: process_sd merges the Solution Descriptor, env_build renders the env
+  # instance, generate_effective_set produces the ES, git_commit commits both.
+
+  Scenario: No-CMDB v1 - a legacy SD-driven run builds the env instance and commits the effective set
+    Given the workspace is initialized with test data from "e2e/uc_deploy_legacy_sd"
+    And the pipeline parameter "ENV_BUILDER" is set to "true"
+    And the pipeline parameter "GENERATE_EFFECTIVE_SET" is set to "true"
+    And the pipeline parameter "SD_DATA" is set to a Solution Descriptor with deployPostfix "core" for "app1:1.0"
+    And the environment AppDefs and RegDefs paths are resolved for the deploy
+    When the unified pipeline orchestrator runs
+    Then the orchestrator completes successfully
+    And the pipeline step "appregdef_render" has status "SUCCESS"
+    And the pipeline step "process_sd" has status "SUCCESS"
+    And the pipeline step "env_build" has status "SUCCESS"
+    And the pipeline step "generate_effective_set" has status "SUCCESS"
+    And the pipeline step "git_commit" has status "SUCCESS"
+    # Per code, not the doc's flow list: DeployPostfixNamespaceMapStep itself requires
+    # GITLAB_DEPLOY, so it does not run for LEGACY - the namespace map that process_sd needs is
+    # instead seeded by MigrateSdToDeployPlanStep.execute() via compute_namespace_map() when
+    # ENV_BUILDER is set. Pinned here so a change either way is caught.
+    And the pipeline step "deploy_postfix_namespace_map" has status "SKIPPED"
+    And the pipeline step "process_deployment_plan" has status "SKIPPED"
+    And the pipeline step "warmup" has status "SKIPPED"
+    And the pipeline step "change_bg_state" has status "SKIPPED"

--- a/cucumber_tests/step_defs/deploy_sub_flows_steps.py
+++ b/cucumber_tests/step_defs/deploy_sub_flows_steps.py
@@ -1,0 +1,26 @@
+"""Feature-specific step definitions for deploy-sub-flows.feature."""
+from pytest_bdd import given, parsers
+from cucumber_tests.framework.workspace import EnvGeneWorkspace
+import yaml
+
+
+@given(parsers.parse(
+    'the pipeline parameter "SD_DATA" is set to a Solution Descriptor with '
+    'deployPostfix "{deploy_postfix}" for "{app_version}"'))
+def given_sd_data_as_solution_descriptor(
+    workspace: EnvGeneWorkspace, deploy_postfix: str, app_version: str
+):
+    # Deliberately hardcodes SD_DATA (not a generic {param} placeholder) so this step's Gherkin
+    # text cannot overlap with bgd_sub_flows_steps.given_application_versions_as_solution_descriptor,
+    # which matches the same "... is set to a Solution Descriptor ..." phrasing for
+    # APPLICATION_VERSIONS. process_sd.py's handle_sd() accepts inline SD content via SD_DATA,
+    # parsed with load_json_or_yaml() - unlike APPLICATION_VERSIONS, which dpg resolves as a file
+    # path (utils.is_file_path), so SD_DATA is written as inline YAML, not a file.
+    sd_content = yaml.dump({
+        "version": 2.2,
+        "type": "solutionDeploy",
+        "applications": [{"version": app_version, "deployPostfix": deploy_postfix}],
+    })
+    if not hasattr(workspace, "extra_env"):
+        workspace.extra_env = {}
+    workspace.extra_env["SD_DATA"] = sd_content

--- a/cucumber_tests/step_defs/test_deploy_sub_flows.py
+++ b/cucumber_tests/step_defs/test_deploy_sub_flows.py
@@ -1,0 +1,7 @@
+from pytest_bdd import scenarios
+from cucumber_tests.step_defs.deploy_sub_flows_steps import *  # noqa: F401,F403
+from cucumber_tests.step_defs.bgd_sub_flows_steps import *  # noqa: F401,F403
+from cucumber_tests.shared_steps.common_steps import *  # noqa: F401,F403
+from cucumber_tests.shared_steps.unified_pipeline_steps import *  # noqa: F401,F403
+
+scenarios('../features/deploy-sub-flows.feature')

--- a/cucumber_tests/test_data/e2e/uc_deploy/configuration/artifact_definitions/test-artifact.yaml
+++ b/cucumber_tests/test_data/e2e/uc_deploy/configuration/artifact_definitions/test-artifact.yaml
@@ -1,0 +1,11 @@
+name: "test-artifact"
+groupId: "org.test"
+artifactId: "test-artifact"
+registry:
+  name: "test-registry"
+  credentialsId: "test-registry"
+  mavenConfig:
+    repositoryDomainName: "http://localhost:8000/"
+    targetRelease: "release"
+    targetSnapshot: "release"
+    targetStaging: "release"

--- a/cucumber_tests/test_data/e2e/uc_deploy/environments/test-cluster/test-env/Credentials/credentials.yml
+++ b/cucumber_tests/test_data/e2e/uc_deploy/environments/test-cluster/test-env/Credentials/credentials.yml
@@ -1,0 +1,8 @@
+dummy:
+  type: secret
+  data:
+    secret: "dummy-secret"
+dummy-cred:
+  type: secret
+  data:
+    secret: "dummy-secret"

--- a/cucumber_tests/test_data/e2e/uc_deploy/environments/test-cluster/test-env/Inventory/env_definition.yml
+++ b/cucumber_tests/test_data/e2e/uc_deploy/environments/test-cluster/test-env/Inventory/env_definition.yml
@@ -1,0 +1,6 @@
+inventory:
+  environmentName: "test-env"
+  cloudName: "test-cluster"
+envTemplate:
+  name: "test"
+  artifact: "test-artifact:v1"

--- a/cucumber_tests/test_data/e2e/uc_deploy_legacy_sd/configuration/artifact_definitions/test-artifact.yaml
+++ b/cucumber_tests/test_data/e2e/uc_deploy_legacy_sd/configuration/artifact_definitions/test-artifact.yaml
@@ -1,0 +1,11 @@
+name: "test-artifact"
+groupId: "org.test"
+artifactId: "test-artifact"
+registry:
+  name: "test-registry"
+  credentialsId: "test-registry"
+  mavenConfig:
+    repositoryDomainName: "http://localhost:8000/"
+    targetRelease: "release"
+    targetSnapshot: "release"
+    targetStaging: "release"

--- a/cucumber_tests/test_data/e2e/uc_deploy_legacy_sd/environments/test-cluster/test-env/Credentials/credentials.yml
+++ b/cucumber_tests/test_data/e2e/uc_deploy_legacy_sd/environments/test-cluster/test-env/Credentials/credentials.yml
@@ -1,0 +1,8 @@
+dummy:
+  type: secret
+  data:
+    secret: "dummy-secret"
+dummy-cred:
+  type: secret
+  data:
+    secret: "dummy-secret"

--- a/cucumber_tests/test_data/e2e/uc_deploy_legacy_sd/environments/test-cluster/test-env/Inventory/env_definition.yml
+++ b/cucumber_tests/test_data/e2e/uc_deploy_legacy_sd/environments/test-cluster/test-env/Inventory/env_definition.yml
@@ -1,0 +1,6 @@
+inventory:
+  environmentName: "test-env"
+  cloudName: "test-cluster"
+envTemplate:
+  name: "test"
+  artifact: "test-artifact:v1"


### PR DESCRIPTION
## Summary
- Add `cucumber_tests/features/deploy-sub-flows.feature` covering `docs/technical-design/instance-pipeline/sub-flows/deploy.md`:
  - **No-CMDB v2** — Deploy computes the deploy plan from `APPLICATION_VERSIONS` and commits the effective set through the full step chain (`appregdef_render` → `deploy_postfix_namespace_map` → `process_deployment_plan` → `env_build` → `generate_effective_set` → `git_commit`).
  - **No-CMDB v1** — a legacy SD-driven run (`ENV_BUILDER` + `GENERATE_EFFECTIVE_SET` + `SD_DATA`) builds the env instance and commits the effective set. Pinned a real-vs-documented-flow gap: `deploy_postfix_namespace_map` itself is `SKIPPED` for this path since it requires `GITLAB_DEPLOY` — the namespace map it would produce is instead seeded by `MigrateSdToDeployPlanStep.execute()` via `compute_namespace_map()`.
- "Deploy to a Blue-Green side" is intentionally **not** duplicated here — already covered by `bgd-sub-flows.feature`'s Sub-flow 3 / Sub-flow 3 (SD path), whose assertions center on `namespace-map.yml` resolution.
- CMDB architecture is out of scope: `orchestrator.py` has no `cmdb_import` step, so it can't be exercised through the unified orchestrator this harness drives.
- New `test_data/e2e/uc_deploy` and `uc_deploy_legacy_sd` fixtures, a `deploy_sub_flows_steps.py` step module (only a `SD_DATA`-specific Solution Descriptor step - everything else reuses `bgd_sub_flows_steps.py` / `shared_steps`), `test_deploy_sub_flows.py` runner, and a CI step in `perform_e2e_tests.yml`.

## Test plan
- [x] `pytest cucumber_tests/step_defs/ -c cucumber_tests/pytest.ini --collect-only` — 77 tests collected, no ambiguous/missing step errors
- [x] `pytest cucumber_tests/step_defs/test_deploy_sub_flows.py -c cucumber_tests/pytest.ini -v -s` — 2/2 passed
- [x] `pytest cucumber_tests/step_defs/test_deploy_sub_flows.py cucumber_tests/step_defs/test_bgd_sub_flows.py -c cucumber_tests/pytest.ini` — 15/15 passed (no step collision with existing BGD scenarios)
- [x] `/code-review medium` on the staged diff — flagged a real step-definition collision (a too-generic `{param}` step shadowed `bgd_sub_flows_steps`'s APPLICATION_VERSIONS step); fixed by hardcoding `SD_DATA` in the step text
- [ ] CI: E2E BDD Tests / eig-e2e-tests (Docker-based full run)