### PR TITLE
docs: decompose CUSTOM_PARAMS deployment overrides into global and per-service

### DIFF
--- a/docs/adr/0005-decompose-custom-params-deployment-overrides.md
+++ b/docs/adr/0005-decompose-custom-params-deployment-overrides.md
@@ -1,0 +1,49 @@
+# ADR-0005: Decompose custom_params deployment overrides into global and per-service
+
+Status: Proposed
+Date: 2026-08-31
+
+## Context
+
+`custom_params` (the `CUSTOM_PARAMS` pipeline parameter) is the highest-priority, session-scoped override, applied
+last in the deployer's values merge. Its deployment overrides are written flat into `custom-params.yaml`, so an
+override sits only at the root level. A deployment parameter, by contrast, is laid out at the root, under the `global`
+block, and under each per-service key generated from the application's SBOM, so it is reachable inside each service. A
+flat custom override is absent from `global` and from the per-service keys, so it does not apply where a deployment
+parameter applies, which defeats the purpose of an incident-override tool.
+
+## Decision
+
+We decompose `custom_params` deployment overrides into the same root, `global`, and per-service structure that
+`deployment-parameters.yaml` uses, generated from the application's SBOM, written to `custom-params.yaml`, reusing the
+existing decomposition. The override then keeps its highest priority and applies wherever a deployment parameter
+applies. The scope is the deployment context only. The runtime and cleanup contexts are flat, so they are unchanged.
+`custom_params` overrides deployment and runtime parameters, not image or artifact metadata. `docker_tag`,
+`docker_registry` and `image` live in the read-only, SBOM-derived `deployDescriptor` block and stay non-overridable
+through `custom_params`.
+
+Rejected:
+
+- Author-controlled structured targeting, where the author writes the full path into `deployDescriptor`, because no
+  confirmed case needs overriding image metadata and it leaks the internal Effective Set structure to authors.
+- Generating a `deployDescriptor` block from `custom_params`, because `deployDescriptor` is read-only provenance
+  derived from the SBOM and user input has no mapping to it.
+- Extending the change to the runtime or cleanup context, because runtime is flat (Config Server injection) and
+  cleanup receives no Custom Params. The pipeline context is not a Custom Params target.
+
+## Consequences
+
+- A `custom_params` deployment override is present at the root, in `global`, and per-service, matching a deployment
+  parameter, and wins the merge, closing the silent no-op.
+- An override now applies at every per-service scope instead of at the root alone. This parity with deployment
+  parameters is intended, and the accepted cost is the wider scope compared with the former flat behavior.
+- A custom key equal to a service name reuses the existing collision handling. A custom key equal to `global`,
+  `deployDescriptor`, or a service name, carrying a scalar value, replaces a structural map and breaks the deploy. A
+  map value deep-merges safely. This is documented, not guarded.
+- The schema and `calculator-cli.md` currently imply `custom_params` applies to the cleanup context. This is
+  inaccurate against the behavior and is corrected to state deployment and runtime only.
+- This is a decision ahead of implementation. The decomposition is not yet wired, so `custom_params` keeps its flat
+  behavior until that lands.
+
+See [`CUSTOM_PARAMS`](/docs/instance-pipeline-parameters.md#custom_params) and the Effective Set deployment context
+in [Calculator CLI](/docs/features/calculator-cli.md).

--- a/docs/features/calculator-cli.md
+++ b/docs/features/calculator-cli.md
@@ -117,7 +117,7 @@ Below is a **complete** list of attributes
 | `--extra_params`/`-ex`                              | string  | no        | Additional parameters used by the Calculator for effective set generation. Multiple instances of this attribute can be provided                                                                                                                                                                               | N/A     | `DEPLOYMENT_SESSION_ID=550e8400-e29b-41d4-a716-446655440000`              |
 | `--app_chart_validation`/`-acv`                     | boolean | no        | Determines whether [app chart validation](#version-20-app-chart-validation) should be performed. If `true` validation is enabled (checks for `application/vnd.qubership.app.chart` in SBOM). If `false` validation is skipped                                                                                 | `true`  | `false`                                                                   |
 | `--enable-traceability`/`-etr`                      | boolean | no        | Determines whether [traceability](#version-20-traceability-comments) will be enabled. If `true`, traceability comments will be added. If `false`, they will be omitted.                                                                                                                                       | `false` | `true`                                                                    |
-| `--custom-params`/`-cp`                             | string  | no        | [Custom Params](/docs/glossary.md#custom-params) to inject into the Effective Set with highest priority. Applied to deployment, runtime, and cleanup contexts. Treated as sensitive. JSON-in-string format; value structure described in [CUSTOM_PARAMS](/docs/instance-pipeline-parameters.md#custom_params) | N/A     | `"{\"deployment\":{\"KEY\":\"val\"}}"`                                    |
+| `--custom-params`/`-cp`                             | string  | no        | [Custom Params](/docs/glossary.md#custom-params) to inject into the Effective Set with highest priority. Applied to the deployment and runtime contexts. Treated as sensitive. JSON-in-string format; value structure described in [CUSTOM_PARAMS](/docs/instance-pipeline-parameters.md#custom_params)       | N/A     | `"{\"deployment\":{\"KEY\":\"val\"}}"`                                    |
 
 ### Registry Configuration
 
@@ -866,7 +866,28 @@ These files must only contain keys that match the name of a [services](#version-
 
 This file is based on the parameter passed to the Calculator via `--custom-params`.
 
-It contains parameters from the `deployment` section of the object passed to `--custom-params`.
+It contains parameters from the `deployment` section of the object passed to `--custom-params`, decomposed into the
+same `global` block and per-service keys as
+[`deployment-parameters.yaml`](#version-20deployment-parameter-context-deployment-parametersyaml), generated from the
+application's SBOM. A Custom Param override is then present at the root, in the `global` block, and inside each service,
+so it applies the same way a deployment parameter does. The file keeps the highest priority because it is applied last.
+
+The structure of this file is as follows:
+
+```yaml
+<key-1>: <value-1>
+<key-N>: <value-N>
+global: &id001
+  <key-1>: <value-1>
+  <key-N>: <value-N>
+<service-name-1>: *id001
+<service-name-2>: *id001
+```
+
+Custom Params override deployment parameters, not artifact metadata. The `docker_tag`, `docker_registry`, and `image`
+values come from the Application's SBOM, live in the read-only
+[`deploy-descriptor.yaml`](#version-20deployment-parameter-context-deploy-descriptoryaml), and cannot be overridden
+through `--custom-params`.
 
 If `--custom-params` is not passed, the file is generated empty.
 
@@ -1506,13 +1527,9 @@ The structure of this file is as follows:
 
 ##### \[Version 2.0][Cleanup Context] `credentials.yaml`
 
-This file contains
-
-1. Sensitive parameters defined in the `deployParameters` sections of the `Tenant`, `Cloud`, and `Namespace` Environment Instance objects. For more information, refer to [Sensitive parameter processing](#version-20-sensitive-parameter-processing)
-
-2. Parameters from the `runtime` section of the object passed to `--custom-params`
-
-Parameters from `--custom-params` have higher priority.
+This file contains sensitive parameters defined in the `deployParameters` sections of the `Tenant`, `Cloud`, and
+`Namespace` Environment Instance objects. For more information, refer to [Sensitive parameter
+processing](#version-20-sensitive-parameter-processing).
 
 The structure of this file is as follows:
 

--- a/docs/how-to/generate-effective-set.md
+++ b/docs/how-to/generate-effective-set.md
@@ -212,7 +212,7 @@ Set this as a pipeline variable:
 CUSTOM_PARAMS: '{"deployment":{"FEATURE_FLAG_NEW_BILLING":"true","MAX_RETRIES":"5"}}'
 ```
 
-The injected parameters are written to `custom-params.yaml` inside each application's `values/` folder, applied at the highest priority level after all other values files.
+The injected parameters are written to `custom-params.yaml` inside each application's `values/` folder, applied at the highest priority level after all other values files. A `deployment` override is decomposed the same way as a deployment parameter (root, `global`, and per-service), so it applies inside each service. It cannot change image or artifact metadata such as `docker_tag`, `docker_registry`, or `image`, which come from the Application's SBOM.
 
 To target only specific namespaces instead of all, use the `namespaces` key. Namespaces not listed receive an empty `custom-params.yaml`. This mode is mutually exclusive with top-level `deployment`/`runtime` keys:
 

--- a/docs/instance-pipeline-parameters.md
+++ b/docs/instance-pipeline-parameters.md
@@ -530,11 +530,13 @@ hierarchy, and are treated as sensitive.
 
 Processed at both `PIPELINE_TYPE: GITLAB_DEPLOY` and `PIPELINE_TYPE: LEGACY`.
 
-`CUSTOM_PARAMS` is only applied when [`GENERATE_EFFECTIVE_SET`](#generate_effective_set) is `true`. If
-`GENERATE_EFFECTIVE_SET` is `false`, the `generate_effective_set` job does not run and `CUSTOM_PARAMS` has no effect.
-
 EnvGene passes the value unchanged to the Calculator CLI via `--custom-params`. See [Calculator
 CLI](/docs/features/calculator-cli.md) for how Custom Params are applied to the Effective Set.
+
+A `deployment` override is laid out at the root, in the `global` block, and per-service, the same as a deployment
+parameter, so it applies inside each service. Custom Params override deployment and runtime parameters. They do not
+override image or artifact metadata such as `docker_tag`, `docker_registry`, or `image`, which come from the
+Application's SBOM.
 
 **Format**: A map conforming to the [schema](/schemas/custom-params.schema.json). See
 [Parameter value formats](#parameter-value-formats).

--- a/schemas/custom-params.schema.json
+++ b/schemas/custom-params.schema.json
@@ -8,7 +8,7 @@
    "properties":{
       "deployment":{
          "type":"object",
-         "description":"Overrides applied to the deployment and cleanup context of Effective Set"
+         "description":"Overrides applied to the deployment context of Effective Set"
       },
       "runtime":{
          "type":"object",


### PR DESCRIPTION
## What

Document that `CUSTOM_PARAMS` `deployment` overrides are decomposed into the same root, `global`, and per-service
structure that `deployment-parameters.yaml` uses, generated from the application's SBOM, so an override applies inside
each service. Today `custom-params.yaml` is emitted flat, so an override sits only at the root level and does not apply
where a deployment parameter applies.

## Changes

- Add `docs/adr/0005-decompose-custom-params-deployment-overrides.md` (the design decision).
- `docs/features/calculator-cli.md`: describe the decomposition and add the `custom-params.yaml` structure block;
  state the contract boundary (no image or artifact metadata); drop `cleanup` from the `--custom-params` contexts.
- `docs/instance-pipeline-parameters.md`, `docs/how-to/generate-effective-set.md`: same contract in the operator docs.
- `schemas/custom-params.schema.json`: correct the `deployment` description to the deployment context only.

## Note

This is documentation ahead of code. The decomposition is not yet wired, so `custom_params` keeps its flat behavior
until the implementation lands. Reported as JCPR-3049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)