### PR TITLE
feat: add discrepancy-audit skill

### DIFF
--- a/.claude/skills/discrepancy-audit/SKILL.md
+++ b/.claude/skills/discrepancy-audit/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: discrepancy-audit
+description: >-
+  Explicit trigger only: /discrepancy-audit. Runs a topic-scoped, report-only audit that
+  reconciles EnvGene docs against code and schema and against other docs, emitting a
+  fact-oriented verdict table. Does not author or edit documentation (that is writing-docs),
+  does not review a PR through its BDD tests (that is bdd-test-review), and does not compare
+  code against coding standards or an issue spec (that is code-review). Do not auto-fire on
+  a general PR review ask, a doc editing request, or a single identifier factual question.
+---
+
+# discrepancy-audit
+
+Systematic subject-area reconciliation of docs-vs-code-vs-docs with a verdict table, no test
+intermediary, and no doc authoring. The skill takes a topic, gathers the relevant docs, code, and
+schemas, and produces a verdict report of discrepancies. Resolution - filing a CR, opening a docs PR -
+is handed off to `design-to-cr` or `writing-docs`. The skill never guesses intent. It reports the
+fact of a discrepancy plus what code or schema says, and leaves the fix direction to the human.
+
+## Neighbor boundary
+
+| Skill                              | Its job                                              | Why not it                                                  |
+|------------------------------------|------------------------------------------------------|-------------------------------------------------------------|
+| `writing-docs` (content-integrity) | Verify one identifier while writing a doc            | Not a systematic audit, no doc-vs-doc, no verdict report    |
+| `bdd-test-review`                  | Discrepancies seen through BDD tests on a PR         | Intermediary is tests. Here there is none.                  |
+| `code-review` (mattpocock)         | Code vs coding standards or issue spec               | Truth is code standards, not documentation                  |
+| `design-to-cr`                     | Turn a settled decision into a CR                    | Downstream. Consumes the verdict report from this skill.    |
+
+## Trigger
+
+Explicit only: `/discrepancy-audit`. Do not auto-fire. Do not fire on a general doc review request,
+a doc editing task, a single factual question about an identifier, or a PR review not explicitly
+directed at this skill.
+
+## Five phases
+
+1. **Scope resolution** - turn the topic into a concrete corpus: docs, code entry points, and schemas.
+   Show the corpus to the user before auditing. Boundaries are editable before phase 2 starts.
+2. **Claim extraction** - from corpus docs, pull checkable claims: identifiers, defaults, enum values,
+   contract parameters, behavior, and artifact producer/consumer pairs. Pure conceptual prose becomes
+   `unverifiable`.
+3. **Truth location** - for each claim, find the code or schema anchor. Apply the verify-before-claim
+   rules from `references/verify-before-claim.md`.
+4. **Verdict and evidence** - assign a verdict from `references/verdict-model.md`. Drop any row that
+   lacks its evidence pair.
+5. **Report** - emit the verdict table using the format in `references/report-format.md`.
+
+## Execution model
+
+Phases 1 and 2 may fan out to subagents to cover a wide corpus: `Explore` agents in phase 1 to gather
+candidate files, and one worker per corpus slice in phases 2 and 3 to extract claims and locate their
+code or schema anchors in parallel. A slice is a coherent sub-area (one CLI, one data-model group, one
+generation stage). Never fan out phase 4.
+
+Findings returned by a subagent are candidates, not verdicts. Before any finding enters the report, the
+controller re-verifies its evidence pair in the main context: open the cited doc line and the cited
+code or schema line and confirm both say what the finding claims. This keeps the grounded discipline of
+`references/verify-before-claim.md` even when reading was delegated. A candidate whose evidence does not
+survive re-verification is dropped or downgraded, never passed through on the subagent's word.
+
+For a narrow corpus, run all phases inline in the main context - the fan-out earns its cost only when
+the corpus is too large to hold at once.
+
+## Mode table
+
+| Mode        | Phase 1 (acquisition)                              | Status   |
+|-------------|----------------------------------------------------|----------|
+| topic       | Topic -> corpus (Explore agents or inline grep)    | live now |
+| PR/diff     | Worktree on PR head -> changed docs + their truth  | not yet  |
+| single-file | One .md -> its claims + cross-referenced docs      | not yet  |
+
+Adding mode 2 or 3 requires one new reference file and one new router row. Phases 2-5 and all core
+reference files stay untouched.
+
+## Reference files
+
+| Phase or concern                        | File                                   |
+|-----------------------------------------|----------------------------------------|
+| Verdict scale and evidence-pair gate    | `references/verdict-model.md`          |
+| Truth-location rules (phase 3)          | `references/verify-before-claim.md`    |
+| Topic-mode acquisition (phases 1 and 2) | `references/acquisition-topic.md`      |
+| Report structure (phase 5)              | `references/report-format.md`          |

--- a/.claude/skills/discrepancy-audit/references/acquisition-topic.md
+++ b/.claude/skills/discrepancy-audit/references/acquisition-topic.md
@@ -1,0 +1,60 @@
+# Acquisition - topic mode
+
+This file describes phases 1 and 2 of the audit harness for the topic-scoped mode. Phases 3, 4,
+and 5 (truth location, verdict assignment, and report) are governed by `references/verify-before-claim.md`,
+`references/verdict-model.md`, and `references/report-format.md` respectively, and are shared
+across all modes.
+
+## Phase 1 - scope resolution
+
+Turn the topic into a concrete corpus before any claim extraction begins. The corpus has three
+parts: a list of docs, a list of code entry points, and a list of relevant schemas.
+
+**Wide topics** (a feature area, an object type, a pipeline stage): fan out `Explore` agents to
+gather candidates across `docs/`, `scripts/`, `modules/`, `schemas/`, and `build_effective_set_generator/`.
+Return candidates as a list, not as pre-read content.
+
+**Narrow topics** (a single parameter, a single config key): use an inline glob or grep to locate
+the relevant files directly without fan-out.
+
+The corpus is shown to the user before any auditing starts. Boundaries are editable at that point.
+Do not proceed to phase 2 until the user confirms or adjusts the corpus. This confirmation gate
+exists because a missed doc or an extra doc changes which claims are extracted and which
+contradictions are visible. The primary corpus is user-facing documentation under `docs/`. Internal
+developer docs such as `CLAUDE.md` files may be included as a secondary source, but findings
+against them are flagged as internal-doc, not user-facing.
+
+### Worked example - "cert handling"
+
+Topic: how EnvGene handles SSL certificates.
+
+Corpus assembled from a narrow grep and directory scan:
+
+- Docs: `docs/how-to/configure-system-certificates.md`, `docs/features/system-certificate.md`
+- Code entry point: `scripts/utils/handle_certs.sh`
+- Schema: none (shell script, no JSON schema)
+
+The user confirms this corpus (or adds `configuration/config.yml` if cert-backend config is in
+scope). Phase 2 then extracts claims from the two doc files against the shell script.
+
+## Phase 2 - claim extraction
+
+From the confirmed corpus docs, pull every checkable claim. A checkable claim names a concrete,
+verifiable fact about the system. Pure conceptual prose that makes no falsifiable assertion becomes
+`unverifiable` and is carried in the report with that verdict, not dropped.
+
+The EnvGene claim taxonomy - the kinds of claims worth extracting:
+
+- **Identifiers** - parameter names, environment variable names, YAML field names, kind values,
+  enum values.
+- **Defaults** - the default value stated for a parameter or config field.
+- **Enum values** - the full set of allowed values and what each does.
+- **Contract parameters** - inputs and outputs of a pipeline step, calculator CLI argument names,
+  and flags.
+- **Behavior** - what the pipeline does in a given condition (for example, "skips provisioning
+  when `EXTERNAL_CREDENTIAL_PROVISIONING=skip`").
+- **Artifact producer/consumer pairs** - which step writes a file and which step reads it (for
+  example, "the SBOM downloader writes `dd.zip`, the effective-set generator reads it").
+
+For each extracted claim, record the source doc and line number. That record becomes the "doc
+quote" half of the evidence pair required in phase 4.

--- a/.claude/skills/discrepancy-audit/references/report-format.md
+++ b/.claude/skills/discrepancy-audit/references/report-format.md
@@ -1,0 +1,60 @@
+# Report format
+
+This file defines the structure phase 5 emits. Follow it exactly. Every rule here was established
+to keep the report grounded and auditable.
+
+## Header
+
+The report opens with three items, each on its own line:
+
+- **Topic** - the subject area as stated by the user.
+- **Corpus** - the docs, code entry points, and schemas actually read. List every file by path.
+  This transparency makes it visible what was NOT examined.
+- **Scope note** - any boundary the user confirmed, adjusted, or excluded during phase 1.
+
+## Discrepancy table
+
+Columns: `#`, `Claim (doc quote)`, `Axis`, `Verdict`, `Evidence (doc file:line + code/schema file:line)`,
+`Recommendation`.
+
+Rows are grouped in descending severity order:
+
+1. `contradiction`
+2. `doc-vs-doc` (covers both `doc-vs-doc / code breaks tie` and `doc-vs-doc / code silent`)
+3. `doc-ahead`
+4. `unverifiable`
+
+The table ends with a single summary line: `consistent: checked N` where N is the count of claims
+that were verified and matched. Consistent items are not listed as rows.
+
+## Legends
+
+After the table, include a legend block covering only the verdict values that actually appear in
+the table. Do not include legends for verdicts not used.
+
+| Verdict                        | Meaning                                                          |
+|--------------------------------|------------------------------------------------------------------|
+| `contradiction`                | Code exists and behaves differently from the doc.                |
+| `doc-ahead`                    | Behavior is documented but no code implements it yet.            |
+| `doc-vs-doc / code breaks tie` | Two docs disagree. Code matches one of them; that doc is correct.|
+| `doc-vs-doc / code silent`     | Two docs disagree. Code is silent. Resolution deferred.          |
+| `unverifiable`                 | Claim is pure prose with no code or schema anchor to check.      |
+
+## Self-checks before showing the report
+
+Run these three checks before presenting the report to the user:
+
+1. Every claim extracted in phase 2 is either a row in the table or carries the verdict `unverifiable`.
+   No claim may be silently dropped.
+2. Every row (other than `doc-ahead` and `unverifiable`) carries a complete evidence pair: a doc
+   quote with its file and line number, and a code or schema reference with its file and line number.
+3. The corpus stated in the header is complete: every file read during the audit appears in the
+   corpus list, and no file not in the corpus was used to form a verdict.
+
+## Publication
+
+The default output is chat. On the user's explicit request, write the report to
+`stuff/<topic>-discrepancy-audit.md` beside the repository clone (the scratch directory, not inside
+the repository). When writing to a file, apply house style: English, prose wrapped at 120 characters,
+no em dashes, no en dashes, no semicolons, `|---|` table separators with aligned pipes. Nothing is
+pushed or committed without explicit confirmation from the user.

--- a/.claude/skills/discrepancy-audit/references/verdict-model.md
+++ b/.claude/skills/discrepancy-audit/references/verdict-model.md
@@ -1,0 +1,30 @@
+# Verdict model
+
+The skill states the relationship between a doc claim and what code or schema does - never who is at
+fault and never what the intent was. Verdicts are fact-oriented. When two sources conflict, the skill
+records both sides and leaves the fix direction to the human.
+
+## Verdicts
+
+| Verdict                          | Condition                                             | Report carries                                                        |
+|----------------------------------|-------------------------------------------------------|-----------------------------------------------------------------------|
+| `contradiction`                  | Code exists and behaves differently from the doc      | Doc quote + code `file:line`. Fix direction is the human's call.      |
+| `doc-ahead`                      | Code absent for documented behavior                   | Doc quote. Separate category, not a defect.                           |
+| `doc-vs-doc / code breaks tie`   | Two docs disagree, code resolves it                   | Both quotes + code `file:line`. Names the doc that diverges from code.|
+| `doc-vs-doc / code silent`       | Two docs disagree, code is silent                     | Both quotes. Verdict deferred.                                        |
+| `unverifiable`                   | No code or schema anchor (pure prose)                 | Doc quote. Surfaced but flagged.                                      |
+| `consistent`                     | Checked, matches                                      | Not listed (or a "checked N" summary line at the table bottom).       |
+
+## Evidence-pair rule (hard gate)
+
+Every row in the verdict table must carry an evidence pair: a doc quote AND a code or schema
+`file:line`. A row that lacks either half of the pair is dropped from the report - not softened,
+not marked `unverifiable`, dropped. The purpose of this rule is to keep the report grounded in
+verifiable facts rather than in recalled or inferred claims.
+
+The only exception is `doc-ahead`, where the code half of the pair is "absent" by definition.
+For `doc-ahead` rows, the doc quote alone is sufficient, and the evidence cell records "no code
+found at HEAD."
+
+For `unverifiable`, no code anchor exists by definition either. The evidence cell records the
+doc quote and notes "pure prose - no code or schema to check."

--- a/.claude/skills/discrepancy-audit/references/verify-before-claim.md
+++ b/.claude/skills/discrepancy-audit/references/verify-before-claim.md
@@ -1,0 +1,39 @@
+# Verify before claim
+
+These are the truth-location rules for phase 3 of the audit harness. They apply in every mode
+(topic, PR/diff, single-file). Each rule exists because breaking it once produced a false claim
+in a real audit pass.
+
+EnvGene runs all pipeline jobs as one consolidated job, dispatched by `scripts/pipeline/orchestrator.py::dispatch`.
+The orchestrator fans out to parallel child processes via `multi_env_runner.fan_out()` for multi-environment
+runs. This architecture matters for rule 3: a step that looks absent from the primary flow may be
+invoked as a separate orchestrator phase, not inlined.
+
+## The four rules
+
+1. **Verify on the current HEAD.** Directories move between branches. The `python/` directory was
+   renamed to `modules/` in this branch, which made earlier greps silently blind and produced a
+   false "not implemented" claim. Always confirm the path exists before quoting it. A grep that
+   returns nothing may be pointing at a path that no longer exists.
+
+2. **For an artifact claim, locate both the writer and the reader.** A claim about a file or
+   parameter that the code produces requires finding where it is written AND where it is consumed.
+   A writer whose output no reader consumes is a different finding from a name mismatch between
+   writer and reader - and it is the worse finding. Do not stop the search at the writer.
+
+3. **Before declaring something unimplemented, search `dispatch` for a separate step.** The
+   orchestrator calls steps that are not inline in the main flow function. A behavior that appears
+   absent from one step may be implemented in a distinct phase invoked by `dispatch`. Exhausting
+   the orchestrator search is required before the `doc-ahead` verdict is used.
+
+4. **Verify where a payload actually fails and where data actually differs.** Names and comments
+   lie. A function named `validate_credentials` may exit without calling the schema validator in
+   certain branches. Always trace the actual execution path to the point of failure or divergence,
+   not the path implied by the symbol name.
+
+5. **A delegated finding is a candidate until re-verified in the main context.** When phases 2 and 3
+   are fanned out to subagents (see the execution model in `SKILL.md`), the findings they return are
+   candidates, not verdicts. Before a finding enters the report, open its cited doc line and its cited
+   code or schema line yourself and confirm both say what the finding claims. Rules 1 to 4 apply to
+   that re-verification. A candidate whose evidence does not survive is dropped or downgraded, never
+   passed through on the subagent's word.


### PR DESCRIPTION
# Pull Request

## Summary

Adds a Claude Code skill, `discrepancy-audit`, that reconciles EnvGene documentation against code and
schema and against other documentation, emitting a fact-oriented verdict table. The skill is
topic-scoped and report-only: it finds, classifies, and grounds discrepancies in evidence pairs, then
hands resolution off to `design-to-cr` or `writing-docs`. It never guesses intent; code and schema are
the truth source, and doc-vs-doc conflicts are resolved by code as the tiebreaker or deferred.

## Issue

No tracking issue. This is internal repository tooling (an agent skill under `.claude/skills/`) that
extends the existing skill set alongside `writing-docs`, `bdd-test-review`, and `design-to-cr`.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`.claude/skills/` (agent tooling). No product code, docs, workflows, or schemas are changed.

## Implementation Notes

- Thin `SKILL.md` router over four input-agnostic core reference files: `verdict-model.md`,
  `verify-before-claim.md`, `acquisition-topic.md`, `report-format.md`.
- Only the topic-scoped acquisition mode is live. PR/diff and single-file modes are stub rows in the
  router, extensible later by adding one reference file and one router row without touching the core.
- Fact-oriented verdict model (`contradiction`, `doc-ahead`, `doc-vs-doc / code breaks tie`,
  `doc-vs-doc / code silent`, `unverifiable`, `consistent`) with a hard evidence-pair gate: every
  reported row carries a doc quote and a code or schema `file:line`.
- `SKILL.md` documents the phase 1-3 subagent fan-out execution model, with mandatory main-context
  re-verification of delegated findings so the grounded discipline holds even when reading is delegated.

## Tests / Evidence

- Per-file spec-compliance review of all five files against the design (fresh-context reviewer):
  spec PASS, quality APPROVED.
- End-to-end dry-run on the topic "system certificate handling": the harness built a corpus, extracted
  claims, located truth on HEAD, and emitted a verdict table. The verify-on-HEAD rule caught a stale
  path inside the skill's own worked example, which was then fixed.
- Second live run: a cross-branch external-credentials audit (docs on this branch, code on a POC
  branch) exercised the fan-out execution model and surfaced real doc-vs-code and doc-vs-doc
  discrepancies with verified evidence pairs.

## Additional Notes

- No runtime dependencies introduced. The skill is Markdown only.
- Follow-up: the PR/diff and single-file acquisition modes are left as stubs for a later change.