### PR TITLE
docs: correct external-credentials docs against phase-2 code

### DIFF
--- a/docs/features/calculator-cli.md
+++ b/docs/features/calculator-cli.md
@@ -1540,10 +1540,11 @@ credentials:
     # Carries `?secret_store_id=<id>` when the store is not `default_store`.
     vals: string
     # Derived from Credential.create: `fail_if_absent` when absent or false,
-    # `create_if_absent` when true.
+    # `create_if_absent` when true. `overwrite` is reserved for a future rotation
+    # flow and is not emitted by the calculator.
     strategy: enum [ fail_if_absent, create_if_absent, overwrite ]
-    # Emitted only for `create_if_absent` (or `overwrite`), omitted for
-    # `fail_if_absent`. Carries the reserved marker `_generateValue` per field.
+    # Emitted only for `create_if_absent`, omitted for `fail_if_absent`. Carries
+    # the reserved marker `_generateValue` per field.
     data: string | map
 ```
 

--- a/docs/features/external-creds-provisioning-cli.md
+++ b/docs/features/external-creds-provisioning-cli.md
@@ -55,9 +55,10 @@ external-cred-provision --dry-run effective-set/external-credential/external-cre
 
 ### Options
 
-| Flag                       | Default | Meaning                                              |
-|----------------------------|---------|------------------------------------------------------|
-| `--dry-run`                | off     | Run checks only, no writes                           |
+| Flag                  | Default | Meaning                                                        |
+|-----------------------|---------|----------------------------------------------------------------|
+| `--dry-run`           | off     | Run checks only, no writes                                     |
+| `--log-level <LEVEL>` | `DEBUG` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
 
 When `--dry-run` is set, the CLI runs the [Dry-run phase](#dry-run-phase). No writes happen.
 
@@ -215,11 +216,11 @@ failures. The summary line tallies them.
 In dry-run mode the CLI performs no writes. For each strategy, the CLI runs the
 prerequisite check shown below.
 
-| Strategy           | Dry-run check                                              |
-|--------------------|------------------------------------------------------------|
-| `fail_if_absent`   | the credential exists at the target path                   |
-| `create_if_absent` | the authenticated principal can create at the target path  |
-| `overwrite`        | the authenticated principal can create at the target path  |
+| Strategy           | Dry-run check                                                                         |
+|--------------------|---------------------------------------------------------------------------------------|
+| `fail_if_absent`   | the credential exists at the target path                                              |
+| `create_if_absent` | the store is reachable and authentication succeeds (write permission is not verified) |
+| `overwrite`        | the store is reachable and authentication succeeds (write permission is not verified) |
 
 ## Value generation
 

--- a/docs/features/external-creds.md
+++ b/docs/features/external-creds.md
@@ -332,6 +332,9 @@ It may contain several secret store objects:
   projectId: string
 ```
 
+For OpenBao, use `type: vault`. OpenBao is Vault-compatible, so EnvGene addresses it through the Vault
+reference scheme, and no separate store type exists.
+
 The map key `<secret-store-name>` is the **store identifier**. It must match the regular expression
 `[A-Za-z_][A-Za-z0-9_]*`, so it is usable as a CI/CD variable prefix at provisioning time (see
 [Store identifier and CI/CD variables](#store-identifier-and-cicd-variables)). Dashes and other characters
@@ -471,8 +474,9 @@ consumed by the [External Credentials provisioning CLI](/docs/features/external-
 The context shape is a `credentials` map. Secret Store definitions and authentication are out of band - the
 CLI reads them from the job environment.
 
-The file is emitted when at least one [Credential](#credential) has `type: external`. Otherwise the file is
-not produced.
+The file is emitted when every [Credential](#credential) in the Environment Instance has `type: external`. If
+all Credentials are local, the file is not produced. Effective Set generation rejects a mix of external and
+local Credentials.
 
 This context is located at:
 
@@ -502,7 +506,7 @@ credentials:
     # `overwrite` is reserved for a future rotation flow and is not emitted by
     # the calculator.
     strategy: enum [fail_if_absent, create_if_absent, overwrite]
-    # Emitted only when `strategy` is `create_if_absent` (or `overwrite`).
+    # Emitted only when `strategy` is `create_if_absent`.
     # Omitted for `fail_if_absent` because the CLI does not write.
     #
     # Calculator-emitted Context carries the reserved marker `_generateValue`.

--- a/docs/technical-design/instance-pipeline/flow.md
+++ b/docs/technical-design/instance-pipeline/flow.md
@@ -568,7 +568,6 @@ Functions:
     - actions:
       - if the Effective Set includes external credential context, run the credential provisioning CLI, which creates or verifies the credentials in the external credential store
       - if it does not, no-op
-    - AI[phase2]: merge external creds feature
 
 #### 1.16 step `git_commit`
 


### PR DESCRIPTION
# Pull Request

## Summary

Corrects the external-credentials documentation where it diverged from the phase-2 provisioning code.
The discrepancies were found by a docs-vs-code audit of the external-credentials feature (docs on
`feature/modern-toolset`, code on `feature/external_credentials_phase2_on_POC`). Each change was
verified against the actual code and passed an author-critic review.

## Issue

No tracking issue. Documentation-accuracy fixes surfaced during an audit.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`docs` only. No code, schema, or workflow changes.

## Implementation Notes

- `docs/features/external-creds.md`
  - The External Credential Context file is emitted for an all-external Environment Instance, not
    "when at least one Credential is external". A mix of external and local Credentials is rejected
    during Effective Set generation.
  - Note that OpenBao uses `type: vault` (OpenBao is Vault-compatible, there is no separate store type).
  - `data` is emitted only for `create_if_absent` (removed the stray "or overwrite").
- `docs/features/calculator-cli.md`
  - Note that `overwrite` is reserved for a future rotation flow and is not emitted by the calculator.
- `docs/features/external-creds-provisioning-cli.md`
  - Document the `--log-level` option of the CLI.
  - Correct the dry-run description: for `create_if_absent` and `overwrite`, the check confirms the
    store is reachable and authentication succeeds, but write permission is not verified.
- `docs/technical-design/instance-pipeline/flow.md`
  - Drop the stale `AI[phase2]` annotation on the `external_credential_provisioning` step (the step is
    implemented in the phase-2 code).

## Tests / Evidence

- Every changed claim was verified against the phase-2 provisioning code (Python CLI, Java calculator,
  and schemas).
- An author-critic review pass confirmed factual accuracy against the code and house-style compliance.
- `markdownlint` with the project config reports no issues on the changed files.

## Additional Notes

- Out of scope by decision: removing the unused `url` field from `secret-stores.schema.json` (a code and
  fixture change that rides with the phase-2 merge), the `azure` env-var row (a separate gap), and the
  `vaultAppRole` credential type (intentionally not surfaced in the feature doc).