### PR TITLE
feat: add writing-gherkin skill

### DIFF
--- a/.claude/skills/writing-gherkin/SKILL.md
+++ b/.claude/skills/writing-gherkin/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: writing-gherkin
+description: >-
+  Generate NEW acceptance criteria or Cucumber (Gherkin) scenarios for a qubership-envgene feature or
+  change, before the tests exist. Use this whenever someone wants to enumerate the cases a behavior must
+  satisfy: "draft gherkin for X", "write cucumber scenarios for this feature", "list the scenarios
+  covering feature X", "acceptance criteria or conditions for a CR or issue #N", "turn this use case
+  into test cases", or a request to cover the happy path plus each failure mode of some behavior,
+  including a specific named failure like "cover the missing-at-root case" or "every way the merge can
+  fail". The source can be a change request or issue, a subject area or topic, or a single feature or
+  use-case doc. Produces both a collapsed acceptance-criteria list and full Given/When/Then scenarios.
+  Do not trigger to grade or review scenarios that already exist (that is bdd-test-review), to file the
+  CR issue itself (that is design-to-cr), to run or debug existing tests, or to write step definitions
+  or other test code.
+---
+
+# writing-gherkin
+
+Turn described behavior into checkable cases. The skill reads a source, enumerates the observable cases
+the behavior must satisfy, grounds each case in an observable channel, and renders the cases as two
+projections of one ladder: collapsed-Gherkin acceptance criteria and full Given/When/Then Cucumber
+scenarios.
+
+The skill produces the cases and their renderings. It does not judge scenarios that already exist, it
+does not open the CR issue, and it does not write step definitions or golden files. Those are separate
+jobs (see the boundary below).
+
+## Why one ladder
+
+A CR states acceptance criteria before code exists. A test suite needs full Cucumber scenarios after
+code exists. When these are authored by two independent hands, they drift: the CR promises one set of
+cases and the suite checks another. This skill enumerates the cases once, then renders the same case
+list two ways, so the acceptance section of a CR and the scenarios in the suite stay the same behavior
+described at two levels of detail.
+
+## Boundary
+
+| Skill                    | Its job                                             | Why not it                                            |
+|--------------------------|-----------------------------------------------------|-------------------------------------------------------|
+| `bdd-test-review`        | Validate and grade scenarios that already exist     | That reviews existing tests. This authors new cases.  |
+| `design-to-cr`           | File the CR issue and write its body                | That publishes the issue. This only drafts the cases. |
+| `writing-docs`           | Write the prose of docs, readmes, issues            | That is prose style. This is behavior enumeration.    |
+| step definitions / code  | Implement the Gherkin steps in Python               | This authors scenarios, never their executable code.  |
+
+## Trigger
+
+Invoke explicitly, or when a consumer skill calls for case generation. Do not auto-fire on a request to
+review existing tests, to file a CR, or to edit prose.
+
+## Five phases
+
+1. **Acquisition** - resolve the source into the material to read: the described behavior, its
+   variations, and the observable channels it names. Read `references/acquisition.md` for the three
+   input modes (CR, topic, doc file).
+2. **Enumeration** - derive the case list: documented variations, the happy path per valid combination,
+   and each independent failure mode. Read `references/enumeration.md`.
+3. **Grounding** - attach each case to an observable channel and verify it, adapting to whether code
+   exists yet. Cases with no channel are flagged, not rendered as fake tests. Read
+   `references/grounding.md`.
+4. **Rendering** - render the grounded case list as collapsed-Gherkin acceptance criteria and full
+   Cucumber scenarios, reusing the suite's existing step vocabulary. Read `references/rendering.md`.
+5. **Output** - present the case list, the two renderings, and the grounding report. Default to chat.
+   On request, write a `.feature` draft under `cucumber_tests/features/` or a scratch draft under
+   `stuff/`. Never commit or push without explicit confirmation.
+
+## Input modes
+
+| Mode      | Source                                                        | Status   |
+|-----------|---------------------------------------------------------------|----------|
+| CR        | A filed issue or a CR draft that carries a design reference   | live now |
+| topic     | A subject area, resolved to the relevant docs and behavior    | live now |
+| doc file  | A single `docs/features/*.md` or `docs/use-cases/*.md`        | live now |
+
+The router in this file picks the mode. Phases 2 to 5 and the core reference files are input-agnostic.
+
+## Reference files
+
+| Phase or concern                          | File                            |
+|-------------------------------------------|---------------------------------|
+| Input handling per mode (phase 1)         | `references/acquisition.md`     |
+| Case enumeration (phase 2)                | `references/enumeration.md`     |
+| Observable-channel grounding (phase 3)    | `references/grounding.md`       |
+| Ladder rendering to both forms (phase 4)  | `references/rendering.md`       |
+
+## Output discipline
+
+- Show the enumerated case list before rendering, so the boundaries are editable. A missed variation or
+  an extra case changes every scenario downstream.
+- Every rendered row traces to one enumerated case. No scenario appears without a case, and no grounded
+  case is silently dropped.
+- Flag ungroundable cases explicitly. A case with no observable channel cannot become an honest test.
+- When running unattended - invoked by another skill or a batch run with no interactive user - list the
+  corpus and the case list for the record and proceed, rather than blocking on a confirmation that will
+  never come.

--- a/.claude/skills/writing-gherkin/references/acquisition.md
+++ b/.claude/skills/writing-gherkin/references/acquisition.md
@@ -1,0 +1,53 @@
+# Acquisition - the three input modes
+
+Phase 1 resolves the source into three things the later phases need: the described behavior, its
+variations, and the observable channels the behavior names. This file covers how each input mode gets
+there. Phases 2 to 5 are the same regardless of mode.
+
+Show the assembled material to the user before enumerating. A missed doc or an extra one changes which
+cases come out, so the source boundary is worth confirming once.
+
+## Mode: doc file
+
+The source is a single `docs/features/*.md` or `docs/use-cases/*.md` path.
+
+- A use-case doc is the richest source. Use cases are written as observable behavior that doubles as
+  test-design input, so their steps already name outcomes and often the channel that carries them.
+- A feature doc states the contract: the objects, the fields, the enum values, the behavior in each
+  condition. Read the whole doc, not one section - a variation named in an early section often drives a
+  failure mode described later.
+- Collect the doc's cross-references. When the doc links a schema or another feature doc for a rule it
+  relies on, that linked file is part of the material.
+
+## Mode: topic
+
+The source is a subject area, for example "external credentials" or "SBOM retention".
+
+- Resolve the topic into a corpus the way `discrepancy-audit` does in its topic mode: fan out to gather
+  the relevant feature docs, use-case docs, and schemas, then read them.
+- A wide topic spans several docs. Gather candidates first, show the corpus, and let the user trim it
+  before enumeration.
+- The topic mode carries the most risk of missing a variation, because nothing scopes the behavior for
+  you. Prefer a use-case doc as the spine when one exists, and treat the feature docs as the source of
+  the variation axes.
+
+## Mode: CR
+
+The source is a filed issue or a CR draft that carries a design reference.
+
+- A CR is pre-code by default: it describes behavior a developer has not built yet. This is the mode
+  where grounding is truth-adaptive toward the design-named channel (see `references/grounding.md`).
+- Read the CR body for the In scope items and any Covered cases, and read the linked design doc for the
+  behavior and its channels. The CR's own Acceptance section, if present, is a starting case list to
+  extend and ground, not a finished answer.
+- A CR without a design reference is not ready for case generation. Say so and stop, the same way
+  `design-to-cr` refuses a link-less CR. There is no addressable behavior to enumerate against.
+
+## What phase 1 hands to phase 2
+
+- The behavior statement: what the system does, in the source's own words.
+- The variation axes: the dimensions the behavior varies along (action, place, mode, object shape).
+- The named channels: every log line, error message, emitted request, or output file the source names
+  as an observable effect. These seed grounding.
+- Whether code exists yet: post-code (an implemented PR or a shipped feature) or pre-code (a CR for
+  unbuilt behavior). This selects the grounding strategy.

--- a/.claude/skills/writing-gherkin/references/enumeration.md
+++ b/.claude/skills/writing-gherkin/references/enumeration.md
@@ -1,0 +1,69 @@
+# Enumeration - deriving the case list
+
+Phase 2 turns the behavior and its variation axes into a list of cases. A case is a distinct situation
+the behavior must handle, stated precisely enough that one scenario can check it. The list drives
+everything downstream, so completeness here matters more than polish.
+
+The method is the union of what the two consumer skills already do by hand: the completeness matrix that
+`bdd-test-review` builds, and the independent-failure enumeration that `design-to-cr` writes into an
+Acceptance section.
+
+## Step 1 - build the variation matrix
+
+Take the variation axes from phase 1 and cross them. Typical axes in this repository:
+
+- **action** - create, update, delete, warmup, and so on.
+- **place** - tenant, cloud, namespace, application, or the topology positions baseline and satellite.
+- **mode** - dry-run versus apply, a toggle set versus absent, a run mode.
+- **object shape** - the discrete shapes a payload can take (a credential type, a topology case).
+
+Cross the axes that actually interact. Do not cross axes that are independent - a full Cartesian product
+of unrelated axes produces cases that cannot fail independently, and those are noise. The matrix is a
+tool for finding combinations you would otherwise miss, not a mandate to enumerate every cell.
+
+## Step 2 - one happy path per valid combination
+
+For each combination that produces an observable success, write one happy-path case. Its outcome is the
+success the behavior promises, and it must be observable (see grounding).
+
+## Step 3 - each independent failure mode
+
+Add a case for every way the behavior can fail independently of the others. This is the rule that keeps
+the list honest, borrowed from `design-to-cr`:
+
+- A case earns its place only when it can fail on its own. A missing folder and a missing file inside
+  that folder are two cases, because each fails for its own reason and produces its own error.
+- A case that is only logically derivable from another is not a separate case. If case B cannot fail
+  unless case A already failed, B is not independent.
+- Enumerate the failure, not the mechanism. "The registry rejects the request" is a failure mode. "The
+  retry counter reaches three" is a mechanism, not a case, unless the retry limit is the documented
+  behavior under test.
+
+## Step 4 - mark discriminating siblings
+
+Two cases are siblings when they differ only in a precondition that flips the outcome: a mode set versus
+absent, a file present versus missing, an external credential versus a local one. For every sibling
+pair, record the discriminating precondition. Rendering will put it in the Given so the outcome cannot
+be read as applying to the sibling.
+
+## Step 5 - record the failure point for negatives
+
+For each failure case, record where the behavior fails - the stage that produces the error. This is the
+rule `bdd-test-review` uses to catch tests that prove nothing: a "rollback on mid-processing failure"
+case whose input dies at upfront schema validation never exercises rollback and silently duplicates the
+plain schema negative. The failure point is what makes the negative discriminating, and rendering writes
+it into the Then.
+
+## What each case carries into phase 3
+
+- A discriminating precondition (fixture, placement, mode).
+- The observable outcome the case asserts.
+- For negatives, the failure point the outcome must reach.
+- A short note on which variation cell or failure mode the case covers, so the list can be checked for
+  gaps against the matrix.
+
+## Check the list before grounding
+
+Read the list back against the matrix. Every documented variation is either a case or a deliberate
+omission with a reason. Every failure mode named in the source has a case. Present the list to the user
+at this point - it is far cheaper to add a missed case here than after both renderings exist.

--- a/.claude/skills/writing-gherkin/references/grounding.md
+++ b/.claude/skills/writing-gherkin/references/grounding.md
@@ -1,0 +1,66 @@
+# Grounding - the observable-channel gate
+
+Phase 3 is the gate that keeps generated scenarios from being empty. A scenario is only worth writing
+if its outcome can be observed from outside the system, because a check against unobservable internal
+state passes whether or not the behavior works. This is the exact failure `bdd-test-review` hunts, so
+the generator refuses to produce it in the first place.
+
+Run this gate on every case before rendering. A case that passes carries a verified channel into
+rendering. A case that fails is reported as `ungroundable`, never rendered as if it were a real test.
+
+## The channel requirement
+
+Every case outcome must attach to an observable channel: something a step can actually assert against.
+The channels available in this repository, from the existing suite:
+
+- **a log line** - "the pipeline log contains X".
+- **an error message** - the job fails with an error that names the specific cause.
+- **an emitted request** - a request arrives at a mock registry or store, with a distinguishing target.
+- **an output or golden file** - a file is written, or a directory contains exactly the expected files.
+
+An outcome phrased as internal state ("resolution uses the root-level copy", "the entry is marked
+stale") has no channel. Rewrite it into the observable effect that state produces ("the request targets
+the root-level registry", "the directory retains exactly K files"), or flag it if no such effect exists.
+
+Give fixtures distinguishing traits so the outcome is checkable. When two copies of a definition could
+both satisfy an outcome, a distinct registry name per copy makes the emitted request reveal which copy
+won. Without the distinguishing trait, the check cannot tell the right outcome from a wrong one.
+
+## Truth-adaptive verification
+
+Where you confirm the channel exists depends on whether the code exists yet. Phase 1 recorded which
+case you are in.
+
+### Post-code (an implemented PR or a shipped feature)
+
+The code and often existing `.feature` and step definitions exist. Verify each channel against reality,
+borrowing the discipline from `discrepancy-audit`:
+
+- Confirm the code actually emits the outcome on the channel. Do not trust the outcome's name - trace
+  the execution path to the point where the log line, error, request, or file is produced.
+- For a file or golden outcome, find the writer. An outcome that asserts a file no code writes is not
+  grounded.
+- Check whether the existing step vocabulary can already assert the channel. If a step like "the SBOM
+  directory X contains N files" exists, the case is paste-ready. If not, note that a new step is needed.
+- For a negative, confirm the failure actually reaches the recorded failure point in the code, not an
+  earlier stage.
+
+### Pre-code (a CR for unbuilt behavior)
+
+The code does not exist, so there is nothing to trace. Ground against the design instead:
+
+- Require the design or CR to name the channel. "The job fails with an error naming the missing
+  definition and both checked locations" names the channel (the error message) even though no code
+  produces it yet. The acceptance criterion binds to that named channel.
+- Mark these outcomes as pre-code and unverified against code. When the code lands, that named channel
+  is exactly what the test will check, which is the point of authoring the acceptance criteria first.
+- If the design names no channel for an outcome, the outcome is not yet a testable contract. Flag it as
+  an open question for the design rather than inventing a channel.
+
+## The ungroundable report
+
+Collect every case that has no channel - no real one post-code, no design-named one pre-code. Report
+them as a short list with the reason each one lacks a channel. These are not failures of the skill, they
+are findings: either the outcome needs to be restated observably, or the behavior needs a new observable
+effect before it can be tested. Surfacing them is more useful than hiding them inside a scenario whose
+Then asserts nothing.

--- a/.claude/skills/writing-gherkin/references/rendering.md
+++ b/.claude/skills/writing-gherkin/references/rendering.md
@@ -1,0 +1,77 @@
+# Rendering - the ladder into two forms
+
+Phase 4 renders the grounded case list. The same list produces two projections at different levels of
+detail: collapsed-Gherkin acceptance criteria for a CR, and full Cucumber scenarios for a `.feature`
+file. Render whichever the caller asked for, or both when running standalone. Because both come from one
+case list, a CR's acceptance section and the suite's scenarios describe the same behavior.
+
+## Acceptance criteria (collapsed Gherkin)
+
+One line per case: `Given <discriminating fixture and mode>, <observable outcome through its channel>.`
+The Given states the prepared on-disk state and any run or placement mode. The rest collapses When and
+Then into a single observable-outcome clause. This is the notation `design-to-cr` consumes, so honor its
+Acceptance rules:
+
+- Make every outcome externally observable through the channel grounding verified. Prefer "the job fails
+  with an error naming the missing definition and both checked locations" over internal state.
+- Keep each line self-contained. Inline the observable contract. Do not link to a use case or a design
+  section from inside an acceptance line.
+- Put a sibling's discriminating precondition in the Given, so the outcome cannot be read as applying to
+  the sibling.
+- One line per independently-failing case. Do not fold a missing folder and a missing file into one.
+
+Example:
+
+> - Given an AppDef committed only under `configuration/` and none at the instance root, the job fails
+>   with an error naming the missing definition and both checked locations.
+
+## Cucumber scenarios (full Gherkin)
+
+Full `Scenario` blocks with Given, When, Then. Match the existing suite exactly so drafts are
+paste-ready, because a scenario that invents its own step vocabulary cannot run.
+
+- **Reuse the suite's step vocabulary verbatim.** Read the existing `.feature` files and step
+  definitions first, and phrase steps the way they already read: "the workspace is initialized with test
+  data from ...", "the pipeline parameter ... is set to ...", "the unified pipeline orchestrator runs",
+  "the orchestrator completes successfully", "the pipeline log contains ...". A new step is a last
+  resort, and when one is unavoidable, call it out so a step definition can be written.
+- **Name each scenario with its case.** Use the family's UC ID scheme, continuing the numbering. When
+  proposing additions to an existing family, continue from the last used ID.
+- **The Then asserts the grounded channel.** Every Then checks the observable channel from phase 3 - a
+  log line, an error, an emitted request, a file or directory assertion. A scenario whose Then only
+  restates the When is empty.
+- **Negatives assert the failure point.** Write the Then so the failure is observed at the stage the
+  case recorded, not merely that something failed.
+- **Use Scenario Outline with an Examples table only when the fixture structure is identical across
+  variants and only a literal value changes** - a place or mode that renames a scope but keeps the same
+  setup. When variants need different fixtures (for example a different secret-store type with its own
+  test data and reference shape), write separate scenarios. An Examples table over structurally
+  different fixtures is superficial and hides the real setup.
+- **Start each draft with a `# why:` comment** stating the case it covers, so any case ID can be found
+  by search.
+
+## Handling data that does not exist yet
+
+- Paths and fixtures that already exist in the repository stay real, so the draft is paste-ready.
+- Data that must be created appears as a `<placeholder>` in the angle-bracket style the suite uses, so
+  it is obviously not yet real.
+- A scenario expected to fail until an issue is fixed carries a comment naming the state: `@xfail(strict)
+  with a link to #NNNN until the fix`. This is the same convention `bdd-test-review` uses when a
+  divergence is resolved code-side.
+
+## When the feature has no test-suite integration yet
+
+A subject area may have no way to reach it through the existing suite - a component that runs standalone
+(a CLI invoked outside the pipeline) or a behavior with no pipeline entry point. Every step for it is a
+new step. Do not hide this by rendering the scenarios as if they were paste-ready. Put them in a
+separate Feature or scenario group, annotate each new step with `# NEW STEP NEEDED`, and open the group
+with a comment that it is a stub pending step definitions. This tells the reader honestly that the cases
+are designed but not yet runnable, which is more useful than a green-looking block that cannot execute.
+Treat a file-absence or file-content assertion the same way when the suite has no step for it.
+
+## Keep the two forms in step
+
+The acceptance line and the full scenario for one case must assert the same channel. If rendering an
+acceptance line reveals that the full scenario would check a different observable, the case was
+under-specified - go back and fix the case, not one rendering. The value of the ladder is that the two
+forms cannot drift, and that only holds if both trace to the same grounded case.


### PR DESCRIPTION
# Pull Request

## Summary

Adds a Claude Code skill, `writing-gherkin`, that generates acceptance criteria and Cucumber (Gherkin)
scenarios from a change request, a subject area, or a doc file. It enumerates the observable cases a
behavior must satisfy once, then renders them two ways - collapsed-Gherkin acceptance criteria and full
Given/When/Then scenarios - so a CR's acceptance section and the test suite's scenarios describe the
same behavior at two levels of detail. It is standalone now, and is intended to be reused later by
`bdd-test-review` and `design-to-cr`.

## Issue

No tracking issue. Internal repository tooling (an agent skill under `.claude/skills/`), a third member
of the `writing-*` skill family alongside `writing-docs` and `writing-adrs`.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`.claude/skills/` (agent tooling). No product code, docs, schemas, or workflows change.

## Implementation Notes

- Thin `SKILL.md` router over four input-agnostic reference files: `acquisition.md` (three input modes:
  CR, topic, doc file), `enumeration.md` (variation matrix plus each independent failure mode plus
  discriminating siblings), `grounding.md`, and `rendering.md`.
- The quality gate is observable-channel grounding, adapted to whether code exists. Every case outcome
  must attach to an observable channel (a log line, an error message, an emitted request, or an output
  or golden file). Post-code, the channel is verified against the real code and existing steps.
  Pre-code (a CR for unbuilt behavior), it binds to the channel the design names. A case with no channel
  is flagged, not rendered as an empty test.
- Rendering reuses the existing suite's step vocabulary so scenarios are paste-ready, and a subsystem
  with no suite integration is rendered as an explicit stub block rather than a green-looking one that
  cannot run.

## Tests / Evidence

- End-to-end dry-run on the topic "external credentials": the skill built a corpus, enumerated about
  thirty cases across seven groups, grounded them truth-adaptively (correctly separating pre-code
  effective-set generation from post-code CLI behavior), surfaced a real gap (a documented
  single-category validation with no observable code path, marked with an xfail placeholder), and
  rendered both acceptance criteria and full scenarios. Three refinements from the dry-run feedback were
  folded back into the skill.
- Trigger evaluation over twenty queries showed precision 100 percent (no false triggers) and low
  recall, the expected profile for an authoring skill. The description was tuned for clarity, and the
  reliable invocation paths are the explicit command and the consumer skills.
- `markdownlint` with the project config reports no issues on the skill files.

## Additional Notes

- Wiring `writing-gherkin` into `bdd-test-review` and `design-to-cr` is deliberately left for a later
  change. This PR adds the standalone skill only.