### PR TITLE
docs: add optional root description attribute to Template Descriptor

### DIFF
--- a/docs/envgene-objects.md
+++ b/docs/envgene-objects.md
@@ -81,6 +81,9 @@ It has the following structure:
 
 ```yaml
 # Optional
+# Free-form text describing the purpose of this Template Descriptor
+description: string
+# Optional
 # Template Composition configuration
 # See details in https://github.com/Netcracker/qubership-envgene/blob/main/docs/features/template-composition.md
 parent-templates:

--- a/schemas/template-descriptor.schema.json
+++ b/schemas/template-descriptor.schema.json
@@ -4,6 +4,14 @@
   "description": "Configuration for environment templates including tenant, cloud, namespaces, optional external credential template path",
   "type": "object",
   "properties": {
+    "description": {
+      "title": "Description",
+      "description": "Free-form text describing the purpose of this Template Descriptor",
+      "type": "string",
+      "examples": [
+        "Environment template for the dev BSS solution"
+      ]
+    },
     "tenant": {
       "title": "Tenant Path",
       "description": "Path to the tenant template file",


### PR DESCRIPTION
## What

Adds an optional root-level `description` attribute to the Template Descriptor: a free-form string where a user states the purpose of the descriptor.

## Changes

- `docs/envgene-objects.md` — documents `description` as the first optional root attribute in the Template Descriptor YAML structure block.
- `schemas/template-descriptor.schema.json` — adds a `description` string property (with title and example). It stays optional, since it is not in the `required` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)