### PR TITLE
feat(writing-gherkin): enumerate output-surface and entity-category axes

### DIFF
--- a/.claude/skills/writing-gherkin/references/enumeration.md
+++ b/.claude/skills/writing-gherkin/references/enumeration.md
@@ -16,10 +16,24 @@ Take the variation axes from phase 1 and cross them. Typical axes in this reposi
 - **place** - tenant, cloud, namespace, application, or the topology positions baseline and satellite.
 - **mode** - dry-run versus apply, a toggle set versus absent, a run mode.
 - **object shape** - the discrete shapes a payload can take (a credential type, a topology case).
+- **output surface** - every distinct artifact or context the behavior writes to: each generated file,
+  each effective-set context, each output channel. A behavior that writes several outputs usually
+  applies a different rule per output, so each surface is its own axis. A surface that explicitly
+  EXCLUDES the behavior is a case too - the exclusion is a testable rule, not an absence to skip.
+- **entity category** - every kind or role of the central entity the behavior handles: for example a
+  user-supplied instance of it, a system-supplied one, and a built-in reference to one. Each category
+  often carries its own rules and its own failures, on its own code path.
 
 Cross the axes that actually interact. Do not cross axes that are independent - a full Cartesian product
 of unrelated axes produces cases that cannot fail independently, and those are noise. The matrix is a
 tool for finding combinations you would otherwise miss, not a mandate to enumerate every cell.
+
+Before you leave Step 1, list every output surface and every entity category the docs name, out loud,
+and confirm each one has at least one case or a stated reason it does not apply. The most common miss is
+a surface or a category that the docs mention once and the enumeration never returns to - a second
+output context that carries the same references under a different rule, or a system or built-in variant
+of the entity with its own constraints. Naming them explicitly is what stops the matrix from silently
+collapsing to the one surface and the one category you started with.
 
 ## Step 2 - one happy path per valid combination
 


### PR DESCRIPTION
# Pull Request

## Summary

Improves the `writing-gherkin` skill's enumeration phase so it does not miss whole families of cases.
The phase listed only action, place, mode, and object-shape as variation axes, so a behavior that writes
to several output contexts or handles several categories of its central entity would silently collapse
to the one surface and the one category the run started from. This adds two axes and requires an explicit
audit of both.

## Issue

Follow-up to #1757 (the skill's initial version). A real coverage gap was found when the skill's output
was reviewed: scenarios missed system and built-in credentials and the pipeline, topology, and runtime
contexts.

## Breaking Change?

- [ ] Yes
- [x] No

## Scope / Project

`.claude/skills/writing-gherkin/references/enumeration.md` (agent tooling). No product code, docs,
schemas, or workflows change.

## Implementation Notes

- Adds an **output surface** axis: every distinct artifact or context the behavior writes to (each
  generated file, each effective-set context, each output channel), including a surface that explicitly
  excludes the behavior, since the exclusion is itself a testable rule.
- Adds an **entity category** axis: every kind or role of the central entity (a user-supplied instance,
  a system-supplied one, a built-in reference to one), each often on its own code path with its own
  rules and failures.
- Requires an explicit audit of both, out loud, before leaving Step 1, so the matrix cannot silently
  collapse to the single surface and category the run began with.

## Tests / Evidence

- Blind re-run on the external-credentials topic with no hint about the gap: the skill independently
  surfaced the pipeline, topology, and runtime contexts and the system and built-in credential
  categories, and its self-check credited the two new audits for the discovery. The prior version, run
  the same way, had missed them.
- `markdownlint` with the project config reports no issues.

## Additional Notes

- The gap was found while reviewing the scenario set produced for a real story. The two new axes are
  general (any feature that produces multiple output artifacts, or handles multiple kinds of an entity),
  not specific to credentials.