### PR TITLE
feat: add dev-flow orchestrator skill and design-to-cr handoff improvements

### DIFF
--- a/.claude/skills/design-to-cr/SKILL.md
+++ b/.claude/skills/design-to-cr/SKILL.md
@@ -96,6 +96,14 @@ For Acceptance, when a condition has a sibling case (a mode set versus absent, a
 missing), put the discriminating precondition in the Given so the outcome cannot be read as applying to
 the sibling.
 
+Carry the design-time seam into Implementation notes. When the design settled a load-bearing implementation
+insight - where the change attaches and how - record it as guidance, because the developer who implements
+this may be a different person or session than the one who designed it, and that insight does not survive
+the handoff unless the CR carries it. The canonical form: reuse the existing mechanism, and if it is not
+directly reusable, extract a helper rather than adding a parallel path. This is what a developer's plan
+turns into a first-task spike. Keep it in documented-surface vocabulary - name the behavior or mechanism
+the design reused, not a function or a file.
+
 ### Acceptance notation
 
 Write each acceptance condition in collapsed Gherkin: `Given <fixture>, <observable outcome>.` The Given
@@ -182,6 +190,10 @@ is a miss that has actually shipped in a filed CR, so treat them as blocking rat
   Use commit-SHA permalinks, pinned to the doc PR head commit when the doc has not merged yet.
 - House rules (as stated under House-rule compliance): no em or en dashes, no semicolons in prose,
   prose wrapped at 120.
+- No doc-ahead-of-code meta line: strip any sentence that frames the CR as catching code up to docs,
+  for example "the design docs are ahead of the code" or "this CR wires the described behavior". It is
+  noise, not guidance - the reader is the developer who will write the code, and the code's current
+  state is theirs to change. State the behavior contract and how to verify it, nothing about the gap.
 
 ### File the issue
 

--- a/.claude/skills/dev-flow/SKILL.md
+++ b/.claude/skills/dev-flow/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: dev-flow
+description: >-
+  Orchestrate the design-to-code-PR delivery flow for a qubership-envgene change as a sequence of
+  isolated phase subagents, each on an explicit model, handing work over through files rather than
+  conversation history. Use this to run or resume the full flow - "run the dev flow for this change",
+  "orchestrate design to PR", "drive this CR through plan, implement, review", "resume the flow", "what
+  phase are we on" - or to run a single named phase (cr, plan, implement, review, verify) against a
+  settled design. Each phase reads its entry artifact, invokes the right child skill, writes its exit
+  artifact, updates the flow ledger, and returns only a short status. Keeps the orchestrator context
+  small and routes cheap models to mechanical work. Do not use this to author a design from scratch
+  (that is brainstorming), to write docs (writing-docs), or to file a CR directly (design-to-cr) - this
+  wraps those, it does not replace them.
+---
+
+# dev-flow
+
+Run the delivery flow - design, CR, plan, implement, review, verify - as a chain of **isolated phase
+subagents**. Each phase is a fresh context that reads a file artifact, does its work through a child
+skill, writes a file artifact, and returns a short status. The orchestrator stays thin, and each phase
+runs on the cheapest model that fits.
+
+## Why this exists
+
+Running the whole flow in one growing conversation is expensive: the context is re-read on every turn,
+at the session model's rate, for thousands of turns. Two levers fix it, and this skill encodes both:
+
+- **Phase isolation (context stays small).** A subagent runs in its own context, transcript, and
+  cache. Only a short result summary returns to the orchestrator, so the orchestrator does not grow as
+  phases complete. Handing work over as files, not chat, is what makes a phase restartable from
+  nothing.
+- **Model routing (rate stays low).** Model tier is a function of a turn's judgement depth, not its
+  importance. Mechanical and reversible work runs cheap, load-bearing judgement runs on a strong
+  model. Because each phase is a separate dispatch, the model is chosen per phase.
+
+## The invariant
+
+If a phase cannot be run from scratch by reading only its entry artifacts, the hand-over artifact is
+incomplete. That is the quality gate - not "it is convenient to continue in this chat". State lives in
+git, the CR issue, and the ledger. A phase never reads "what we discussed".
+
+## Phases at a glance
+
+Read `references/phase-map.md` for the full per-phase contract (entry and exit artifacts, the child
+skill, the dispatch prompt, and the model). Summary:
+
+| Phase       | Child skill                     | Model (default)          | Exit artifact              |
+|-------------|---------------------------------|--------------------------|----------------------------|
+| design      | brainstorming + adrs + docs     | interactive, main loop   | ADR + doc edits + doc PR   |
+| cr          | design-to-cr                    | Sonnet                   | CR issue (Story or Feature)|
+| plan        | writing-plans                   | Sonnet                   | plan file + task briefs    |
+| implement   | subagent-driven-development     | Sonnet controller        | code + tests + code PR     |
+| review      | code-review (+ writing-gherkin) | Sonnet, Spec escalates   | review report + BDD slice  |
+| verify      | none (CI poll)                  | Haiku or Sonnet, async   | green checks recorded      |
+| acceptance  | none (human sign-off)           | human                    | sign-off recorded          |
+
+`design` and `acceptance` are interactive and human-gated - the orchestrator prepares their inputs and
+waits, it does not dispatch a subagent to hold a human dialogue. Everything from `cr` through `verify`
+is dispatched.
+
+## How to run
+
+1. **Locate or create the ledger.** The ledger is `.superpowers/flow/<slug>.md`, git-ignored scratch.
+   Its format and the resume protocol are in `references/ledger.md`. If a ledger for this change
+   exists, read it and resume at the first unchecked phase. If not, create one from the template.
+2. **Confirm the entry point.** A flow starts from a settled design - an ADR and a doc PR that a fresh
+   reader can open. If the design is not settled, stop and run `brainstorming` first. This skill wraps
+   the mechanical phases, it does not invent the design.
+3. **Run one phase at a time.** For the current phase, dispatch exactly as `references/phase-map.md`
+   specifies: the entry-artifact paths, the child skill to invoke, the exit-artifact path, and the
+   model. Pass the model explicitly on every dispatch - an omitted model inherits the orchestrator's,
+   which defeats routing.
+4. **Gate between phases.** By default, after a phase completes, summarize its result in one or two
+   lines and ask the user before starting the next phase. Run straight through only when the user asked
+   for `auto`.
+5. **Update the ledger, then continue.** Mark the phase complete with its exit artifact, append any
+   ruling, and move on. The ledger - not this conversation - is the recovery map.
+
+## Dispatch discipline
+
+The whole cost argument rests on keeping the orchestrator thin. Hold to these:
+
+- **Hand over files, never pasted context.** A dispatch prompt names the entry-artifact paths and the
+  exit-artifact path. It does not paste prior-phase output or conversation history into the prompt. The
+  subagent reads the files itself.
+- **Return status, not content.** Each phase subagent writes its full output to the exit artifact and
+  returns only: status, the artifact path, the identifiers it created (issue number, PR number,
+  commits), and any concern. Do not ask it to echo the artifact back.
+- **One phase, one dispatch.** Do not fan out phases in parallel - they depend on each other's exit
+  artifacts. Within a phase, the child skill may fan out (implement dispatches implementers) - that is
+  the child skill's job, up to the 3-layer spawn depth.
+- **Explicit model always.** Every dispatch carries its model from `references/phase-map.md`. When a
+  phase escalates a cheap turn to a stronger model, record why in the ledger.
+
+## Model routing rules
+
+The per-phase defaults are in `references/phase-map.md`. On top of them:
+
+- **Sonnet is the floor for anything with a reasoning loop.** Haiku is for pure transcription and CI
+  polling only. A weak model on branching work takes more turns and costs more overall - the false
+  economy the routing exists to avoid.
+- **Escalate to a strong model** when the entry artifact does not settle a fork, when an adversarial
+  verification must genuinely refute a claim, or after a repeated failure in a fix loop.
+- **The one expensive point inside implement** is the final whole-branch review - dispatch it on the
+  most capable model. Implementers doing transcription from a complete plan run cheap.
+
+## Reference files
+
+- `references/phase-map.md` - the per-phase contract: entry and exit artifacts, child skill, dispatch
+  prompt template, and model, for every phase.
+- `references/ledger.md` - the flow-ledger format, the resume protocol, and the ruling log.

--- a/.claude/skills/dev-flow/references/ledger.md
+++ b/.claude/skills/dev-flow/references/ledger.md
@@ -1,0 +1,65 @@
+# Flow ledger
+
+The ledger is the recovery map. It lives at `.superpowers/flow/<slug>.md`, git-ignored scratch, one
+file per change. The orchestrator reads it to know the current phase and resumes from it after any
+interruption. It records state, not narration - the commits, issues, and PRs it names exist in git and
+GitHub even when no conversation remembers creating them.
+
+The `<slug>` is a short kebab-case name for the change, matching the work branch where practical, for
+example `custom-params-decomposition`.
+
+## Template
+
+```markdown
+# dev-flow ledger - <slug>
+
+Design reference: <ADR path> / doc PR #<NNNN>
+CR issue: #<NNNN>
+Base branch: feature/modern-toolset
+Work branch: <branch>
+Mode: gate | auto
+
+## Phases
+
+- [ ] design      - <ADR + doc PR, or "settled elsewhere">
+- [ ] cr          - <issue #, when filed>
+- [ ] plan        - <plan path, when written>
+- [ ] implement   - <PR #, when opened>
+- [ ] review      - <report path, when done>
+- [ ] verify      - <checks outcome, when green>
+- [ ] acceptance  - <sign-off, when signed>
+
+## Log
+
+<append-only. one line per dispatch, ruling, or escalation, newest last.>
+```
+
+## Resume protocol
+
+1. Read the ledger. The first phase whose checkbox is unchecked is the current phase. Every checked
+   phase is done - do not re-run it. Its exit artifact exists in git or GitHub.
+2. If the current phase is `implement` and an SDD ledger exists under
+   `.superpowers/sdd/<plan-basename>/`, that ledger governs the task loop. Resume the task loop from
+   it, not from this flow ledger. This flow ledger only records that `implement` is in progress.
+3. Verify the previous phase's exit artifact is real before starting the current phase - the issue
+   exists, the plan file is on disk, the PR is open. A ledger checkbox is a claim, git is the truth. If
+   they disagree, trust git and correct the ledger.
+4. Dispatch the current phase per `phase-map.md`, on its model, with its entry-artifact paths.
+
+## Recording rules
+
+- **Mark complete only on a real exit artifact.** `cr` is complete when the issue is filed and its
+  number is in the ledger, not when a draft is written. `implement` is complete when the PR is open.
+- **Append rulings, never rewrite them.** When the entry artifact does not settle a fork and the phase
+  decides it, append `Ruling: <decision> - <why> - <cost if wrong>` to the log. This is how a decision
+  survives a fresh session.
+- **Record model escalations.** When a phase runs a turn on a stronger model than its default, append
+  one line saying which turn and why. This keeps the routing auditable.
+- **One ledger per change.** A ledger whose first line names a different change is not yours. Leave it
+  and create your own.
+
+## Git-ignore
+
+The `.superpowers/` tree is scratch and must be git-ignored. If the repository does not already ignore
+it, add `.superpowers/` to `.gitignore`. The ledger is never committed - it is a local recovery aid,
+and its durable facts (issues, PRs, commits) live in git and GitHub already.

--- a/.claude/skills/dev-flow/references/phase-map.md
+++ b/.claude/skills/dev-flow/references/phase-map.md
@@ -1,0 +1,108 @@
+# Phase map
+
+The per-phase contract. Each phase lists its entry artifacts (what a fresh subagent reads), the child
+skill it invokes, the exit artifact it writes, the model it runs on, and the dispatch prompt template.
+Substitute the bracketed values from the ledger before dispatching.
+
+A dispatch prompt never pastes prior-phase output or conversation history. It names file paths and the
+child skill. The subagent reads the files itself and writes its full output to the exit artifact,
+returning only a short status.
+
+## design (interactive, not dispatched)
+
+- **Entry:** the ticket or idea, plus the code the change touches for grounding.
+- **Child skill:** `brainstorming`, then `writing-adrs` and `writing-docs`.
+- **Exit:** an ADR under `docs/adr/`, the doc edits, and a doc PR.
+- **Model:** interactive in the main loop. Brainstorming has a hard human-approval gate, so it is not
+  handed to a subagent that cannot hold the dialogue.
+- **Note:** the flow proper begins once the design is settled and addressable. Verify before leaving
+  this phase that a fresh reader could open the ADR and doc PR and understand the change. Ground every
+  named identifier against the code before it enters the docs - an ungrounded claim here costs a full
+  rewrite cycle downstream.
+
+## cr
+
+- **Entry:** the ADR and doc PR permalink from `design`.
+- **Child skill:** `design-to-cr`.
+- **Exit:** a filed CR issue (Story or Feature), its number recorded in the ledger.
+- **Model:** Sonnet. This is transcription of a settled design into the CR format, not fresh judgement.
+- **Dispatch prompt:**
+  > Read the design at [ADR path] and the doc PR [#NNNN]. Invoke the design-to-cr skill to draft and
+  > file a CR for this change. The design is settled - do not redesign. Follow the skill's dry-run
+  > discipline and house rules. Carry into Implementation notes the design-time seam hint from
+  > [ledger ruling / design doc]: reuse the existing mechanism, and if it is not directly reusable,
+  > extract a helper rather than adding a parallel path. Do not write any "docs are ahead of code" meta
+  > line. When filed, return the issue number and the draft path only.
+
+## plan
+
+- **Entry:** the CR issue number and the design permalink.
+- **Child skill:** `writing-plans`.
+- **Exit:** a plan at `docs/superpowers/plans/YYYY-MM-DD-<slug>.md` with per-task briefs and Global
+  Constraints.
+- **Model:** Sonnet. Structured authoring from a settled design. Escalate to a strong model only if the
+  design carries a load-bearing unknown that the plan must resolve with a spike.
+- **Dispatch prompt:**
+  > Read CR issue [#NNNN] and the design at [permalink]. Invoke the writing-plans skill to produce an
+  > implementation plan. Annotate each task brief with a recommended model tier: transcription of
+  > complete code is a cheap tier, integration across files is a standard tier. If a load-bearing
+  > unknown exists, make Task 0 a spike that confirms it. Write the plan to the standard path and return
+  > only that path.
+
+## implement
+
+- **Entry:** the plan file and, if resuming, the SDD ledger at `.superpowers/sdd/<plan-basename>/`.
+- **Child skill:** `subagent-driven-development`.
+- **Exit:** the code and tests committed on the work branch, and a code PR into the base branch.
+- **Model:** Sonnet for the SDD controller. The controller coordinates - it does not need a top-tier
+  model. Inside SDD, follow its own Model Selection section strictly:
+  - implementers doing transcription from a complete task brief run on the cheapest tier,
+  - implementers doing multi-file integration run on a standard tier,
+  - task reviewers run on a standard tier scaled to the diff,
+  - the final whole-branch review runs on the most capable model - the one expensive point,
+  - fix-loop rounds 4 and 5 escalate one tier above the implementer that got stuck.
+- **Controller checkpointing:** the SDD controller checkpoints itself to its ledger by task batch. It
+  does not carry the whole session in one context. On resume, it reads the ledger and git, not the
+  conversation.
+- **Dispatch prompt:**
+  > Read the plan at [plan path] and its ledger if present. Invoke the subagent-driven-development
+  > skill to execute the plan task by task. Follow its Model Selection section exactly: cheap tier for
+  > transcription implementers, standard for integration and reviewers, most capable for the final
+  > whole-branch review, escalate on fix rounds 4 and 5. Commit per task, keep the ledger current, and
+  > open a PR into [base branch] when the final review is clean. Return the PR number, the commit list,
+  > and any parked findings only.
+
+## review
+
+- **Entry:** the diff `BASE..HEAD` for the code PR and the CR acceptance conditions.
+- **Child skill:** `code-review`, and `writing-gherkin` when a BDD slice is warranted.
+- **Exit:** a review report file and, when authored, a BDD slice added to the suite.
+- **Model:** Sonnet. The two axes split by nature:
+  - Standards axis is rule matching against repo standards and the smell baseline - Sonnet,
+  - Spec axis is judgement against the CR acceptance - Sonnet, escalate to the most capable model when
+    the diff is subtle or high risk.
+- **Dispatch prompt:**
+  > Read the diff for PR [#NNNN] against [BASE] and the acceptance conditions in CR [#NNNN]. Invoke the
+  > code-review skill against that fixed point. Run the Standards axis on a standard tier and the Spec
+  > axis on a standard tier, escalating the Spec axis to the most capable model if the diff is subtle.
+  > If a coverage gap warrants a BDD slice, invoke writing-gherkin to enumerate the missing cases. Write
+  > the report to [report path] and return the path plus the count of findings per axis.
+
+## verify
+
+- **Entry:** the code PR number.
+- **Child skill:** none - poll CI check runs.
+- **Exit:** the check-run outcomes recorded in the ledger.
+- **Model:** Haiku or Sonnet. Pure mechanical polling. Run it out of the orchestrator's context - a
+  background watcher or a cheap dispatched poll - so a long wait does not re-read the orchestrator
+  context on every tick.
+- **Note:** cover every terminal state, not only success. A green build gates on the head commit type
+  where the CI requires it (for this repo, the Java Docker build needs a feat/fix/BREAKING head).
+
+## acceptance (human)
+
+- **Entry:** the CR acceptance conditions and the green checks from `verify`.
+- **Child skill:** none.
+- **Exit:** a human sign-off recorded in the ledger and on the issue.
+- **Model:** human. The acceptance is executable - the CR acceptance conditions are projected into the
+  BDD and unit tests - so the human signs off on green checks rather than running the pipeline by hand.

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ junit*
 # Claude Code local (per-user) files - the shared skill under .claude/skills/ is committed
 .claude/settings.local.json
 .claude/*.lock
+
+# dev-flow and subagent-driven-development scratch (ledgers, briefs, review packages)
+.superpowers/


### PR DESCRIPTION
## What

Adds a `dev-flow` orchestrator skill that runs the design-to-code-PR delivery flow as a chain of
isolated phase subagents, and improves `design-to-cr` so the design-to-developer handoff survives a
fresh session. Both are tooling under `.claude/skills/`, not product code.

## Why

Running a whole delivery flow in one growing conversation is expensive: the context is re-read on every
turn, at the session model's rate, across thousands of turns. Cost scales as
`context-size x turns x model-rate`, and a single long session maxes all three. This skill encodes two
levers that cut it.

## dev-flow skill

- **Phase isolation (context stays small).** Each phase - cr, plan, implement, review, verify - runs as
  a separate subagent. A subagent has its own context, transcript, and cache, and only a short result
  summary returns to the orchestrator, so the orchestrator does not grow as phases complete. Work is
  handed over through file artifacts, never conversation history. The quality gate is that a phase can
  run from scratch on its entry artifacts alone.
- **Model routing (rate stays low).** Model tier follows a turn's judgement depth, not its importance.
  Mechanical phases run on a cheap tier, the final whole-branch review runs on the most capable model.
  Because each phase is a separate dispatch, the model is chosen per phase. Sonnet is the floor for any
  reasoning loop - a weak model on branching work takes more turns and costs more overall.
- **Vendored skills are driven, not forked.** `subagent-driven-development`, `writing-plans`, and
  `code-review` are invoked from dispatch prompts that pass the model and the artifact contract, so a
  plugin update does not overwrite the routing.

Files: `SKILL.md` (router), `references/phase-map.md` (per-phase entry and exit artifacts, child skill,
model, dispatch prompt), `references/ledger.md` (flow-ledger format and resume protocol). `.gitignore`
now ignores `.superpowers/`, the scratch tree for the flow ledger and the SDD workspace.

## design-to-cr improvements

- Carry the design-time seam into Implementation notes: reuse the existing mechanism, and if it is not
  directly reusable, extract a helper rather than adding a parallel path. This is the insight a
  developer's plan turns into a first-task spike, and it is lost across the design-to-implementation
  handoff unless the CR carries it.
- Block any doc-ahead-of-code meta line in the pre-file gate, for example "the design docs are ahead of
  the code" or "this CR wires the described behavior". It is noise, not guidance.

`design-to-cr` stays fully standalone - model routing lives in `dev-flow`, not in the CR skill.

## Testing

Self-tested the `cr` phase end-to-end in dry-run against a settled design (doc PR #1753). Confirmed
live: the phase subagent invoked `design-to-cr` from its own context, read the design by reference from
the PR rather than from chat, wrote its draft to a file, returned status only with its heavy context
isolated, and nothing was filed. The draft carried the seam hint in Implementation notes and contained
no doc-ahead line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)